### PR TITLE
ci(pages): add SPA 404 fallback for GitHub Pages deploy

### DIFF
--- a/.github/workflows/deploy-docs.yml
+++ b/.github/workflows/deploy-docs.yml
@@ -91,6 +91,18 @@ jobs:
           cp -R docs/.vitepress/dist/. _site/docs/
           touch _site/.nojekyll
 
+          # SPA fallback: GitHub Pages returns 404.html (with the request URL
+          # preserved) for any path it can't resolve to a static file. Serving
+          # the Angular shell there lets the client-side router handle deep
+          # links on hard reload instead of showing a 404. base-href is "/",
+          # so index.html works unchanged as the fallback.
+          if [ -f _site/index.html ]; then
+            cp _site/index.html _site/404.html
+          else
+            echo "Expected _site/index.html for SPA 404 fallback" >&2
+            exit 1
+          fi
+
       - name: Setup Pages
         uses: actions/configure-pages@v5
 


### PR DESCRIPTION
## What

Adds a SPA fallback for the GitHub Pages deployment: the built Angular shell is copied to `_site/404.html` during Pages artifact assembly.

## Why

The Angular UI uses HTML5 history routing (default `PathLocationStrategy`) and is deployed to GitHub Pages at root `/` via the custom domain `slicer.maxscopp.de`. On a hard reload of a client-side route such as `/slice/new`, GitHub Pages can't resolve the path to a static file and returns a generic 404 — even though the SPA can handle that route.

GitHub Pages serves `404.html` for any unresolved path **while preserving the requested URL** in the browser. Serving the Angular `index.html` there boots the SPA and lets the router render the correct route on reload / deep-link.

Because `base-href` is `/`, `index.html` uses absolute asset paths and works unchanged as the fallback from any route depth — no redirect/URL-rewrite script needed.

## Scope

- Change lives entirely in the "Assemble Pages artifact" step of `.github/workflows/deploy-docs.yml`.
- Does not touch `ui/public/`, `angular.json`, the local dev server, or the desktop (`ui-desktop`) build.
- VitePress docs under `_site/docs/` keep their own generated pages and are unaffected (the SPA fallback lives at `_site/404.html`).

## Notes for reviewers

The step guards on `_site/index.html` existing and fails the build if it's missing, so a broken Angular build won't silently ship an empty fallback.
