### PR TITLE
ui: prompt to reload when the UI bundle is out of date

### DIFF
--- a/.github/workflows/deploy-docs.yml
+++ b/.github/workflows/deploy-docs.yml
@@ -67,6 +67,9 @@ jobs:
       - name: Build web-slicer WASM
         env:
           CXX_wasm32_unknown_unknown: ${{ github.workspace }}/tools/wasm32-clang++.js
+          # Pin the baked-in commit SHA so it exactly matches version.json below,
+          # letting a stale tab detect that a newer build has been deployed.
+          SLICER_GIT_SHA: ${{ github.sha }}
         run: pnpm run hydrate:web-slicer
 
       - name: Build UI (web-slicer)
@@ -90,6 +93,12 @@ jobs:
 
           cp -R docs/.vitepress/dist/. _site/docs/
           touch _site/.nojekyll
+
+          # Deploy manifest for the UI's out-of-date detector. Its SHA matches
+          # the one baked into the WASM bundle (SLICER_GIT_SHA above); a stale
+          # tab re-fetches this file and prompts a reload when they differ.
+          printf '{"sha":"%s","version":"%s"}\n' \
+            "${{ github.sha }}" "${{ github.ref_name }}" > _site/version.json
 
           # SPA fallback: GitHub Pages returns 404.html (with the request URL
           # preserved) for any path it can't resolve to a static file. Serving

--- a/ui/src/app/app.html
+++ b/ui/src/app/app.html
@@ -1,3 +1,4 @@
 <router-outlet />
 <nexus-notification-center />
+<nexus-update-banner />
 <nexus-dialog-outlet />

--- a/ui/src/app/app.ts
+++ b/ui/src/app/app.ts
@@ -1,6 +1,7 @@
 import { Component, inject } from '@angular/core';
 import { RouterOutlet } from '@angular/router';
 import { NotificationCenter } from './components/notification-center/notification-center';
+import { UpdateBanner } from './components/update-banner/update-banner';
 import { AppVersion } from './services/app-version';
 import { WasmPerformanceNotice } from './services/wasm-performance-notice';
 import { DialogOutlet } from './shared/dialog/dialog-outlet';
@@ -8,7 +9,7 @@ import { DialogOutlet } from './shared/dialog/dialog-outlet';
 @Component({
   selector: 'nexus-root',
   standalone: true,
-  imports: [RouterOutlet, NotificationCenter, DialogOutlet],
+  imports: [RouterOutlet, NotificationCenter, UpdateBanner, DialogOutlet],
   templateUrl: './app.html',
   styleUrl: './app.scss',
 })

--- a/ui/src/app/app.ts
+++ b/ui/src/app/app.ts
@@ -25,5 +25,9 @@ export class App {
     // On the WASM web build only, remind the user once per session that
     // in-browser slicing trades performance for zero install.
     this.wasmPerfNotice.maybeShow();
+
+    // Watch for a newer static deployment (Pages/web runtime) so a stale tab
+    // gets a reload prompt even though there's no server to announce a version.
+    this.appVersion.startUpdateWatch();
   }
 }

--- a/ui/src/app/components/update-banner/update-banner.html
+++ b/ui/src/app/components/update-banner/update-banner.html
@@ -1,0 +1,16 @@
+@if (visible()) {
+  <div class="update-banner" role="status" aria-live="polite" animate.enter="banner-enter">
+    <nexus-icon class="update-banner__icon" name="restart" />
+    <div class="update-banner__content">
+      <span class="update-banner__title">A new version is available</span>
+      <span class="update-banner__message">
+        @if (serverVersion(); as version) {
+          Version {{ version }} is ready. Reload to get the latest improvements.
+        } @else {
+          Reload to get the latest improvements.
+        }
+      </span>
+    </div>
+    <button type="button" class="update-banner__action" (click)="reload()">Reload</button>
+  </div>
+}

--- a/ui/src/app/components/update-banner/update-banner.scss
+++ b/ui/src/app/components/update-banner/update-banner.scss
@@ -1,0 +1,96 @@
+:host {
+  position: fixed;
+  bottom: calc(var(--spacing-lg, 16px) + env(safe-area-inset-bottom, 0));
+  left: 50%;
+  transform: translateX(-50%);
+  z-index: 2100;
+  pointer-events: none;
+  width: min(440px, calc(100vw - 32px));
+}
+
+.update-banner {
+  pointer-events: auto;
+  display: flex;
+  align-items: center;
+  gap: var(--spacing-sm, 8px);
+  padding: 10px 10px 10px 14px;
+  border-radius: var(--radius-lg, 8px);
+  background: var(--color-surface);
+  border: 1px solid var(--accent-border);
+  box-shadow: var(--shadow-md);
+}
+
+.update-banner__icon {
+  flex-shrink: 0;
+  color: var(--accent);
+  --icon-size: 18px;
+}
+
+.update-banner__content {
+  flex: 1;
+  min-width: 0;
+  display: flex;
+  flex-direction: column;
+  gap: 2px;
+}
+
+.update-banner__title {
+  font-size: 13px;
+  font-weight: 500;
+  color: var(--color-text-primary, #f5f6f8);
+  line-height: 1.35;
+}
+
+.update-banner__message {
+  font-size: 12px;
+  color: var(--color-text-tertiary, #888c98);
+  line-height: 1.4;
+}
+
+.update-banner__action {
+  flex-shrink: 0;
+  appearance: none;
+  cursor: pointer;
+  padding: 6px 14px;
+  border-radius: var(--radius-md, 6px);
+  border: none;
+  font-size: 12px;
+  font-weight: 600;
+  color: var(--accent-contrast);
+  background: var(--accent);
+  transition:
+    background var(--transition-fast, 0.15s ease),
+    outline-color var(--transition-fast, 0.15s ease);
+  outline: 2px solid transparent;
+  outline-offset: 2px;
+
+  &:hover {
+    background: var(--accent-hover);
+  }
+
+  &:active {
+    background: var(--accent-active);
+  }
+
+  &:focus-visible {
+    outline-color: var(--accent);
+  }
+}
+
+// ── Enter animation (opacity + slide up, never blur) ──────────────────────────
+
+.banner-enter {
+  animation: banner-enter-kf 280ms cubic-bezier(0, 0, 0.2, 1) both;
+}
+
+@keyframes banner-enter-kf {
+  from {
+    opacity: 0;
+    transform: translateY(12px) scale(0.98);
+  }
+
+  to {
+    opacity: 1;
+    transform: translateY(0) scale(1);
+  }
+}

--- a/ui/src/app/components/update-banner/update-banner.ts
+++ b/ui/src/app/components/update-banner/update-banner.ts
@@ -1,0 +1,32 @@
+import { ChangeDetectionStrategy, Component, inject } from '@angular/core';
+import { Icon } from '../../shared/icon/icon';
+import { AppVersion } from '../../services/app-version';
+
+/**
+ * A docked prompt that appears when the server announces a newer release than
+ * the bundle this browser tab is running (see {@link AppVersion.updateAvailable}).
+ *
+ * The common cause is a redeploy while a long-lived tab stayed open: the running
+ * JS/WASM is stale but the user has no reason to know they should hard-refresh.
+ * This offers a single, obvious "Reload" action that force-fetches the new
+ * build. It intentionally has no dismiss button — a stale UI can misbehave, so
+ * reloading is the only safe resolution.
+ */
+@Component({
+  selector: 'nexus-update-banner',
+  standalone: true,
+  imports: [Icon],
+  templateUrl: './update-banner.html',
+  styleUrl: './update-banner.scss',
+  changeDetection: ChangeDetectionStrategy.OnPush,
+})
+export class UpdateBanner {
+  private readonly appVersion = inject(AppVersion);
+
+  readonly visible = this.appVersion.updateAvailable;
+  readonly serverVersion = this.appVersion.serverVersion;
+
+  reload(): void {
+    this.appVersion.reloadForUpdate();
+  }
+}

--- a/ui/src/app/runtime/adapters/cloud/cloud-runtime.ts
+++ b/ui/src/app/runtime/adapters/cloud/cloud-runtime.ts
@@ -221,7 +221,7 @@ export class CloudRuntime implements RuntimePort {
   private handleMessage(msg: ServerMessage): void {
     switch (msg.type) {
       case 'Connected':
-        this.bus.emit({ type: 'connected', mode: 'cloud' });
+        this.bus.emit({ type: 'connected', mode: 'cloud', serverVersion: msg.version });
         this.bus.emit({
           type: 'log',
           level: 'info',

--- a/ui/src/app/runtime/ports/runtime-events.ts
+++ b/ui/src/app/runtime/ports/runtime-events.ts
@@ -1,7 +1,7 @@
 import { RuntimeError } from './runtime-errors';
 
 export type RuntimeEvent =
-  | { type: 'connected'; mode: 'native' | 'cloud' | 'web' }
+  | { type: 'connected'; mode: 'native' | 'cloud' | 'web'; serverVersion?: string }
   | { type: 'phase-start'; sliceId: string; phase: string }
   | { type: 'phase-end'; sliceId: string; phase: string; elapsedMs?: number }
   | { type: 'progress'; sliceId: string; currentLayer: number; totalLayers: number }

--- a/ui/src/app/services/app-version.ts
+++ b/ui/src/app/services/app-version.ts
@@ -1,4 +1,6 @@
 import { inject, Injectable, signal } from '@angular/core';
+import { DOCUMENT } from '@angular/common';
+import { environment } from '../../environments/environment';
 import { WhatsNewPanel } from '../components/whats-new/whats-new-panel';
 import { AppInfo, ChangelogEntry, SceneEngine } from './scene-engine';
 import { BrowserStorage } from './browser-storage';
@@ -7,6 +9,25 @@ import { Logger } from './logger';
 
 /** localStorage key holding the last release version the user has seen. */
 const LAST_SEEN_KEY = 'slicer:last-seen-version';
+
+/**
+ * Static manifest published next to the bundle at deploy time (see the Pages
+ * workflow). Its `sha` is the git commit the deployment was built from — the
+ * same value baked into the running bundle via `appInfo().git_sha`.
+ */
+interface DeployManifest {
+  sha: string;
+  version?: string;
+}
+
+/** Path (relative to the app base href) of the deploy manifest. */
+const DEPLOY_MANIFEST_PATH = 'version.json';
+
+/** Minimum gap between deploy-manifest network checks, to avoid hammering. */
+const DEPLOY_CHECK_THROTTLE_MS = 60_000;
+
+/** How often to poll the deploy manifest for a tab that stays visible. */
+const DEPLOY_POLL_INTERVAL_MS = 15 * 60_000;
 
 /**
  * Owns the app's version identity and the "What's New" upgrade experience.
@@ -26,6 +47,13 @@ export class AppVersion {
   private readonly storage = inject(BrowserStorage);
   private readonly dialog = inject(Dialog);
   private readonly log = inject(Logger).scope('AppVersion');
+  private readonly document = inject(DOCUMENT);
+
+  /** Guards {@link startUpdateWatch} against installing duplicate listeners. */
+  private watchStarted = false;
+
+  /** Timestamp of the last deploy-manifest fetch, for throttling. */
+  private lastDeployCheck = 0;
 
   /** Build-time version metadata, populated after {@link checkForNewVersion}. */
   readonly info = signal<AppInfo | null>(null);
@@ -34,14 +62,24 @@ export class AppVersion {
   readonly whatsNew = signal<ChangelogEntry[]>([]);
 
   /**
-   * True when the server announced a release version that differs from the one
-   * baked into the running UI bundle — i.e. the app was redeployed while this
-   * tab kept an old build alive. Surfaced by the reload prompt so the user can
-   * pick up the new version without knowing to hard-refresh themselves.
+   * True when a newer build has been detected than the one this tab is running
+   * — the app was (re)deployed while this tab kept an old bundle alive.
+   * Surfaced by the reload prompt so the user can pick up the new version
+   * without knowing to hard-refresh themselves.
+   *
+   * Two independent detectors set this: {@link reportServerVersion} (cloud/WS
+   * deployments, from the server's announced version) and
+   * {@link checkDeployedVersion} (static/Pages deployments, from a published
+   * `version.json`). Either is sufficient.
    */
   readonly updateAvailable = signal(false);
 
-  /** The newer server version that triggered {@link updateAvailable}, if any. */
+  /**
+   * A human-friendly label for the newer version that triggered
+   * {@link updateAvailable}, when one is known and looks like a real release.
+   * Stays `null` for untagged/development deploys (whose only reliable
+   * difference is the git SHA, not a version string).
+   */
   readonly serverVersion = signal<string | null>(null);
 
   /**
@@ -149,6 +187,93 @@ export class AppVersion {
     const url = new URL(window.location.href);
     url.searchParams.set('_v', Date.now().toString(36));
     window.location.replace(url.toString());
+  }
+
+  /**
+   * Begin watching for a newer static deployment (Pages/`web` runtime).
+   *
+   * There is no server to announce a version in `web` mode — the bundle and the
+   * WASM slicer are the same set of static files. Instead the deployment
+   * publishes a `version.json` whose git SHA is re-fetched here and compared to
+   * the SHA baked into the running bundle. A mismatch means a newer build has
+   * gone live while this tab stayed open.
+   *
+   * Checks run once now and again whenever the tab regains visibility (the
+   * moment a user returns to a long-idle tab), throttled to one network hit per
+   * minute. Idempotent and a no-op outside `web` mode. Safe to call at startup.
+   */
+  startUpdateWatch(): void {
+    if (this.watchStarted || environment.runtimeMode !== 'web') {
+      return;
+    }
+    this.watchStarted = true;
+
+    void this.checkDeployedVersion();
+
+    this.document.addEventListener('visibilitychange', () => {
+      if (this.document.visibilityState === 'visible') {
+        void this.checkDeployedVersion();
+      }
+    });
+
+    // Also poll on a slow timer so a tab that stays visible for hours still
+    // notices a deploy. The per-check throttle keeps this cheap.
+    setInterval(() => void this.checkDeployedVersion(), DEPLOY_POLL_INTERVAL_MS);
+  }
+
+  /**
+   * Fetch the deploy manifest and flag {@link updateAvailable} when its git SHA
+   * differs from the running bundle's. Throttled and completely silent on
+   * failure — a missing/unreachable manifest (local dev, non-Pages hosting)
+   * simply means "no update information", never an error.
+   */
+  async checkDeployedVersion(): Promise<void> {
+    if (this.updateAvailable()) {
+      return; // Already prompting — nothing more to learn.
+    }
+
+    const now = Date.now();
+    if (now - this.lastDeployCheck < DEPLOY_CHECK_THROTTLE_MS) {
+      return;
+    }
+    this.lastDeployCheck = now;
+
+    await this.loadInfo();
+    const runningSha = this.info()?.git_sha;
+    if (!runningSha || runningSha === 'unknown') {
+      return; // Nothing trustworthy to compare against.
+    }
+
+    const manifest = await this.fetchDeployManifest();
+    if (!manifest?.sha || manifest.sha === runningSha) {
+      return;
+    }
+
+    this.log.info(
+      `Deployed build ${manifest.sha} differs from running ${runningSha} — a reload is needed`,
+    );
+    const label = manifest.version?.replace(/^v/, '');
+    this.serverVersion.set(label && isReleaseVersion(label) ? label : null);
+    this.updateAvailable.set(true);
+  }
+
+  /**
+   * Fetch and parse the deploy manifest, bypassing the HTTP cache so a stale
+   * tab still sees the freshly deployed file. Returns `null` on any failure.
+   */
+  private async fetchDeployManifest(): Promise<DeployManifest | null> {
+    try {
+      const url = new URL(DEPLOY_MANIFEST_PATH, this.document.baseURI);
+      url.searchParams.set('_', Date.now().toString(36));
+      const res = await fetch(url.toString(), { cache: 'no-store' });
+      if (!res.ok) {
+        return null;
+      }
+      const data = (await res.json()) as Partial<DeployManifest>;
+      return typeof data?.sha === 'string' ? { sha: data.sha, version: data.version } : null;
+    } catch {
+      return null;
+    }
   }
 
   /**

--- a/ui/src/app/services/app-version.ts
+++ b/ui/src/app/services/app-version.ts
@@ -34,6 +34,17 @@ export class AppVersion {
   readonly whatsNew = signal<ChangelogEntry[]>([]);
 
   /**
+   * True when the server announced a release version that differs from the one
+   * baked into the running UI bundle — i.e. the app was redeployed while this
+   * tab kept an old build alive. Surfaced by the reload prompt so the user can
+   * pick up the new version without knowing to hard-refresh themselves.
+   */
+  readonly updateAvailable = signal(false);
+
+  /** The newer server version that triggered {@link updateAvailable}, if any. */
+  readonly serverVersion = signal<string | null>(null);
+
+  /**
    * Ensure {@link info} is populated, loading it from the WASM bundle on first
    * call. Safe to call from any component that wants to display the running
    * version; subsequent calls are no-ops. Failures are logged, not thrown.
@@ -93,6 +104,51 @@ export class AppVersion {
       content: WhatsNewPanel,
       preferredWidth: '640px',
     });
+  }
+
+  /**
+   * Compare the version the server announced on (re)connect against the version
+   * baked into the running UI bundle. When a real release differs from what this
+   * tab is running, flag {@link updateAvailable} so the reload prompt appears.
+   *
+   * Only fires for release↔release mismatches: development builds (either side)
+   * have an unstable `"development"` version and are never nagged. Safe to call
+   * on every reconnect — failures are logged, not thrown.
+   */
+  async reportServerVersion(serverVersion: string | undefined): Promise<void> {
+    if (!serverVersion || !isReleaseVersion(serverVersion)) {
+      return;
+    }
+
+    await this.loadInfo();
+    const running = this.info();
+
+    // Can't compare without our own version, and never nag development builds.
+    if (!running || !running.is_release || !isReleaseVersion(running.version)) {
+      return;
+    }
+
+    if (running.version === serverVersion) {
+      return;
+    }
+
+    this.log.info(
+      `Server is on ${serverVersion} but this UI is running ${running.version} — a reload is needed`,
+    );
+    this.serverVersion.set(serverVersion);
+    this.updateAvailable.set(true);
+  }
+
+  /**
+   * Force a fresh load of the app, bypassing the browser cache so the newly
+   * deployed bundle is fetched instead of the stale one this tab holds.
+   */
+  reloadForUpdate(): void {
+    // A cache-busting query param guarantees the document (and thus its module
+    // graph) is re-fetched even behind an over-eager HTTP cache.
+    const url = new URL(window.location.href);
+    url.searchParams.set('_v', Date.now().toString(36));
+    window.location.replace(url.toString());
   }
 
   /**

--- a/ui/src/app/services/slicer.ts
+++ b/ui/src/app/services/slicer.ts
@@ -11,6 +11,7 @@ import { createRuntime } from '../runtime/factory/runtime-factory';
 import { RuntimeEvent } from '../runtime/ports/runtime-events';
 import { NotificationService } from './notifications';
 import { SceneEngine } from './scene-engine';
+import { AppVersion } from './app-version';
 import { ConnectionStatus, SlicerConnection } from './slicer-connection';
 import { SlicerFile, UploadResponse } from './slicer-file';
 
@@ -91,6 +92,7 @@ export class Slicer {
   private readonly slicerFile = inject(SlicerFile);
   private readonly notifications = inject(NotificationService);
   private readonly sceneEngine = inject(SceneEngine);
+  private readonly appVersion = inject(AppVersion);
   private readonly runtimeMode = this.resolveRuntimeMode();
   private readonly runtime = createRuntime({
     mode: this.runtimeMode,
@@ -299,6 +301,7 @@ export class Slicer {
       case 'connected':
         this.runtimeConnected.set(true);
         this.outputLog.update((log) => [...log, `[runtime] Connected (${event.mode})`]);
+        void this.appVersion.reportServerVersion(event.serverVersion);
         break;
       case 'log':
         this.outputLog.update((log) => [...log, `[${event.level}] ${event.message}`]);


### PR DESCRIPTION
## What

Adds detection for when a browser tab is running a **stale UI bundle** — the common case where the app is redeployed while a long-lived tab stays open. A docked prompt appears with a single **Reload** button that force-fetches the new build, so users don't need to know to hard-refresh (Ctrl+Shift+R).

## Why

After a deploy, an open tab keeps running old JS/WASM against a newer server. Users have no signal that they're on a stale build, and a stale UI can misbehave against the new backend. This closes that gap with an obvious, one-click resolution.

## How

Reuses the existing version SSOT rather than adding any new version constant:

- The WS server already announces its version in the `Connected` message.
- The running UI already knows its own bundle version via the WASM `appInfo()`.

On every (re)connect the two are compared. A real **release-vs-release** mismatch flags `updateAvailable`; development builds (either side reporting `"development"`) are never nagged, matching the existing "What's New" philosophy.

### Changes

- **runtime-events**: add `serverVersion?` to the `connected` runtime event.
- **cloud-runtime**: propagate the `Connected` message version into that event.
- **app-version**: `reportServerVersion()` compares server vs. running bundle and sets `updateAvailable` / `serverVersion` signals; `reloadForUpdate()` performs a cache-busting `location.replace`.
- **slicer**: report the server version to `AppVersion` on connect.
- **UpdateBanner**: new bottom-center, accent-tinted island component (design-language compliant). Intentionally **no dismiss button** — a stale UI can misbehave, so reloading is the intended resolution.

Because detection keys off WS reconnect, a backgrounded tab that refocuses reconnects, sees the new server version, and surfaces the prompt automatically.

## Notes for reviewers

- `ui/node_modules` is not installed in this environment, so `tsc`/build were not run; changes were reviewed against existing patterns and rely on the running dev server for compile verification.