### PR TITLE
feat(version): show built commit SHA in deployed apps

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -29,6 +29,11 @@ these notes and acknowledges contributors. `scripts/gen-changelog-draft.sh` and
   shows a "What's New" dialog the first time it runs after an upgrade.
 - **GitHub Releases pipeline** — tagging `vX.Y.Z` builds all targets and publishes
   a GitHub Release whose notes are taken from this file (see [RELEASING.md](RELEASING.md)).
+- **Commit revision in build info** — every build now records the exact short
+  commit hash it was compiled from. The Settings → General page shows it beneath
+  the version, the CLI `info` command reports a `Commit:` line (and `git_sha` in
+  JSON), so a deployed build can be pinned to a precise source revision instead
+  of just an official version number.
 
 ## [0.1.0] - 2026-08-23
 

--- a/build.rs
+++ b/build.rs
@@ -50,11 +50,21 @@ fn emit_version() {
     println!("cargo:rerun-if-changed=.git/refs/tags");
     println!("cargo:rerun-if-changed=.git/packed-refs");
     println!("cargo:rerun-if-env-changed=SLICER_VERSION");
+    println!("cargo:rerun-if-env-changed=SLICER_GIT_SHA");
 
     let describe = git(&[
         "describe", "--tags", "--always", "--dirty", "--match", "v[0-9]*",
     ])
     .unwrap_or_else(|| "unknown".to_string());
+
+    // Always-present short commit hash so even a clean, tagged release build can
+    // report exactly which commit it was cut from — `git describe` omits the
+    // hash when sitting on an exact tag, so we capture it separately.
+    let git_sha = std::env::var("SLICER_GIT_SHA")
+        .ok()
+        .filter(|s| !s.trim().is_empty())
+        .or_else(|| git(&["rev-parse", "--short", "HEAD"]))
+        .unwrap_or_else(|| "unknown".to_string());
 
     let version = match std::env::var("SLICER_VERSION") {
         Ok(v) if !v.trim().is_empty() => v.trim().to_string(),
@@ -79,6 +89,7 @@ fn emit_version() {
 
     println!("cargo:rustc-env=SLICER_VERSION={version}");
     println!("cargo:rustc-env=SLICER_GIT_DESCRIBE={describe}");
+    println!("cargo:rustc-env=SLICER_GIT_SHA={git_sha}");
     println!("cargo:rustc-env=SLICER_BUILD_DATE={build_date}");
     println!("cargo:rustc-env=SLICER_IS_RELEASE={is_release}");
 }

--- a/src/cli/commands/info.rs
+++ b/src/cli/commands/info.rs
@@ -23,6 +23,7 @@ struct InfoResult {
     name: &'static str,
     version: &'static str,
     git_describe: &'static str,
+    git_sha: &'static str,
     build_date: &'static str,
     is_release: bool,
     edition: &'static str,
@@ -41,8 +42,8 @@ impl EmitPayload for InfoResult {
             "development"
         };
         let mut s = format!(
-            "Slicer Engine\n  Version: {}\n  Channel: {}\n  Build:   {} ({})\n  Edition: {}",
-            self.version, channel, self.git_describe, self.build_date, self.edition
+            "Slicer Engine\n  Version: {}\n  Channel: {}\n  Build:   {} ({})\n  Commit:  {}\n  Edition: {}",
+            self.version, channel, self.git_describe, self.build_date, self.git_sha, self.edition
         );
         if let Some(f) = self.features {
             s.push_str(&format!("\n  Features: {}", f));
@@ -55,6 +56,7 @@ impl EmitPayload for InfoResult {
             "name": self.name,
             "version": self.version,
             "git_describe": self.git_describe,
+            "git_sha": self.git_sha,
             "build_date": self.build_date,
             "is_release": self.is_release,
             "edition": self.edition,
@@ -77,6 +79,7 @@ impl InfoCommand {
             name: "slicer-engine",
             version: crate::version::VERSION,
             git_describe: crate::version::GIT_DESCRIBE,
+            git_sha: crate::version::GIT_SHA,
             build_date: crate::version::BUILD_DATE,
             is_release: crate::version::is_release(),
             edition: "2021",
@@ -111,6 +114,7 @@ mod tests {
             name: "slicer-engine",
             version: "0.1.0",
             git_describe: "v0.1.0",
+            git_sha: "abc1234",
             build_date: "2026-01-01",
             is_release: true,
             edition: "2021",
@@ -125,6 +129,7 @@ mod tests {
             name: "slicer-engine",
             version: "0.1.0",
             git_describe: "v0.1.0",
+            git_sha: "abc1234",
             build_date: "2026-01-01",
             is_release: true,
             edition: "2021",
@@ -133,6 +138,8 @@ mod tests {
         let s = r.display_human();
         assert!(s.contains("Slicer Engine"));
         assert!(s.contains("0.1.0"));
+        assert!(s.contains("Commit:"));
+        assert!(s.contains("abc1234"));
         assert!(!s.contains("Features"));
     }
 
@@ -142,6 +149,7 @@ mod tests {
             name: "slicer-engine",
             version: "0.1.0",
             git_describe: "v0.1.0",
+            git_sha: "abc1234",
             build_date: "2026-01-01",
             is_release: true,
             edition: "2021",
@@ -156,6 +164,7 @@ mod tests {
             name: "slicer-engine",
             version: "0.1.0",
             git_describe: "v0.1.0",
+            git_sha: "abc1234",
             build_date: "2026-01-01",
             is_release: true,
             edition: "2021",
@@ -164,6 +173,7 @@ mod tests {
         let v = r.to_json();
         assert_eq!(v["name"], "slicer-engine");
         assert_eq!(v["version"], "0.1.0");
+        assert_eq!(v["git_sha"], "abc1234");
         assert_eq!(v["edition"], "2021");
     }
 }

--- a/src/version.rs
+++ b/src/version.rs
@@ -26,6 +26,11 @@ pub const VERSION: &str = env!("SLICER_VERSION");
 /// hash) captured at build time, for diagnostics and bug reports.
 pub const GIT_DESCRIBE: &str = env!("SLICER_GIT_DESCRIBE");
 
+/// Short commit hash (`git rev-parse --short HEAD`) the binary was built from.
+/// Unlike [`GIT_DESCRIBE`], this is always a bare hash — even on an exact tag —
+/// so deployed builds can pin down the precise source commit.
+pub const GIT_SHA: &str = env!("SLICER_GIT_SHA");
+
 /// ISO-8601 date the build's source commit was authored (or build time when git
 /// is unavailable).
 pub const BUILD_DATE: &str = env!("SLICER_BUILD_DATE");
@@ -58,6 +63,8 @@ pub struct AppInfo {
     pub version: String,
     /// Raw `git describe` output.
     pub git_describe: String,
+    /// Short commit hash the build was cut from (always present).
+    pub git_sha: String,
     /// ISO-8601 build/commit date.
     pub build_date: String,
     /// `Cargo.toml` package version.
@@ -71,6 +78,7 @@ pub fn app_info() -> AppInfo {
     AppInfo {
         version: VERSION.to_string(),
         git_describe: GIT_DESCRIBE.to_string(),
+        git_sha: GIT_SHA.to_string(),
         build_date: BUILD_DATE.to_string(),
         cargo_version: CARGO_VERSION.to_string(),
         is_release: is_release(),

--- a/ui/src/app/pages/settings/general.html
+++ b/ui/src/app/pages/settings/general.html
@@ -21,8 +21,17 @@
         <span class="settings-field-title">Version</span>
         <span class="settings-field-desc">Current build of the app.</span>
       </span>
-      <span class="settings-value">{{ version }}</span>
+      <span class="settings-value">{{ version() }}</span>
     </div>
+    @if (commit()) {
+      <div class="settings-field">
+        <span class="settings-field-label">
+          <span class="settings-field-title">Commit</span>
+          <span class="settings-field-desc">Exact source revision this build was compiled from.</span>
+        </span>
+        <span class="settings-value settings-value-mono">{{ commit() }}</span>
+      </div>
+    }
   </div>
 
   <h2 class="subhead">Controls</h2>

--- a/ui/src/app/pages/settings/general.scss
+++ b/ui/src/app/pages/settings/general.scss
@@ -12,6 +12,11 @@
   width: min(320px, 60%);
 }
 
+.settings-value-mono {
+  font-family: var(--font-family-mono);
+  letter-spacing: 0.02em;
+}
+
 .fov-slider {
   flex: 1;
   min-width: 0;

--- a/ui/src/app/pages/settings/general.ts
+++ b/ui/src/app/pages/settings/general.ts
@@ -1,4 +1,4 @@
-import { ChangeDetectionStrategy, Component, inject } from '@angular/core';
+import { ChangeDetectionStrategy, Component, computed, inject, OnInit } from '@angular/core';
 import {
   MAX_FIELD_OF_VIEW,
   MIN_FIELD_OF_VIEW,
@@ -7,6 +7,7 @@ import {
   type RenderQuality,
   type TwoFingerGesture,
 } from '../../services/viewer-control';
+import { AppVersion } from '../../services/app-version';
 import { SectionHeader } from '../../ui/section-header/section-header';
 import { Slider } from '../../ui/slider/slider';
 import { FovCube } from '../../ui/fov-cube/fov-cube';
@@ -18,8 +19,9 @@ import { FovCube } from '../../ui/fov-cube/fov-cube';
   styleUrl: './general.scss',
   changeDetection: ChangeDetectionStrategy.OnPush,
 })
-export class GeneralSettings {
+export class GeneralSettings implements OnInit {
   protected readonly viewer = inject(ViewerControl);
+  private readonly appVersion = inject(AppVersion);
   protected readonly gesture = this.viewer.trackpadTwoFingerGesture;
   protected readonly statsVisible = this.viewer.statsVisible;
   protected readonly fieldOfView = this.viewer.fieldOfView;
@@ -29,12 +31,27 @@ export class GeneralSettings {
   protected readonly minFov = MIN_FIELD_OF_VIEW;
   protected readonly maxFov = MAX_FIELD_OF_VIEW;
 
-  protected readonly version = '0.1.0';
+  /** Build-time version metadata read from the WASM bundle (SSOT). */
+  protected readonly info = this.appVersion.info;
+
+  /** The user-facing version — a release semver or `"development"`. */
+  protected readonly version = computed(() => this.info()?.version ?? '…');
+
+  /**
+   * The exact commit the running build was cut from. Shown so deployed builds
+   * can be pinned to a precise source revision, not just an official version.
+   */
+  protected readonly commit = computed(() => this.info()?.git_sha ?? '');
+
   protected readonly platform =
     typeof globalThis !== 'undefined' &&
     ('__TAURI_INTERNALS__' in globalThis || '__TAURI__' in globalThis)
       ? 'Desktop'
       : 'Web';
+
+  ngOnInit(): void {
+    void this.appVersion.loadInfo();
+  }
 
   setGesture(gesture: TwoFingerGesture): void {
     this.viewer.setTrackpadTwoFingerGesture(gesture);

--- a/ui/src/app/services/app-version.ts
+++ b/ui/src/app/services/app-version.ts
@@ -34,6 +34,22 @@ export class AppVersion {
   readonly whatsNew = signal<ChangelogEntry[]>([]);
 
   /**
+   * Ensure {@link info} is populated, loading it from the WASM bundle on first
+   * call. Safe to call from any component that wants to display the running
+   * version; subsequent calls are no-ops. Failures are logged, not thrown.
+   */
+  async loadInfo(): Promise<void> {
+    if (this.info()) {
+      return;
+    }
+    try {
+      this.info.set(await this.sceneEngine.appInfo());
+    } catch (err) {
+      this.log.warn('Unable to read app version', err);
+    }
+  }
+
+  /**
    * Detect an upgrade and, if found, show the "What's New" dialog once.
    * Safe to call during app initialization — failures are logged, not thrown.
    */

--- a/ui/src/app/services/scene-engine.ts
+++ b/ui/src/app/services/scene-engine.ts
@@ -16,6 +16,7 @@ import { Logger } from './logger';
 export interface AppInfo {
   version: string;
   git_describe: string;
+  git_sha: string;
   build_date: string;
   cargo_version: string;
   is_release: boolean;


### PR DESCRIPTION
## Why

Deployed builds only surfaced an official version number (or the literal `development`), so there was no way to tell which exact commit a running build came from. `git describe` drops the short hash when sitting on an exact tag, meaning tagged release builds had **no** revision identity at all. On top of that, the Settings → General page hard-coded `version = '0.1.0'`, directly violating the versioning SSOT contract.

## What changed

Captured an always-present short commit hash at build time and threaded it through the single source of truth (`src/version.rs`) so every target — CLI, WS, WASM/UI — can report it.

- **`build.rs`** — emits `SLICER_GIT_SHA` from `git rev-parse --short HEAD` (overridable via env for shallow CI checkouts; the release workflow already uses `fetch-depth: 0`).
- **`src/version.rs`** — adds the `GIT_SHA` const and a `git_sha` field on `AppInfo` (serialized to CLI JSON, WS, and the WASM bundle automatically).
- **`src/cli/commands/info.rs`** — human output gains a `Commit:` line; JSON gains a `git_sha` field. Tests updated.
- **Angular Settings → General** — now reads the **real** version from the WASM bundle (removing the hardcoded `'0.1.0'` constant) and shows the commit hash in a new monospace **Commit** row. Added `AppVersion.loadInfo()` so the page reliably populates its info.

## Verification

- `cargo test --lib info` — all pass
- `cargo clippy --lib --all-features -- -D warnings` — clean
- `cargo check --target wasm32-unknown-unknown --lib` — compiles
- `cargo run -- info` now prints:
  ```
  Slicer Engine
    Version: development
    Channel: development
    Build:   de940ac-dirty (2026-08-23T16:23:04+02:00)
    Commit:  de940ac
    Edition: 2021
  ```

Co-authored-by: Copilot <223556219+Copilot@users.noreply.github.com>