### PR TITLE
EXPERIMENTAL Implement G2/G3 arc fitting for G-code generation

### DIFF
--- a/src/gcode/arc_fitting.rs
+++ b/src/gcode/arc_fitting.rs
@@ -1,0 +1,509 @@
+//! Arc-fitting (G2/G3) post-processor for polylines.
+//!
+//! Inspired by [ArcWelder](https://github.com/FormerLurker/ArcWelderLib) and the
+//! `ArcFitter` used by OrcaSlicer / PrusaSlicer.
+//!
+//! Given a sequence of 2D points, [`fit_arcs`] greedily welds runs of points
+//! that lie within `tolerance` of a common circle into [`PathSegment::Arc`]
+//! variants and emits the rest as [`PathSegment::Line`] segments.  The result
+//! is a stream the G-code generator can render directly into G1/G2/G3
+//! commands.
+//!
+//! ## Algorithm
+//!
+//! For every starting index `i`, we extend a window `[i, j]` while:
+//!
+//! 1. The three "anchor" points (`p_i`, `p_mid`, `p_j`) are not collinear and
+//!    define a circle with radius below `max_radius`.
+//! 2. Every interior point's perpendicular distance from that circle is
+//!    `≤ tolerance`.
+//! 3. The arc is monotonic — angles around the centre advance in a single
+//!    direction without wrapping past the endpoints.
+//!
+//! When `j` can no longer be extended, the run `[i, j]` is emitted as an arc
+//! (if it covers at least `min_run` segments) and we restart from `j`.
+
+/// Output of [`fit_arcs`] — a single line or arc segment.
+#[derive(Debug, Clone, Copy, PartialEq)]
+pub enum PathSegment {
+    /// Straight move from `start` to `end`.
+    Line { start: (f64, f64), end: (f64, f64) },
+    /// Circular arc from `start` to `end` around `center` (absolute coords).
+    /// `is_cw` selects G2 (clockwise) when true and G3 (counter-clockwise) when false.
+    Arc {
+        start: (f64, f64),
+        end: (f64, f64),
+        center: (f64, f64),
+        radius: f64,
+        is_cw: bool,
+    },
+}
+
+impl PathSegment {
+    /// Geometric length of the segment along its path.
+    pub fn length(&self) -> f64 {
+        match *self {
+            PathSegment::Line { start, end } => {
+                let dx = end.0 - start.0;
+                let dy = end.1 - start.1;
+                (dx * dx + dy * dy).sqrt()
+            }
+            PathSegment::Arc {
+                start,
+                end,
+                center,
+                radius,
+                is_cw,
+            } => {
+                let a0 = (start.1 - center.1).atan2(start.0 - center.0);
+                let a1 = (end.1 - center.1).atan2(end.0 - center.0);
+                let sweep = arc_sweep(a0, a1, is_cw);
+                radius * sweep
+            }
+        }
+    }
+
+    /// End point of this segment (handy for chaining).
+    pub fn end(&self) -> (f64, f64) {
+        match *self {
+            PathSegment::Line { end, .. } => end,
+            PathSegment::Arc { end, .. } => end,
+        }
+    }
+}
+
+/// Greedily weld a polyline of `points` into [`PathSegment`]s.
+///
+/// `points` is expected to have `≥ 2` entries.  Returns one segment per input
+/// edge when arc fitting is impossible.
+pub fn fit_arcs(
+    points: &[(f64, f64)],
+    tolerance: f64,
+    min_run: usize,
+    max_radius: f64,
+) -> Vec<PathSegment> {
+    let n = points.len();
+    let mut out = Vec::with_capacity(n);
+    if n < 2 {
+        return out;
+    }
+    if n < min_run.max(3) || tolerance <= 0.0 {
+        for w in points.windows(2) {
+            out.push(PathSegment::Line {
+                start: w[0],
+                end: w[1],
+            });
+        }
+        return out;
+    }
+
+    let mut i = 0usize;
+    while i + 1 < n {
+        // Try to find the largest j such that points[i..=j] fit a circle.
+        let mut best_j = 0usize;
+        let mut best_circle: Option<(f64, f64, f64, bool)> = None; // (cx, cy, r, is_cw)
+
+        // Need at least 3 points to define a circle — start at i + 2.
+        let mut j = i + 2;
+        while j < n {
+            let p_start = points[i];
+            let p_end = points[j];
+
+            // Reject when the chord between start and end is essentially zero.
+            // This guards against closed-loop perimeters where extending j wraps
+            // back near p_start and the algorithm would otherwise emit a "full
+            // circle" arc.
+            let chord = ((p_end.0 - p_start.0).powi(2) + (p_end.1 - p_start.1).powi(2)).sqrt();
+            if chord < 1e-4 {
+                break;
+            }
+
+            // Use the point with maximum perpendicular deviation from the chord
+            // as the third anchor for the circumcircle.  Using a naive index
+            // midpoint `(i+j)/2` would shift the anchor on every step, changing
+            // the circle definition mid-extension and potentially flipping the
+            // CW/CCW direction or producing a degenerate (collinear) triple —
+            // both of which cause a premature `break` that cuts short valid arcs.
+            // The max-deviation point is the most distant from the chord, making
+            // it the most numerically stable anchor: it is always clearly on the
+            // dominant side of the arc and is closest to what ArcWelder uses.
+            let mid_idx = max_deviation_idx(points, i, j);
+            let p_mid = points[mid_idx];
+
+            let Some((cx, cy, r)) = circle_through(p_start, p_mid, p_end) else {
+                break;
+            };
+            if r > max_radius || !r.is_finite() {
+                break;
+            }
+
+            // Determine direction from the three anchors.
+            let is_cw = cross2(p_start, p_mid, p_end) < 0.0;
+
+            // Verify every interior point is within tolerance of the circle and
+            // monotonically progressing.
+            if !window_fits_arc(&points[i..=j], (cx, cy), r, is_cw, tolerance) {
+                break;
+            }
+
+            best_j = j;
+            best_circle = Some((cx, cy, r, is_cw));
+            j += 1;
+        }
+
+        let run_len = best_j.saturating_sub(i);
+        // Hard floor independent of user setting: very short fitted runs are
+        // visually unstable and prone to overfitting into unwanted bows.
+        // Keep this moderate so tight-radius holes can still form arcs.
+        const HARD_MIN_RUN_SEGMENTS: usize = 5;
+        if run_len + 1 >= min_run.max(3).max(HARD_MIN_RUN_SEGMENTS) {
+            if let Some((cx, cy, r, is_cw)) = best_circle {
+                // Final-arc sanity gate.  Prevents weak/ambiguous arcs from
+                // being emitted, where a wrong CW/CCW flag from numerical
+                // noise would cause printers and viewers to render the long
+                // way around the circle.  Three independent checks:
+                //
+                //   1. Sweep ≥ ~6° — below this the polyline is effectively
+                //      straight; emit lines instead of risking a flipped arc.
+                //   2. Sagitta ≥ 2 × tolerance — the arc must actually bulge
+                //      enough that a straight line would not also fit.
+                //   3. Chord ≥ 0.5 mm AND chord ≥ r × 0.1 — rejects tiny
+                //      crescents whose start ≈ end (closed-loop tail) and
+                //      also tight U-turns where the slicer's intended direction
+                //      is fragile.  These were the source of the "diagonal
+                //      lines criss-crossing the model" artefact in the viewer.
+                let a_start = (points[i].1 - cy).atan2(points[i].0 - cx);
+                let a_end = (points[best_j].1 - cy).atan2(points[best_j].0 - cx);
+                let final_sweep = arc_sweep(a_start, a_end, is_cw);
+                let final_sagitta = r * (1.0 - (final_sweep * 0.5).cos());
+                let chord = ((points[best_j].0 - points[i].0).powi(2)
+                    + (points[best_j].1 - points[i].1).powi(2))
+                .sqrt();
+                // For practical print quality we intentionally keep the fitter
+                // conservative: very shallow arcs are better emitted as lines.
+                const FINAL_MIN_SWEEP: f64 = std::f64::consts::PI / 9.0; // 20°
+                const FINAL_MIN_CHORD_MM: f64 = 0.4;
+                const FINAL_MIN_CHORD_RATIO: f64 = 0.1;
+                const FINAL_MIN_SAGITTA_MM: f64 = 0.08;
+                const FINAL_MIN_CURVATURE_RATIO: f64 = 0.06; // sagitta/chord
+                let required_sagitta = (2.0 * tolerance).max(FINAL_MIN_SAGITTA_MM);
+                let max_chord_deviation = max_distance_to_chord(&points[i..=best_j]);
+                let curvature_ratio = if chord > 1e-9 {
+                    final_sagitta / chord
+                } else {
+                    0.0
+                };
+                if final_sweep >= FINAL_MIN_SWEEP
+                    && final_sagitta >= required_sagitta
+                    && chord >= FINAL_MIN_CHORD_MM
+                    && chord >= r * FINAL_MIN_CHORD_RATIO
+                    && max_chord_deviation >= required_sagitta
+                    && curvature_ratio >= FINAL_MIN_CURVATURE_RATIO
+                {
+                    out.push(PathSegment::Arc {
+                        start: points[i],
+                        end: points[best_j],
+                        center: (cx, cy),
+                        radius: r,
+                        is_cw,
+                    });
+                    i = best_j;
+                    continue;
+                }
+            }
+        }
+
+        // Emit a single line segment and advance one point.
+        out.push(PathSegment::Line {
+            start: points[i],
+            end: points[i + 1],
+        });
+        i += 1;
+    }
+
+    out
+}
+
+/// Maximum perpendicular distance of interior points from the start-end chord.
+///
+/// Values near zero indicate an almost straight run, which should stay as line
+/// segments even if a large-radius circle can be numerically fitted.
+fn max_distance_to_chord(pts: &[(f64, f64)]) -> f64 {
+    if pts.len() < 3 {
+        return 0.0;
+    }
+
+    let a = pts[0];
+    let b = pts[pts.len() - 1];
+    let vx = b.0 - a.0;
+    let vy = b.1 - a.1;
+    let len = (vx * vx + vy * vy).sqrt();
+    if len < 1e-12 {
+        return 0.0;
+    }
+
+    let mut max_d = 0.0;
+    for &p in &pts[1..pts.len() - 1] {
+        let wx = p.0 - a.0;
+        let wy = p.1 - a.1;
+        let cross = (vx * wy - vy * wx).abs();
+        let d = cross / len;
+        if d > max_d {
+            max_d = d;
+        }
+    }
+
+    max_d
+}
+
+// ── Internal helpers ────────────────────────────────────────────────────────
+
+/// Return the index in `pts[first..last]` (exclusive of first and last) whose
+/// point has the greatest perpendicular distance from the chord
+/// `(pts[first], pts[last])`.  Falls back to the naive index midpoint when
+/// the chord length is near zero or there are no interior points.
+fn max_deviation_idx(pts: &[(f64, f64)], first: usize, last: usize) -> usize {
+    if last <= first + 1 {
+        return first;
+    }
+
+    let a = pts[first];
+    let b = pts[last];
+    let vx = b.0 - a.0;
+    let vy = b.1 - a.1;
+    let len_sq = vx * vx + vy * vy;
+
+    if len_sq < 1e-24 {
+        return (first + last) / 2;
+    }
+
+    let mut max_cross_sq = -1.0f64;
+    let mut max_idx = (first + last) / 2;
+
+    for idx in (first + 1)..last {
+        let wx = pts[idx].0 - a.0;
+        let wy = pts[idx].1 - a.1;
+        let cross = vx * wy - vy * wx;
+        let cross_sq = cross * cross;
+        if cross_sq > max_cross_sq {
+            max_cross_sq = cross_sq;
+            max_idx = idx;
+        }
+    }
+
+    max_idx
+}
+
+/// Signed cross product `(b-a) × (c-b)` — sign reveals orientation (CCW > 0).
+fn cross2(a: (f64, f64), b: (f64, f64), c: (f64, f64)) -> f64 {
+    (b.0 - a.0) * (c.1 - b.1) - (b.1 - a.1) * (c.0 - b.0)
+}
+
+/// Compute the unique circle through three points; returns `None` when they are
+/// collinear.
+fn circle_through(a: (f64, f64), b: (f64, f64), c: (f64, f64)) -> Option<(f64, f64, f64)> {
+    let ax = a.0;
+    let ay = a.1;
+    let bx = b.0;
+    let by = b.1;
+    let cx_p = c.0;
+    let cy_p = c.1;
+
+    let d = 2.0 * (ax * (by - cy_p) + bx * (cy_p - ay) + cx_p * (ay - by));
+    if d.abs() < 1e-12 {
+        return None;
+    }
+
+    let ax2_ay2 = ax * ax + ay * ay;
+    let bx2_by2 = bx * bx + by * by;
+    let cx2_cy2 = cx_p * cx_p + cy_p * cy_p;
+
+    let ux = (ax2_ay2 * (by - cy_p) + bx2_by2 * (cy_p - ay) + cx2_cy2 * (ay - by)) / d;
+    let uy = (ax2_ay2 * (cx_p - bx) + bx2_by2 * (ax - cx_p) + cx2_cy2 * (bx - ax)) / d;
+    let r = ((ax - ux).powi(2) + (ay - uy).powi(2)).sqrt();
+    Some((ux, uy, r))
+}
+
+/// Sweep angle (always positive) from `a0` to `a1` taking the direction
+/// implied by `is_cw`.
+fn arc_sweep(a0: f64, a1: f64, is_cw: bool) -> f64 {
+    let two_pi = std::f64::consts::TAU;
+    if is_cw {
+        let mut s = a0 - a1;
+        while s < 0.0 {
+            s += two_pi;
+        }
+        s
+    } else {
+        let mut s = a1 - a0;
+        while s < 0.0 {
+            s += two_pi;
+        }
+        s
+    }
+}
+
+/// Verify that every point in `pts` lies within `tol` of the circle and that
+/// angles around the centre advance monotonically in the direction implied by
+/// `is_cw`.
+fn window_fits_arc(pts: &[(f64, f64)], center: (f64, f64), r: f64, is_cw: bool, tol: f64) -> bool {
+    if pts.len() < 3 {
+        return false;
+    }
+
+    let angle_of = |p: (f64, f64)| -> f64 { (p.1 - center.1).atan2(p.0 - center.0) };
+
+    let a_start = angle_of(pts[0]);
+    let a_end = angle_of(pts[pts.len() - 1]);
+    let total_sweep = arc_sweep(a_start, a_end, is_cw);
+
+    // Cap arc sweep at ~100°.  This remains conservative versus ArcWelder-like
+    // defaults while allowing tighter-radius features (small holes) to retain
+    // meaningful arc coverage.
+    // Larger sweeps are where users most often report
+    // visually odd "half-circle" arcs on wall paths; keeping arcs shorter makes
+    // fitted paths track the original polyline more faithfully.
+    // because the chord-to-arc deviation grows with the squared sweep angle,
+    // and a single G2/G3 carrying half-or-more of a perimeter is brittle on
+    // many firmwares.  Anything larger is split into multiple shorter arcs.
+    const MAX_SWEEP: f64 = std::f64::consts::PI * 5.0 / 9.0;
+    if total_sweep < 1e-6 || total_sweep > MAX_SWEEP {
+        return false;
+    }
+
+    let mut prev_progress = 0.0;
+    for (idx, &p) in pts.iter().enumerate() {
+        let dx = p.0 - center.0;
+        let dy = p.1 - center.1;
+        let d = (dx * dx + dy * dy).sqrt();
+        if (d - r).abs() > tol {
+            return false;
+        }
+
+        if idx == 0 || idx == pts.len() - 1 {
+            continue;
+        }
+
+        let a = angle_of(p);
+        let progress = arc_sweep(a_start, a, is_cw);
+        if progress < prev_progress - 1e-9 || progress > total_sweep + 1e-9 {
+            return false;
+        }
+        prev_progress = progress;
+    }
+
+    true
+}
+
+// ── Tests ───────────────────────────────────────────────────────────────────
+
+#[cfg(test)]
+mod tests {
+    use super::*;
+
+    fn sample_circle(cx: f64, cy: f64, r: f64, n: usize, ccw: bool) -> Vec<(f64, f64)> {
+        let mut pts = Vec::with_capacity(n);
+        // Sample a 70° arc — comfortably within the 100° MAX_SWEEP cap.
+        let total = 7.0 * std::f64::consts::PI / 18.0;
+        for k in 0..n {
+            let t = (k as f64) / ((n - 1) as f64);
+            let theta = if ccw { t * total } else { -t * total };
+            pts.push((cx + r * theta.cos(), cy + r * theta.sin()));
+        }
+        pts
+    }
+
+    #[test]
+    fn fits_a_clean_arc_into_one_arc() {
+        let pts = sample_circle(0.0, 0.0, 10.0, 40, true);
+        let segs = fit_arcs(&pts, 0.01, 4, 1000.0);
+        assert_eq!(segs.len(), 1);
+        match segs[0] {
+            PathSegment::Arc { radius, is_cw, .. } => {
+                assert!((radius - 10.0).abs() < 0.01, "radius {}", radius);
+                assert!(!is_cw, "CCW arc should produce G3");
+            }
+            _ => panic!("expected an arc"),
+        }
+    }
+
+    #[test]
+    fn straight_line_emits_only_lines() {
+        let pts: Vec<(f64, f64)> = (0..10).map(|k| (k as f64, 0.0)).collect();
+        let segs = fit_arcs(&pts, 0.01, 4, 1000.0);
+        assert!(segs.iter().all(|s| matches!(s, PathSegment::Line { .. })));
+        assert_eq!(segs.len(), 9);
+    }
+
+    #[test]
+    fn shallow_bow_stays_lines() {
+        // Very shallow 8° bow across a long chord should remain line segments.
+        let mut pts = Vec::new();
+        let cx = 0.0;
+        let cy = -143.0;
+        let r = 145.0;
+        let total = 8.0_f64.to_radians();
+        let n = 20usize;
+        for k in 0..n {
+            let t = (k as f64) / ((n - 1) as f64);
+            let theta = -total * 0.5 + total * t;
+            pts.push((cx + r * theta.sin(), cy + r * theta.cos()));
+        }
+
+        let segs = fit_arcs(&pts, 0.025, 4, 1000.0);
+        assert!(
+            segs.iter().all(|s| matches!(s, PathSegment::Line { .. })),
+            "shallow bow should not be emitted as arc"
+        );
+    }
+
+    #[test]
+    fn cw_arc_becomes_g2() {
+        let pts = sample_circle(0.0, 0.0, 5.0, 25, false);
+        let segs = fit_arcs(&pts, 0.01, 4, 1000.0);
+        assert!(!segs.is_empty());
+        let arcs: Vec<_> = segs
+            .iter()
+            .filter(|s| matches!(s, PathSegment::Arc { .. }))
+            .collect();
+        assert!(!arcs.is_empty(), "expected at least one arc");
+        if let PathSegment::Arc { is_cw, .. } = arcs[0] {
+            assert!(*is_cw, "CW path should produce G2");
+        }
+    }
+
+    #[test]
+    fn closed_loop_does_not_produce_full_circle() {
+        // Sample a complete circle so the polyline returns to its start; the
+        // fitter must NOT collapse this into a single full-revolution G3.
+        let mut pts = Vec::new();
+        let n = 60;
+        for k in 0..=n {
+            let t = (k as f64) / (n as f64);
+            let theta = t * std::f64::consts::TAU;
+            pts.push((10.0 * theta.cos(), 10.0 * theta.sin()));
+        }
+        let segs = fit_arcs(&pts, 0.01, 4, 1000.0);
+        for seg in &segs {
+            if let PathSegment::Arc {
+                start, end, center, ..
+            } = *seg
+            {
+                let chord = ((end.0 - start.0).powi(2) + (end.1 - start.1).powi(2)).sqrt();
+                let r = ((start.0 - center.0).powi(2) + (start.1 - center.1).powi(2)).sqrt();
+                // Sweep is bounded ≤120° so the chord must be a meaningful span,
+                // not a near-zero start-end coincidence.
+                // a real chord, not a near-zero start-end coincidence.
+                assert!(chord > r * 0.1, "arc chord {} too small for r {}", chord, r);
+            }
+        }
+    }
+
+    #[test]
+    fn empty_and_short_inputs_are_safe() {
+        assert!(fit_arcs(&[], 0.01, 4, 1000.0).is_empty());
+        let two = vec![(0.0, 0.0), (1.0, 0.0)];
+        let segs = fit_arcs(&two, 0.01, 4, 1000.0);
+        assert_eq!(segs.len(), 1);
+    }
+}

--- a/src/gcode/dialect.rs
+++ b/src/gcode/dialect.rs
@@ -91,6 +91,33 @@ pub trait GcodeDialect: Send + Sync {
         format!("G1 X{:.3} Y{:.3} E{:.5} F{:.0}", x, y, e, speed_mm_min)
     }
 
+    /// Move to `(x, y)` along a circular arc around centre `(x + i, y + j)`
+    /// while extruding filament to absolute E position `e` at `speed_mm_min`
+    /// mm/min.  `is_cw` selects `G2` (clockwise) when `true` and `G3`
+    /// (counter-clockwise) otherwise.
+    ///
+    /// Both `i` and `j` are **offsets from the current position** to the arc
+    /// centre, matching the standard RepRap/Marlin/Klipper convention.
+    fn move_arc_extrude(
+        &self,
+        x: f64,
+        y: f64,
+        i: f64,
+        j: f64,
+        e: f64,
+        speed_mm_min: f64,
+        is_cw: bool,
+    ) -> String {
+        let g = if is_cw { 2 } else { 3 };
+        // Keep XY endpoint precision consistent with linear moves while using
+        // higher precision for I/J center offsets. Arc geometry is highly
+        // sensitive to center quantization on large-radius or shallow sweeps.
+        format!(
+            "G{} X{:.3} Y{:.3} I{:.5} J{:.5} E{:.5} F{:.0}",
+            g, x, y, i, j, e, speed_mm_min
+        )
+    }
+
     /// Move the Z axis to `z` at `speed_mm_min` mm/min (no extrusion).
     fn move_z(&self, z: f64, speed_mm_min: f64) -> String {
         format!("G1 Z{:.3} F{:.0}", z, speed_mm_min)

--- a/src/gcode/generator.rs
+++ b/src/gcode/generator.rs
@@ -356,8 +356,13 @@ impl GcodeGenerator {
                 // Apply Ramer-Douglas-Peucker simplification when a tolerance is set.
                 // `douglas_peucker` always preserves the first and last point, so a
                 // path with >= 2 raw points will always yield >= 2 simplified points.
-                let points: Vec<(f64, f64)> = if params.path_tolerance > 0.0 && raw_points.len() > 2
-                {
+                //
+                // Important: when arc fitting is enabled, use the unsimplified point
+                // stream.  Pre-simplifying first can sparsify corners enough that the
+                // fitter chooses visually surprising long-sweep arcs.
+                let points: Vec<(f64, f64)> = if params.arc_fitting_enabled {
+                    raw_points
+                } else if params.path_tolerance > 0.0 && raw_points.len() > 2 {
                     crate::gcode::simplify::douglas_peucker(&raw_points, params.path_tolerance)
                 } else {
                     raw_points
@@ -464,25 +469,81 @@ impl GcodeGenerator {
 
                 // Print the contour segments
                 let mut prev = points[0];
-                for &(x, y) in points.iter().skip(1) {
-                    let dx = x - prev.0;
-                    let dy = y - prev.1;
-                    let len = (dx * dx + dy * dy).sqrt();
-                    if len < 1e-6 {
-                        prev = (x, y);
-                        continue;
+                let segments = if params.arc_fitting_enabled {
+                    crate::gcode::arc_fitting::fit_arcs(
+                        &points,
+                        params.arc_fitting_tolerance,
+                        params.arc_fitting_min_segments,
+                        params.arc_fitting_max_radius,
+                    )
+                } else {
+                    points
+                        .windows(2)
+                        .map(|w| crate::gcode::arc_fitting::PathSegment::Line {
+                            start: w[0],
+                            end: w[1],
+                        })
+                        .collect()
+                };
+
+                for seg in &segments {
+                    match *seg {
+                        crate::gcode::arc_fitting::PathSegment::Line { end, .. } => {
+                            let dx = end.0 - prev.0;
+                            let dy = end.1 - prev.1;
+                            let len = (dx * dx + dy * dy).sqrt();
+                            if len < 1e-6 {
+                                prev = end;
+                                continue;
+                            }
+                            e_total += extrusion_for_move(
+                                len,
+                                params.layer_height,
+                                width_mm,
+                                params.filament_diameter_mm,
+                            );
+                            out.push_str(&format!(
+                                "{}\n",
+                                self.dialect.move_extrude(
+                                    end.0,
+                                    end.1,
+                                    e_total,
+                                    print_speed_mm_min
+                                )
+                            ));
+                            prev = end;
+                        }
+                        crate::gcode::arc_fitting::PathSegment::Arc {
+                            end, center, is_cw, ..
+                        } => {
+                            let arc_len = seg.length();
+                            if arc_len < 1e-6 {
+                                prev = end;
+                                continue;
+                            }
+                            let i_off = center.0 - prev.0;
+                            let j_off = center.1 - prev.1;
+                            e_total += extrusion_for_move(
+                                arc_len,
+                                params.layer_height,
+                                width_mm,
+                                params.filament_diameter_mm,
+                            );
+                            out.push_str(&format!(
+                                "{}\n",
+                                self.dialect.move_arc_extrude(
+                                    end.0,
+                                    end.1,
+                                    i_off,
+                                    j_off,
+                                    e_total,
+                                    print_speed_mm_min,
+                                    is_cw,
+                                )
+                            ));
+                            prev = end;
+                        }
                     }
-                    e_total += extrusion_for_move(
-                        len,
-                        params.layer_height,
-                        width_mm,
-                        params.filament_diameter_mm,
-                    );
-                    out.push_str(&format!(
-                        "{}\n",
-                        self.dialect.move_extrude(x, y, e_total, print_speed_mm_min)
-                    ));
-                    prev = (x, y);
                 }
 
                 // Close the contour — only for inherently closed-loop roles such as

--- a/src/gcode/mod.rs
+++ b/src/gcode/mod.rs
@@ -30,6 +30,7 @@
 //! assert!(gcode.contains("START_PRINT"));
 //! ```
 
+pub mod arc_fitting;
 pub mod dialect;
 pub mod dialects;
 pub mod flavor;

--- a/src/gcode_viewer/parser.rs
+++ b/src/gcode_viewer/parser.rs
@@ -126,6 +126,81 @@ pub(super) fn parse_gcode_bytes(bytes: &[u8]) -> Vec<InternalLayer> {
                     current.push_segment(seg_role, prev_x, prev_y, prev_z, x, y, z, width, height);
                 }
             }
+            "G2" | "G3" => {
+                let is_cw = cmd == "G2";
+                let prev_x = x;
+                let prev_y = y;
+                let prev_z = z;
+                let prev_e = e;
+
+                let mut new_x = x;
+                let mut new_y = y;
+                let mut new_z = z;
+                let mut new_e = e;
+                let mut has_e = false;
+                let mut i_off: f32 = 0.0;
+                let mut j_off: f32 = 0.0;
+                let mut has_ij = false;
+
+                for param in parts {
+                    if param.is_empty() {
+                        continue;
+                    }
+                    let (letter, rest) = param.split_at(1);
+                    let Ok(val) = rest.parse::<f32>() else {
+                        continue;
+                    };
+                    match letter.to_ascii_uppercase().as_str() {
+                        "X" => new_x = if absolute_xyz { val } else { x + val },
+                        "Y" => new_y = if absolute_xyz { val } else { y + val },
+                        "Z" => new_z = if absolute_xyz { val } else { z + val },
+                        "E" => {
+                            has_e = true;
+                            new_e = if absolute_e { val } else { e + val };
+                        }
+                        "I" => {
+                            i_off = val;
+                            has_ij = true;
+                        }
+                        "J" => {
+                            j_off = val;
+                            has_ij = true;
+                        }
+                        _ => {}
+                    }
+                }
+
+                if !seen_layer_change_comment && (new_z - prev_z).abs() > 1e-6 && new_z > prev_z {
+                    let finished = std::mem::replace(&mut current, InternalLayer::new(new_z));
+                    layers.push(finished);
+                }
+
+                x = new_x;
+                y = new_y;
+                z = new_z;
+                e = new_e;
+
+                let is_extruding = has_e && (new_e - prev_e) > 1e-7;
+                let seg_role = if is_extruding { role } else { Role::Travel };
+
+                let moved = (x - prev_x).abs() > 1e-6 || (y - prev_y).abs() > 1e-6;
+                if moved {
+                    if has_ij {
+                        let cx = prev_x + i_off;
+                        let cy = prev_y + j_off;
+                        current.push_arc(
+                            seg_role, prev_x, prev_y, prev_z, x, y, z, cx, cy, is_cw, width,
+                            height,
+                        );
+                    } else {
+                        // R-form arcs are uncommon and don't carry a centre we can
+                        // store directly; fall back to a straight chord.
+                        current.push_segment(
+                            seg_role, prev_x, prev_y, prev_z, x, y, z, width, height,
+                        );
+                    }
+                }
+            }
             _ => {} // G28, G4, M104, M109, T0, etc. — ignore
         }
     }

--- a/src/gcode_viewer/types.rs
+++ b/src/gcode_viewer/types.rs
@@ -49,9 +49,38 @@ impl Role {
 
 // ── Internal layer representation ──────────────────────────────────────────
 
+/// Geometric kind of segments stored in a [`Block`].
+///
+/// `Line` blocks store 8 floats per segment: `[x0, y0, z0, x1, y1, z1, w, h]`.
+/// `Arc` blocks store 11 floats per segment: `[x0, y0, z0, x1, y1, z1, cx, cy, is_cw, w, h]`
+/// where `(cx, cy)` is the absolute centre on the layer's Z plane and `is_cw`
+/// is `1.0` for G2 and `0.0` for G3.
+#[derive(Debug, Clone, Copy, PartialEq, Eq)]
+pub(super) enum SegmentKind {
+    Line,
+    Arc,
+}
+
+impl SegmentKind {
+    pub(super) fn id(self) -> u8 {
+        match self {
+            SegmentKind::Line => 0,
+            SegmentKind::Arc => 1,
+        }
+    }
+
+    pub(super) fn stride(self) -> usize {
+        match self {
+            SegmentKind::Line => 8,
+            SegmentKind::Arc => 11,
+        }
+    }
+}
+
 #[derive(Debug, Clone)]
 pub(super) struct Block {
     pub(super) role: Role,
+    pub(super) kind: SegmentKind,
     pub(super) data: Vec<f32>,
 }
 
@@ -88,14 +117,57 @@ impl InternalLayer {
     ) {
         let segment_data = [x0, y0, z0, x1, y1, z1, width, height];
         if let Some(last) = self.blocks.last_mut() {
-            if last.role == role {
+            if last.role == role && last.kind == SegmentKind::Line {
                 last.data.extend_from_slice(&segment_data);
                 return;
             }
         }
         self.blocks.push(Block {
             role,
+            kind: SegmentKind::Line,
             data: segment_data.to_vec(),
+        });
+    }
+
+    #[allow(clippy::too_many_arguments)]
+    pub(super) fn push_arc(
+        &mut self,
+        role: Role,
+        x0: f32,
+        y0: f32,
+        z0: f32,
+        x1: f32,
+        y1: f32,
+        z1: f32,
+        cx: f32,
+        cy: f32,
+        is_cw: bool,
+        width: f32,
+        height: f32,
+    ) {
+        let arc_data = [
+            x0,
+            y0,
+            z0,
+            x1,
+            y1,
+            z1,
+            cx,
+            cy,
+            if is_cw { 1.0 } else { 0.0 },
+            width,
+            height,
+        ];
+        if let Some(last) = self.blocks.last_mut() {
+            if last.role == role && last.kind == SegmentKind::Arc {
+                last.data.extend_from_slice(&arc_data);
+                return;
+            }
+        }
+        self.blocks.push(Block {
+            role,
+            kind: SegmentKind::Arc,
+            data: arc_data.to_vec(),
         });
     }
 }

--- a/src/gcode_viewer/wasm.rs
+++ b/src/gcode_viewer/wasm.rs
@@ -10,6 +10,7 @@ use super::types::InternalLayer;
 pub struct GcodeLayerBuffer {
     z: f32,
     blocks_roles: Vec<u8>,
+    blocks_kinds: Vec<u8>,
     blocks_data: Vec<Float32Array>,
 }
 
@@ -31,6 +32,13 @@ impl GcodeLayerBuffer {
         self.blocks_roles[i]
     }
 
+    /// Geometric kind of the block at index `i`: `0` = line, `1` = arc.
+    /// Line blocks pack 8 floats per segment; arc blocks pack 11.
+    #[wasm_bindgen(js_name = blockKind)]
+    pub fn block_kind(&self, i: usize) -> u8 {
+        self.blocks_kinds[i]
+    }
+
     #[wasm_bindgen(js_name = blockData)]
     pub fn block_data(&self, i: usize) -> Float32Array {
         self.blocks_data[i].clone()
@@ -43,14 +51,17 @@ fn into_float32_array(data: &[f32]) -> Float32Array {
 
 fn layer_to_buffer(layer: &InternalLayer) -> GcodeLayerBuffer {
     let mut roles = Vec::with_capacity(layer.blocks.len());
+    let mut kinds = Vec::with_capacity(layer.blocks.len());
     let mut data = Vec::with_capacity(layer.blocks.len());
     for b in &layer.blocks {
         roles.push(b.role.id());
+        kinds.push(b.kind.id());
         data.push(into_float32_array(&b.data));
     }
     GcodeLayerBuffer {
         z: layer.z,
         blocks_roles: roles,
+        blocks_kinds: kinds,
         blocks_data: data,
     }
 }

--- a/src/settings/params.rs
+++ b/src/settings/params.rs
@@ -242,6 +242,46 @@ Reduces the number of G-code points without visibly affecting print quality.
     )]
     #[serde(default = "SlicingParams::default_gcode_flavor")]
     pub gcode_flavor: GcodeFlavor,
+
+    #[schemars(
+        description = "Enable G2/G3 arc fitting (ArcWelder-style).
+
+When enabled, sequences of collinear/circular G1 moves are post-processed into G2 (CW) and G3 (CCW) arc commands, drastically reducing G-code size and improving motion smoothness on curved geometry.
+Set to `false` to always emit straight G1 moves.",
+        extend("x-group" = "Output")
+    )]
+    #[serde(default = "SlicingParams::default_arc_fitting_enabled")]
+    pub arc_fitting_enabled: bool,
+
+    #[schemars(
+        description = "Maximum perpendicular deviation (mm) of any point from the fitted arc.
+
+Smaller values produce a more faithful reproduction of the original polyline at the cost of more, smaller arcs.
+**Typical:** 0.005–0.05 mm.",
+        extend("x-group" = "Output")
+    )]
+    #[serde(default = "SlicingParams::default_arc_fitting_tolerance")]
+    pub arc_fitting_tolerance: f64,
+
+    #[schemars(
+        description = "Minimum number of consecutive segments required to consider arc fitting.
+
+Sequences shorter than this are emitted as straight G1 moves. Higher values reduce false positives on noisy short paths.
+**Typical:** 4–8.",
+        extend("x-group" = "Output")
+    )]
+    #[serde(default = "SlicingParams::default_arc_fitting_min_segments")]
+    pub arc_fitting_min_segments: usize,
+
+    #[schemars(
+        description = "Maximum allowed arc radius (mm). Arcs above this radius are emitted as straight lines.
+
+Prevents nearly-straight 'arcs' with kilometre-scale radii that introduce floating-point noise on the firmware side.
+**Typical:** 1000.",
+        extend("x-group" = "Output")
+    )]
+    #[serde(default = "SlicingParams::default_arc_fitting_max_radius")]
+    pub arc_fitting_max_radius: f64,
 }
 
 impl Default for SlicingParams {
@@ -275,6 +315,10 @@ impl Default for SlicingParams {
             infill_overlap_percent: Self::default_infill_overlap_percent(),
             path_tolerance: Self::default_path_tolerance(),
             gcode_flavor: Self::default_gcode_flavor(),
+            arc_fitting_enabled: Self::default_arc_fitting_enabled(),
+            arc_fitting_tolerance: Self::default_arc_fitting_tolerance(),
+            arc_fitting_min_segments: Self::default_arc_fitting_min_segments(),
+            arc_fitting_max_radius: Self::default_arc_fitting_max_radius(),
         }
     }
 }
@@ -366,6 +410,22 @@ impl SlicingParams {
 
     fn default_gcode_flavor() -> GcodeFlavor {
         GcodeFlavor::Marlin
+    }
+
+    fn default_arc_fitting_enabled() -> bool {
+        false
+    }
+
+    fn default_arc_fitting_tolerance() -> f64 {
+        0.025
+    }
+
+    fn default_arc_fitting_min_segments() -> usize {
+        4
+    }
+
+    fn default_arc_fitting_max_radius() -> f64 {
+        1000.0
     }
 }
 

--- a/ui/src/app/components/viewer/gcode-layer-renderer.ts
+++ b/ui/src/app/components/viewer/gcode-layer-renderer.ts
@@ -1,14 +1,17 @@
 import {
   BufferAttribute,
   BufferGeometry,
+  CatmullRomCurve3,
   CylinderGeometry,
   Group,
   InstancedMesh,
   LineBasicMaterial,
   LineSegments,
+  Mesh,
   MeshStandardMaterial,
   Object3D,
   SphereGeometry,
+  TubeGeometry,
   Vector3,
 } from 'three';
 import type { GcodeLayerBuffer } from '../../../generated/scene-wasm/scene_engine';
@@ -21,8 +24,12 @@ export interface RoleSegments {
   mesh?: InstancedMesh;
   joints?: InstancedMesh;
   lines?: LineSegments;
+  /** Tube meshes built from G2/G3 arc blocks, in timeline order for this role. */
+  arcMeshes?: Mesh[];
   /** Number of line segments */
   count: number;
+  /** Number of arc segments */
+  arcCount?: number;
 }
 
 export interface LayerInfo {
@@ -31,7 +38,7 @@ export interface LayerInfo {
   group: Group;
   totalSegments: number;
   roleSegments: RoleSegments[];
-  blockLayout: { role: RoleName; count: number }[];
+  blockLayout: { role: RoleName; count: number; kind: 'line' | 'arc' }[];
 }
 
 // -- Layer builder ------------------------------------------------------------
@@ -40,7 +47,7 @@ interface LayerBuild {
   group: Group;
   totalSegments: number;
   roleSegments: RoleSegments[];
-  blockLayout: { role: RoleName; count: number }[];
+  blockLayout: { role: RoleName; count: number; kind: 'line' | 'arc' }[];
 }
 
 const ROLE_ID_TO_NAME: Record<number, RoleName> = {
@@ -78,57 +85,90 @@ export function buildLayerGroup(buf: GcodeLayerBuffer): LayerBuild {
     other: 0,
   };
 
-  const blockLayout: { role: RoleName; count: number }[] = [];
+  const blockLayout: { role: RoleName; count: number; kind: 'line' | 'arc' }[] = [];
   let totalSegments = 0;
 
-  // Pass 1: Tally counts to allocate exactly one buffer/mesh per role
+  // Pass 1: Tally LINE segment counts so we can pre-allocate instanced meshes.
+  // Arc blocks are not pre-allocated — each arc segment is built lazily as its
+  // own Mesh below.
+  const blockKinds: number[] = [];
+  const roleArcTotals: Record<RoleName, number> = {
+    outerWall: 0,
+    innerWall: 0,
+    infill: 0,
+    topSurface: 0,
+    bottomSurface: 0,
+    travel: 0,
+    other: 0,
+  };
   for (let b = 0; b < numBlocks; b++) {
     const roleId = buf.blockRole(b);
+    const kind = (buf as unknown as { blockKind?: (i: number) => number }).blockKind?.(b) ?? 0;
+    blockKinds.push(kind);
     const dataLen = buf.blockData(b).length;
     if (dataLen === 0) continue;
 
-    const count = dataLen / 8;
+    const stride = kind === 1 ? 11 : 8;
+    const count = Math.floor(dataLen / stride);
     const role = ROLE_ID_TO_NAME[roleId] || 'other';
 
-    roleTotals[role] += count;
-    blockLayout.push({ role, count });
+    blockLayout.push({ role, count, kind: kind === 1 ? 'arc' : 'line' });
     totalSegments += count;
+    if (kind === 0) {
+      roleTotals[role] += count;
+    } else {
+      roleArcTotals[role] += count;
+    }
   }
 
   const roleSegmentsMap: Partial<Record<RoleName, RoleSegments>> = {};
 
-  // Pass 2: Allocate Three.js instances
+  // Pass 2: Allocate Three.js instances for the line counts.
   for (const role of ROLE_ORDER) {
     const count = roleTotals[role];
-    if (count === 0) continue;
-
+    const arcCount = roleArcTotals[role];
     const color = ROLE_COLORS[role];
 
     if (role === 'travel') {
-      const pts = new Float32Array(count * 6);
-      const geometry = new BufferGeometry();
-      geometry.setAttribute('position', new BufferAttribute(pts, 3));
-      const material = new LineBasicMaterial({ color });
-      const lines = new LineSegments(geometry, material);
-      group.add(lines);
-      roleSegmentsMap[role] = { role, lines, count };
+      if (count === 0 && arcCount === 0) {
+        roleSegmentsMap[role] = { role, count: 0, arcCount: 0, arcMeshes: [] };
+        continue;
+      }
+      let lines: LineSegments | undefined;
+      if (count > 0) {
+        const pts = new Float32Array(count * 6);
+        const geometry = new BufferGeometry();
+        geometry.setAttribute('position', new BufferAttribute(pts, 3));
+        const material = new LineBasicMaterial({ color });
+        lines = new LineSegments(geometry, material);
+        group.add(lines);
+      }
+      roleSegmentsMap[role] = { role, lines, count, arcCount, arcMeshes: [] };
     } else {
-      const material = new MeshStandardMaterial({ color, roughness: 0.6 });
-      const mesh = new InstancedMesh(segmentGeometry, material, count);
-      const joints = new InstancedMesh(jointGeometry, material, count * 2);
-      mesh.instanceMatrix.setUsage(35044 /* THREE.DynamicDrawUsage */);
-      joints.instanceMatrix.setUsage(35044 /* THREE.DynamicDrawUsage */);
+      if (count === 0 && arcCount === 0) {
+        roleSegmentsMap[role] = { role, count: 0, arcCount: 0, arcMeshes: [] };
+        continue;
+      }
+      let mesh: InstancedMesh | undefined;
+      let joints: InstancedMesh | undefined;
+      if (count > 0) {
+        const material = new MeshStandardMaterial({ color, roughness: 0.6 });
+        mesh = new InstancedMesh(segmentGeometry, material, count);
+        joints = new InstancedMesh(jointGeometry, material, count * 2);
+        mesh.instanceMatrix.setUsage(35044 /* THREE.DynamicDrawUsage */);
+        joints.instanceMatrix.setUsage(35044 /* THREE.DynamicDrawUsage */);
 
-      mesh.count = count;
-      joints.count = count * 2;
-      group.add(mesh);
-      group.add(joints);
+        mesh.count = count;
+        joints.count = count * 2;
+        group.add(mesh);
+        group.add(joints);
+      }
 
-      roleSegmentsMap[role] = { role, mesh, joints, count };
+      roleSegmentsMap[role] = { role, mesh, joints, count, arcCount, arcMeshes: [] };
     }
   }
 
-  // Pass 3: Fill matrices and buffers sequentially per role
+  // Pass 3: Fill line buffers per role and build arc tubes per arc segment.
   const roleOffsets: Record<RoleName, number> = {
     outerWall: 0,
     innerWall: 0,
@@ -143,20 +183,38 @@ export function buildLayerGroup(buf: GcodeLayerBuffer): LayerBuild {
     const data = buf.blockData(b);
     if (data.length === 0) continue;
 
-    const count = data.length / 8;
     const roleId = buf.blockRole(b);
     const role = ROLE_ID_TO_NAME[roleId] || 'other';
-
     const rs = roleSegmentsMap[role];
     if (!rs) continue;
 
+    const kind = blockKinds[b];
+
+    if (kind === 1) {
+      // Arc block: 11 floats per segment.
+      const stride = 11;
+      const count = Math.floor(data.length / stride);
+      for (let i = 0; i < count; i++) {
+        const off = i * stride;
+        const arcMesh = buildArcTube(data, off, role, ROLE_COLORS[role]);
+        if (arcMesh) {
+          group.add(arcMesh);
+          rs.arcMeshes!.push(arcMesh);
+        }
+      }
+      continue;
+    }
+
+    // Line block: 8 floats per segment.
+    const stride = 8;
+    const count = Math.floor(data.length / stride);
     const baseOffset = roleOffsets[role];
 
     if (role === 'travel') {
       const pts = (rs.lines!.geometry.getAttribute('position') as BufferAttribute)
         .array as Float32Array;
       for (let i = 0; i < count; i++) {
-        const off = i * 8;
+        const off = i * stride;
         const pOff = (baseOffset + i) * 6;
         pts[pOff] = data[off];
         pts[pOff + 1] = data[off + 1];
@@ -172,7 +230,7 @@ export function buildLayerGroup(buf: GcodeLayerBuffer): LayerBuild {
 
       for (let i = 0; i < count; i++) {
         const globalI = baseOffset + i;
-        const offset = i * 8;
+        const offset = i * stride;
 
         _p0.set(data[offset], data[offset + 1], data[offset + 2]);
         _p1.set(data[offset + 3], data[offset + 4], data[offset + 5]);
@@ -212,9 +270,100 @@ export function buildLayerGroup(buf: GcodeLayerBuffer): LayerBuild {
   return { group, totalSegments, roleSegments, blockLayout };
 }
 
+/**
+ * Build a Three.js mesh that represents a single G2/G3 arc segment as a
+ * tube swept along the circular path on the layer's Z plane.
+ */
+function buildArcTube(
+  data: Float32Array,
+  off: number,
+  role: RoleName,
+  color: number | string,
+): Mesh | null {
+  const x0 = data[off];
+  const y0 = data[off + 1];
+  const z0 = data[off + 2];
+  const x1 = data[off + 3];
+  const y1 = data[off + 4];
+  const z1 = data[off + 5];
+  const cx = data[off + 6];
+  const cy = data[off + 7];
+  let isCw = data[off + 8] >= 0.5;
+  const width = data[off + 9] || 0.4;
+  const height = data[off + 10] || 0.2;
+
+  const dx0 = x0 - cx;
+  const dy0 = y0 - cy;
+  const dx1 = x1 - cx;
+  const dy1 = y1 - cy;
+  const r = Math.hypot(dx0, dy0);
+  if (!isFinite(r) || r < 1e-5) return null;
+
+  const a0 = Math.atan2(dy0, dx0);
+  const a1 = Math.atan2(dy1, dx1);
+  const TWO_PI = Math.PI * 2;
+  let sweep: number;
+  if (isCw) {
+    sweep = a0 - a1;
+    while (sweep <= 0) sweep += TWO_PI;
+  } else {
+    sweep = a1 - a0;
+    while (sweep <= 0) sweep += TWO_PI;
+  }
+  // Defensive clamp.  The slicer caps emitted arcs at 100° (5π/9) — anything
+  // larger here means our reading of CW/CCW disagrees with the firmware
+  // intent (numerical noise on near-collinear endpoints, an upstream bug, or
+  // a hand-edited G-code).  Flip to the short arc rather than draw a sweeping
+  // diagonal across the print bed, which is what produced the "weird circles"
+  // criss-crossing the model in the viewer.
+  const SLICER_MAX_SWEEP = (Math.PI * 5) / 9;
+  if (sweep > SLICER_MAX_SWEEP) {
+    sweep = TWO_PI - sweep;
+    isCw = !isCw;
+  }
+  // After the flip the sweep should be small; if it still exceeds the slicer
+  // cap, the data is malformed (e.g. radius mismatch) — skip rather than
+  // render junk.
+  if (sweep > SLICER_MAX_SWEEP || sweep < 1e-4) return null;
+
+  // Tessellate the arc with enough samples to stay smooth; ~10° per step.
+  // Build the curve in *layer-local* space (z = 0) so we can scale the Z axis
+  // to squash the cross-section without dragging the curve toward the bed.
+  // The layer's true Z is applied via `mesh.position.z` afterwards.
+  const steps = Math.max(8, Math.ceil((sweep * 180) / Math.PI / 10));
+  const dz = z1 - z0;
+  const points: Vector3[] = [];
+  for (let s = 0; s <= steps; s++) {
+    const t = s / steps;
+    const angle = isCw ? a0 - sweep * t : a0 + sweep * t;
+    const px = cx + r * Math.cos(angle);
+    const py = cy + r * Math.sin(angle);
+    points.push(new Vector3(px, py, dz * t));
+  }
+
+  // Use a Catmull-Rom curve with `centripetal` parametrisation for stable
+  // sweeps without overshoot at endpoints.
+  const curve = new CatmullRomCurve3(points, false, 'centripetal', 0.5);
+  const tubularSegments = Math.max(steps * 2, 24);
+  const radialSegments = 12;
+  // Tube radius matches the straight-segment cylinder XY thickness; the Z
+  // squash to layer-height is applied via mesh.scale below (safe now because
+  // the curve sits at local z = 0, so scaling Z only affects the cross-section
+  // and any in-layer ramp, not the layer's elevation).
+  const tubeRadius = width * 0.5;
+  const geometry = new TubeGeometry(curve, tubularSegments, tubeRadius, radialSegments, false);
+
+  const material = new MeshStandardMaterial({ color, roughness: 0.6 });
+  const mesh = new Mesh(geometry, material);
+  mesh.position.z = z0;
+  mesh.scale.set(1, 1, height / Math.max(width, 1e-4));
+  mesh.userData['role'] = role;
+  return mesh;
+}
+
 export function disposeLayerGroup(group: Group): void {
   for (const child of group.children) {
-    if (child instanceof InstancedMesh || child instanceof LineSegments) {
+    if (child instanceof InstancedMesh || child instanceof LineSegments || child instanceof Mesh) {
       child.geometry.dispose();
       if (Array.isArray(child.material)) {
         for (const m of child.material) m.dispose();
@@ -237,6 +386,9 @@ export function showLayerRange(
       if (rs.mesh) rs.mesh.count = rs.count;
       if (rs.joints) rs.joints.count = rs.count * 2;
       if (rs.lines) rs.lines.geometry.setDrawRange(0, Infinity);
+      if (rs.arcMeshes) {
+        for (const m of rs.arcMeshes) m.visible = true;
+      }
     }
   }
 
@@ -255,7 +407,16 @@ export function applySegmentProgress(
 
   const target = Math.round(progress * info.totalSegments);
 
-  const visibleCounts: Record<RoleName, number> = {
+  const visibleLineCounts: Record<RoleName, number> = {
+    outerWall: 0,
+    innerWall: 0,
+    infill: 0,
+    topSurface: 0,
+    bottomSurface: 0,
+    travel: 0,
+    other: 0,
+  };
+  const visibleArcCounts: Record<RoleName, number> = {
     outerWall: 0,
     innerWall: 0,
     infill: 0,
@@ -268,16 +429,26 @@ export function applySegmentProgress(
   let remaining = target;
   for (const block of info.blockLayout) {
     const show = Math.min(remaining, block.count);
-    visibleCounts[block.role] += show;
+    if (block.kind === 'arc') {
+      visibleArcCounts[block.role] += show;
+    } else {
+      visibleLineCounts[block.role] += show;
+    }
     remaining -= show;
     if (remaining <= 0) break;
   }
 
   for (const rs of info.roleSegments) {
-    const show = visibleCounts[rs.role] || 0;
-    if (rs.mesh) rs.mesh.count = show;
-    if (rs.joints) rs.joints.count = show * 2;
-    if (rs.lines) rs.lines.geometry.setDrawRange(0, show * 2);
+    const showLines = visibleLineCounts[rs.role] || 0;
+    if (rs.mesh) rs.mesh.count = showLines;
+    if (rs.joints) rs.joints.count = showLines * 2;
+    if (rs.lines) rs.lines.geometry.setDrawRange(0, showLines * 2);
+    if (rs.arcMeshes) {
+      const showArcs = visibleArcCounts[rs.role] || 0;
+      for (let i = 0; i < rs.arcMeshes.length; i++) {
+        rs.arcMeshes[i].visible = i < showArcs;
+      }
+    }
   }
 }
 
@@ -288,6 +459,9 @@ export function applyHiddenRoles(layers: LayerInfo[], hiddenRoles: ReadonlySet<R
       if (rs.mesh) rs.mesh.visible = visible;
       if (rs.joints) rs.joints.visible = visible;
       if (rs.lines) rs.lines.visible = visible;
+      if (rs.arcMeshes) {
+        for (const m of rs.arcMeshes) m.visible = visible;
+      }
     }
   }
 }


### PR DESCRIPTION
- Added arc fitting functionality to convert sequences of G1 moves into G2/G3 arcs, improving G-code efficiency and motion smoothness.
- Introduced new parameters for arc fitting in SlicingParams, including enabling/disabling arc fitting, tolerance, minimum segments, and maximum radius.
- Updated GcodeLayerBuffer to store geometric kinds of blocks (line or arc).
- Enhanced the Gcode layer renderer to handle arc meshes and render them appropriately.
- Created a new module for arc fitting logic, including algorithms for detecting arcs and calculating their properties.
- Added tests to ensure the arc fitting functionality behaves as expected, covering various edge cases and scenarios.