### PR TITLE
ui: warn once per session about WASM web build performance

### DIFF
--- a/ui/src/app/app.ts
+++ b/ui/src/app/app.ts
@@ -2,6 +2,7 @@ import { Component, inject } from '@angular/core';
 import { RouterOutlet } from '@angular/router';
 import { NotificationCenter } from './components/notification-center/notification-center';
 import { AppVersion } from './services/app-version';
+import { WasmPerformanceNotice } from './services/wasm-performance-notice';
 import { DialogOutlet } from './shared/dialog/dialog-outlet';
 
 @Component({
@@ -13,10 +14,15 @@ import { DialogOutlet } from './shared/dialog/dialog-outlet';
 })
 export class App {
   private readonly appVersion = inject(AppVersion);
+  private readonly wasmPerfNotice = inject(WasmPerformanceNotice);
 
   constructor() {
     // Fire-and-forget: detect upgrades and surface "What's New" without
     // blocking startup. Failures are handled inside the service.
     void this.appVersion.checkForNewVersion();
+
+    // On the WASM web build only, remind the user once per session that
+    // in-browser slicing trades performance for zero install.
+    this.wasmPerfNotice.maybeShow();
   }
 }

--- a/ui/src/app/components/wasm-performance-notice/wasm-performance-panel.html
+++ b/ui/src/app/components/wasm-performance-notice/wasm-performance-panel.html
@@ -1,0 +1,30 @@
+<p class="wasm-perf__lead">
+  You're running the full <strong>WebAssembly</strong> build — the entire slicer runs inside your
+  browser tab, with nothing to install. To make that possible it has to make real compromises, and
+  the biggest one is <strong>raw performance</strong>.
+</p>
+
+<div class="wasm-perf__metric" role="group" aria-label="Slice time comparison">
+  <div class="wasm-perf__card">
+    <span class="wasm-perf__card-label">In the browser (WASM)</span>
+    <span class="wasm-perf__card-value">34.1<span class="wasm-perf__card-unit">s</span></span>
+    <span class="wasm-perf__card-note">MacBook M1, one slice</span>
+  </div>
+
+  <div class="wasm-perf__versus" aria-hidden="true">
+    <span class="wasm-perf__versus-arrow">→</span>
+    <span class="wasm-perf__versus-badge">~10× faster</span>
+  </div>
+
+  <div class="wasm-perf__card wasm-perf__card--native">
+    <span class="wasm-perf__card-label">Native app</span>
+    <span class="wasm-perf__card-value">&lt;3<span class="wasm-perf__card-unit">s</span></span>
+    <span class="wasm-perf__card-note">Same machine, same model</span>
+  </div>
+</div>
+
+<p class="wasm-perf__outro">
+  Everything here is the real slicing engine, so the quality and results match the native app
+  exactly — it's just slower. If you like what you see, grab the <strong>native version</strong> for
+  the full-speed experience.
+</p>

--- a/ui/src/app/components/wasm-performance-notice/wasm-performance-panel.scss
+++ b/ui/src/app/components/wasm-performance-notice/wasm-performance-panel.scss
@@ -1,0 +1,97 @@
+:host {
+  display: block;
+  font-size: 0.9rem;
+  line-height: 1.5;
+}
+
+.wasm-perf__lead {
+  margin: 0 0 var(--spacing-lg);
+  color: var(--color-text-secondary);
+}
+
+.wasm-perf__metric {
+  display: flex;
+  align-items: stretch;
+  gap: var(--spacing-sm);
+  margin: 0 0 var(--spacing-lg);
+}
+
+.wasm-perf__card {
+  flex: 1 1 0;
+  display: flex;
+  flex-direction: column;
+  align-items: center;
+  justify-content: center;
+  gap: var(--spacing-xs);
+  padding: var(--spacing-md);
+  text-align: center;
+  border-radius: var(--radius-lg);
+  background: var(--color-bg-secondary);
+
+  &--native {
+    background: var(--accent-soft);
+    border: 1px solid var(--accent-border);
+  }
+}
+
+.wasm-perf__card-label {
+  font-size: 0.72rem;
+  font-weight: 600;
+  letter-spacing: 0.03em;
+  text-transform: uppercase;
+  color: var(--color-text-tertiary);
+}
+
+.wasm-perf__card-value {
+  font-size: 1.9rem;
+  font-weight: 700;
+  font-variant-numeric: tabular-nums;
+  line-height: 1.1;
+  color: var(--color-text-primary);
+
+  .wasm-perf__card--native & {
+    color: var(--accent);
+  }
+}
+
+.wasm-perf__card-unit {
+  margin-left: 1px;
+  font-size: 0.9rem;
+  font-weight: 600;
+  opacity: 0.7;
+}
+
+.wasm-perf__card-note {
+  font-size: 0.72rem;
+  color: var(--color-text-tertiary);
+  opacity: 0.85;
+}
+
+.wasm-perf__versus {
+  flex: none;
+  display: flex;
+  flex-direction: column;
+  align-items: center;
+  justify-content: center;
+  gap: var(--spacing-xs);
+}
+
+.wasm-perf__versus-arrow {
+  font-size: 1.1rem;
+  color: var(--color-text-tertiary);
+}
+
+.wasm-perf__versus-badge {
+  padding: 2px 8px;
+  border-radius: var(--radius-sm);
+  font-size: 0.72rem;
+  font-weight: 700;
+  white-space: nowrap;
+  color: var(--accent-contrast);
+  background: var(--accent);
+}
+
+.wasm-perf__outro {
+  margin: 0;
+  color: var(--color-text-secondary);
+}

--- a/ui/src/app/components/wasm-performance-notice/wasm-performance-panel.ts
+++ b/ui/src/app/components/wasm-performance-notice/wasm-performance-panel.ts
@@ -1,0 +1,17 @@
+import { ChangeDetectionStrategy, Component } from '@angular/core';
+
+/**
+ * Dialog body shown once per browser session on the WebAssembly web build.
+ *
+ * Explains — with a concrete before/after metric — that running the slicer
+ * entirely in the browser trades a large amount of raw performance for zero
+ * install, and points users at the native app when they want full speed.
+ */
+@Component({
+  selector: 'nexus-wasm-performance-panel',
+  standalone: true,
+  templateUrl: './wasm-performance-panel.html',
+  styleUrl: './wasm-performance-panel.scss',
+  changeDetection: ChangeDetectionStrategy.OnPush,
+})
+export class WasmPerformancePanel {}

--- a/ui/src/app/services/wasm-performance-notice.ts
+++ b/ui/src/app/services/wasm-performance-notice.ts
@@ -1,0 +1,51 @@
+import { inject, Injectable } from '@angular/core';
+import { environment } from '../../environments/environment';
+import { WasmPerformancePanel } from '../components/wasm-performance-notice/wasm-performance-panel';
+import { BrowserStorage } from './browser-storage';
+import { Dialog } from './dialog';
+
+/**
+ * sessionStorage key recording that the WASM performance notice has been shown
+ * in the current browser session. Session-scoped on purpose — the reminder
+ * reappears in a fresh tab/session but never nags twice within one.
+ */
+const NOTICE_SEEN_KEY = 'slicer:wasm-perf-notice-seen';
+
+/**
+ * Surfaces a one-time-per-session heads-up on the WebAssembly web build that
+ * running the slicer entirely in the browser costs a lot of performance, and
+ * points users at the native app for full speed.
+ *
+ * Only the `web` runtime (the full WASM web bundle) is affected — the native
+ * (Tauri) and cloud runtimes never see it.
+ */
+@Injectable({ providedIn: 'root' })
+export class WasmPerformanceNotice {
+  private readonly storage = inject(BrowserStorage);
+  private readonly dialog = inject(Dialog);
+
+  /**
+   * Show the WASM performance notice once per browser session. Safe to call
+   * during app initialization — it's a no-op off the web build or when already
+   * shown this session.
+   */
+  maybeShow(): void {
+    if (environment.runtimeMode !== 'web') {
+      return;
+    }
+
+    if (this.storage.get(NOTICE_SEEN_KEY, 'session')()) {
+      return;
+    }
+
+    // Record before showing so a mid-animation refresh can't reopen it.
+    this.storage.write(NOTICE_SEEN_KEY, '1', 'session');
+
+    this.dialog.alert({
+      title: 'Running in your browser',
+      confirmLabel: 'Got it',
+      content: WasmPerformancePanel,
+      preferredWidth: '560px',
+    });
+  }
+}


### PR DESCRIPTION
## What

On the **full WebAssembly web build** (`environment.runtimeMode === 'web'`), show a **once-per-session** dialog reminding the user that running the slicer entirely in the browser trades a lot of raw performance for a zero-install experience, and encourage switching to the native app for full speed.

The dialog uses a concrete before/after metric:

| In the browser (WASM) | Native app |
| --- | --- |
| 34.1s (MacBook M1, one slice) | <3s (same machine, same model) — **~10x faster** |

It also reassures the user that slice quality/results are identical to native — only speed differs.

## Why

The WASM build makes real compromises to run fully in-browser, and performance is the most user-visible one. Setting expectations up front (and pointing power users at the native build) avoids the impression that the slicer itself is slow.

## How

- **New `WasmPerformanceNotice` service** (`ui/src/app/services/wasm-performance-notice.ts`): `maybeShow()` no-ops unless the runtime is `web`, guards on a `sessionStorage` flag (`slicer:wasm-perf-notice-seen`), records the flag before opening (so a mid-animation refresh can't reopen it), then fires `Dialog.alert({ content })`. Mirrors the existing `AppVersion` "What's New" pattern.
- **New `WasmPerformancePanel` component** (`ui/src/app/components/wasm-performance-notice/`): dialog body with the two-card before/after metric, an accent "~10x faster" badge, and the native-app nudge. Standalone, `OnPush`, `nexus-` prefix, design-token styling (no blur, solid surface).
- **`app.ts`**: injects the service and calls `maybeShow()` on startup.

## Reviewer notes

- Native (Tauri) and cloud runtimes are unaffected — the notice only fires on `web`.
- Session-scoped on purpose: it reappears in a fresh tab/session but never nags twice within one.
- The metric numbers (34.1s / <3s / ~10x) are hardcoded copy in the panel HTML — easy to tweak.
- Per the UI-style workflow, build verification was skipped; prettier passes on all changed files.
