### PR TITLE
ci: report test results back to GitHub

### DIFF
--- a/.config/nextest.toml
+++ b/.config/nextest.toml
@@ -1,0 +1,12 @@
+# Nextest configuration
+# https://nexte.st/docs/configuration/
+
+[profile.ci]
+# Don't stop at the first failure so the JUnit report captures every test.
+fail-fast = false
+retries = 0
+
+[profile.ci.junit]
+# Emit JUnit XML so CI can report test results back to GitHub.
+# Written to target/nextest/ci/junit.xml.
+path = "junit.xml"

--- a/.github/workflows/test-results.yml
+++ b/.github/workflows/test-results.yml
@@ -1,0 +1,44 @@
+name: Test Results
+
+on:
+  push:
+    branches: [ main, develop ]
+  pull_request:
+    branches: [ main, develop ]
+
+env:
+  CARGO_TERM_COLOR: always
+
+permissions:
+  contents: read
+  checks: write
+  pull-requests: write
+
+jobs:
+  test:
+    name: Run tests and report results
+    runs-on: ubuntu-latest
+    steps:
+      - uses: actions/checkout@v4
+
+      - uses: dtolnay/rust-toolchain@stable
+
+      - uses: Swatinem/rust-cache@v2
+
+      - name: Install cargo-nextest
+        uses: taiki-e/install-action@v2
+        with:
+          tool: cargo-nextest
+
+      - name: Run tests
+        run: cargo nextest run --profile ci --all-features
+        continue-on-error: true
+
+      - name: Publish test results
+        uses: dorny/test-reporter@v1
+        if: ${{ !cancelled() }}
+        with:
+          name: Rust Tests
+          path: target/nextest/ci/junit.xml
+          reporter: java-junit
+          fail-on-error: true


### PR DESCRIPTION
## Summary

Adds a dedicated **Test Results** GitHub Actions workflow that runs the Rust test suite and reports the results back to GitHub — pass/fail counts and per-test annotations appear directly on the pull request and as a check run, instead of being buried in raw job logs.

## What changed

- **`.github/workflows/test-results.yml`** — new workflow triggered on push / PR to `main` and `develop`. It:
  - Runs the suite with [`cargo-nextest`](https://nexte.st/) (`cargo nextest run --profile ci --all-features`), which natively emits JUnit XML.
  - Publishes the JUnit report via [`dorny/test-reporter`](https://github.com/dorny/test-reporter), producing a **Rust Tests** check with a summary table and inline annotations on failing tests.
  - Uses `continue-on-error` on the test step + `fail-on-error` on the reporter so the report is always generated, and the check still fails when tests fail.
  - Grants the minimal `checks: write` / `pull-requests: write` permissions the reporter needs.

- **`.config/nextest.toml`** — new `ci` nextest profile that writes JUnit XML to `target/nextest/ci/junit.xml` and sets `fail-fast = false` so every test is captured in the report.

## Verification

Ran locally with the exact CI profile:

```
cargo nextest run --profile ci --all-features
   Summary [2.382s] 460 tests run: 460 passed, 0 skipped
```

`target/nextest/ci/junit.xml` was produced and validated with `xmllint` (well-formed JUnit). `target/` is already gitignored, so no artifacts are committed.

## Notes

This is additive and does not touch the existing `Multi-Platform Build` workflow, which continues to run `cargo test` across platforms.