### PR TITLE
feat(gcode): layer-type acceleration control (Phase 2)

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -22,6 +22,12 @@ these notes and acknowledges contributors. `scripts/gen-changelog-draft.sh` and
 
 ### Added
 
+- **Layer-type acceleration control** — new `acceleration`, `first_layer_acceleration`,
+  and `top_surface_acceleration` slicing parameters. When set, the slicer emits a
+  firmware acceleration command whenever the target changes — Klipper
+  `SET_VELOCITY_LIMIT ACCEL=…`, Marlin `M204 P…` — using a lower first-layer value
+  for adhesion and a distinct top-surface value for finish. All default to `0`
+  (disabled), so existing output is unchanged.
 - **Pressure / linear advance output** — when a filament or process profile sets
   a non-zero pressure-advance value it is now emitted to G-code once, right after
   the start script. The active firmware dialect renders the correct form

--- a/src/gcode/dialect.rs
+++ b/src/gcode/dialect.rs
@@ -176,6 +176,16 @@ pub trait GcodeDialect: Send + Sync {
         format!("M900 K{:.4}", value)
     }
 
+    /// Set the printing acceleration in mm/s².
+    ///
+    /// Emitted whenever the slicer's target acceleration changes (per layer /
+    /// per role) so motion can be tuned for adhesion, surface finish, or speed.
+    /// The default implementation targets Marlin's `M204 P<accel>` (printing
+    /// acceleration); Klipper overrides this with `SET_VELOCITY_LIMIT ACCEL=…`.
+    fn set_acceleration(&self, accel: f64) -> String {
+        format!("M204 P{:.0}", accel)
+    }
+
     /// Home all axes (`G28`).
     fn home_axes(&self) -> String {
         "G28".to_string()

--- a/src/gcode/dialects/klipper.rs
+++ b/src/gcode/dialects/klipper.rs
@@ -104,6 +104,13 @@ impl GcodeDialect for KlipperDialect {
         format!("SET_PRESSURE_ADVANCE ADVANCE={:.4}", value)
     }
 
+    /// Klipper configures acceleration at runtime via `SET_VELOCITY_LIMIT`
+    /// rather than Marlin's `M204`.  Only the `ACCEL` field is set here; the
+    /// velocity cap is left to the printer's configured default.
+    fn set_acceleration(&self, accel: f64) -> String {
+        format!("SET_VELOCITY_LIMIT ACCEL={:.0}", accel)
+    }
+
     /// Named Klipper fans use `SET_FAN_SPEED fan=<name> speed=<0.0–1.0>`; the
     /// default part-cooling fan uses `M106`/`M107` instead.
     ///

--- a/src/gcode/generator.rs
+++ b/src/gcode/generator.rs
@@ -462,6 +462,44 @@ impl GcodeGenerator {
         }
     }
 
+    /// Resolve the target acceleration (mm/s²) for a path, or `None` when
+    /// acceleration control is disabled for it.
+    ///
+    /// Precedence (Phase 2 — layer-type acceleration):
+    /// 1. **First layer** → `first_layer_acceleration` (falls back to
+    ///    `acceleration`), applied to every role for adhesion.
+    /// 2. **Top surface** → `top_surface_acceleration` (falls back to
+    ///    `acceleration`).
+    /// 3. Everything else → `acceleration`.
+    ///
+    /// A resolved value of `0` (nothing configured) yields `None`, so no
+    /// firmware command is emitted and existing output is unchanged.
+    fn effective_acceleration(
+        role: crate::core::ExtrusionRole,
+        is_first_layer: bool,
+        params: &SlicingParams,
+    ) -> Option<f64> {
+        use crate::core::ExtrusionRole;
+        let normal = params.acceleration;
+        if is_first_layer {
+            let a = params.first_layer_acceleration;
+            let a = if a > 0.0 { a } else { normal };
+            return (a > 0.0).then_some(a);
+        }
+        let a = match role {
+            ExtrusionRole::TopSurface => {
+                let t = params.top_surface_acceleration;
+                if t > 0.0 {
+                    t
+                } else {
+                    normal
+                }
+            }
+            _ => normal,
+        };
+        (a > 0.0).then_some(a)
+    }
+
     /// Generate a complete G-code program from the given layers and parameters.
     ///
     /// The output is a single `String` with lines separated by `'\n'`.
@@ -539,6 +577,9 @@ impl GcodeGenerator {
         let mut total_filament_mm = 0.0_f64;
         // Track previous fan speed per config index for rate limiting (aux overrides).
         let mut prev_fan_speeds: Vec<Option<f64>> = vec![None; params.fan_configs.len()];
+        // Track the last emitted acceleration so we only emit a firmware
+        // command when the target changes (persists across layers).
+        let mut last_accel: Option<f64> = None;
 
         for (layer_index, layer) in layers.iter().enumerate() {
             let z_str = format!("{:.3}", layer.z);
@@ -683,6 +724,20 @@ impl GcodeGenerator {
 
                 // Resolve per-role print speed.
                 let speed_mm_min = Self::effective_speed_mm_min(role, is_first_layer, params);
+
+                // ── Adaptive acceleration (opt-in; emitted on change only) ────
+                // Set the firmware acceleration before this path's moves when the
+                // target differs from the last emitted value.  Disabled roles
+                // resolve to `None` and leave the previous limit in place.
+                if let Some(accel) = Self::effective_acceleration(role, is_first_layer, params) {
+                    if last_accel != Some(accel) {
+                        out.push_str(&format!(
+                            "{} ; acceleration\n",
+                            self.dialect.set_acceleration(accel)
+                        ));
+                        last_accel = Some(accel);
+                    }
+                }
 
                 // Apply Ramer-Douglas-Peucker simplification when a tolerance is
                 // set.  Constant-width paths use the plain pass; variable-width
@@ -1695,6 +1750,112 @@ mod tests {
         assert!(
             pa > start,
             "pressure advance must be emitted after the start script"
+        );
+    }
+
+    // ── Acceleration (Phase 2 — layer-type) ─────────────────────────────────────
+
+    /// Build a single-path layer at height `z` with the given role.
+    fn layer_with_role(z: f64, role: crate::core::ExtrusionRole) -> SliceLayer {
+        use clipper2::Path;
+        let mut layer = SliceLayer::new(z);
+        let square: Path = vec![(0.0, 0.0), (10.0, 0.0), (10.0, 10.0), (0.0, 10.0)].into();
+        layer.paths.push(square);
+        layer.path_roles.push(role);
+        layer
+    }
+
+    #[test]
+    fn test_marlin_dialect_set_acceleration_default() {
+        let d = MarlinDialect;
+        assert_eq!(d.set_acceleration(6000.0), "M204 P6000");
+    }
+
+    #[test]
+    fn test_klipper_dialect_set_acceleration() {
+        let d = KlipperDialect;
+        assert_eq!(d.set_acceleration(6000.0), "SET_VELOCITY_LIMIT ACCEL=6000");
+    }
+
+    #[test]
+    fn test_generator_emits_first_layer_then_normal_acceleration() {
+        use crate::core::ExtrusionRole;
+        let mut params = SlicingParams::default();
+        params.acceleration = 6000.0;
+        params.first_layer_acceleration = 2000.0;
+        // z=0.2 → first layer (layer_height 0.2); z=0.4 → subsequent.
+        let layers = [
+            layer_with_role(0.2, ExtrusionRole::OuterWall),
+            layer_with_role(0.4, ExtrusionRole::OuterWall),
+        ];
+        let gcode = GcodeGenerator::new(GcodeFlavor::Marlin).generate(&layers, &params);
+        let first = gcode.find("M204 P2000").expect("first-layer accel");
+        let normal = gcode.find("M204 P6000").expect("normal accel");
+        assert!(
+            first < normal,
+            "first-layer acceleration must precede the normal acceleration:\n{gcode}"
+        );
+    }
+
+    #[test]
+    fn test_generator_emits_top_surface_acceleration() {
+        use crate::core::ExtrusionRole;
+        let mut params = SlicingParams::default();
+        params.acceleration = 6000.0;
+        params.top_surface_acceleration = 9000.0;
+        // Non-first layer with a wall followed by a top surface.
+        let mut layer = SliceLayer::new(0.4);
+        let sq1: clipper2::Path = vec![(0.0, 0.0), (10.0, 0.0), (10.0, 10.0), (0.0, 10.0)].into();
+        let sq2: clipper2::Path = vec![(1.0, 1.0), (9.0, 1.0), (9.0, 9.0), (1.0, 9.0)].into();
+        layer.paths.push(sq1);
+        layer.path_roles.push(ExtrusionRole::OuterWall);
+        layer.paths.push(sq2);
+        layer.path_roles.push(ExtrusionRole::TopSurface);
+        let gcode = GcodeGenerator::new(GcodeFlavor::Klipper).generate(&[layer], &params);
+        let wall = gcode
+            .find("SET_VELOCITY_LIMIT ACCEL=6000")
+            .expect("normal accel");
+        let top = gcode
+            .find("SET_VELOCITY_LIMIT ACCEL=9000")
+            .expect("top-surface accel");
+        assert!(
+            wall < top,
+            "top-surface acceleration must follow the wall acceleration:\n{gcode}"
+        );
+    }
+
+    #[test]
+    fn test_generator_omits_acceleration_when_zero() {
+        use crate::core::ExtrusionRole;
+        let params = SlicingParams::default(); // all acceleration fields default to 0
+        let layers = [layer_with_role(0.4, ExtrusionRole::OuterWall)];
+        let marlin = GcodeGenerator::new(GcodeFlavor::Marlin).generate(&layers, &params);
+        let klipper = GcodeGenerator::new(GcodeFlavor::Klipper).generate(&layers, &params);
+        assert!(
+            !marlin.contains("M204 P"),
+            "Marlin emitted acceleration when disabled:\n{marlin}"
+        );
+        assert!(
+            !klipper.contains("SET_VELOCITY_LIMIT ACCEL="),
+            "Klipper emitted acceleration when disabled:\n{klipper}"
+        );
+    }
+
+    #[test]
+    fn test_generator_no_redundant_acceleration() {
+        use crate::core::ExtrusionRole;
+        let mut params = SlicingParams::default();
+        params.acceleration = 6000.0;
+        // Two non-first layers, same role → the accel command must appear once.
+        let layers = [
+            layer_with_role(0.4, ExtrusionRole::OuterWall),
+            layer_with_role(0.6, ExtrusionRole::OuterWall),
+        ];
+        let gcode = GcodeGenerator::new(GcodeFlavor::Marlin).generate(&layers, &params);
+        let count = gcode.matches("M204 P6000").count();
+        assert_eq!(
+            count, 1,
+            "acceleration should only be emitted on change:\n{gcode}"
         );
     }
 

--- a/src/settings/params.rs
+++ b/src/settings/params.rs
@@ -1116,6 +1116,40 @@ active filament profile at resolve time. Exposed to custom start G-code as `{fil
     pub pressure_advance: f64,
 
     #[schemars(
+        description = "Print acceleration for normal moves in mm/s². `0` disables acceleration control.
+
+When set, the slicer emits a firmware acceleration command whenever the target
+changes (Klipper `SET_VELOCITY_LIMIT ACCEL=…`, Marlin `M204 P…`). Lower values
+smooth motion and reduce ringing; higher values print faster.
+**Typical:** 3000–10000.",
+        extend("x-group" = "Speed")
+    )]
+    #[serde(default = "SlicingParams::default_acceleration")]
+    pub acceleration: f64,
+
+    #[schemars(
+        description = "First-layer acceleration in mm/s². `0` = use `acceleration`.
+
+A lower first-layer acceleration improves bed adhesion by giving the nozzle more
+dwell time. Applies to every role on the first layer.
+**Typical:** 1000–3000.",
+        extend("x-group" = "Speed")
+    )]
+    #[serde(default = "SlicingParams::default_first_layer_acceleration")]
+    pub first_layer_acceleration: f64,
+
+    #[schemars(
+        description = "Top-surface acceleration in mm/s². `0` = use `acceleration`.
+
+Solid top surfaces benefit from a distinct (often higher) acceleration for a
+smoother finish. Applies to top-surface solid infill.
+**Typical:** 5000–10000.",
+        extend("x-group" = "Speed")
+    )]
+    #[serde(default = "SlicingParams::default_top_surface_acceleration")]
+    pub top_surface_acceleration: f64,
+
+    #[schemars(
         description = "Number of initial layers with the part-cooling fan forced off.
 
 Improves adhesion of the first few layers.
@@ -1285,6 +1319,9 @@ impl Default for SlicingParams {
             chamber_temp: Self::default_chamber_temp(),
             filament_type: String::new(),
             pressure_advance: Self::default_pressure_advance(),
+            acceleration: Self::default_acceleration(),
+            first_layer_acceleration: Self::default_first_layer_acceleration(),
+            top_surface_acceleration: Self::default_top_surface_acceleration(),
             disable_fan_first_layers: Self::default_disable_fan_first_layers(),
             max_volumetric_speed: Self::default_max_volumetric_speed(),
             extruder_count: Self::default_extruder_count(),
@@ -1331,6 +1368,15 @@ impl SlicingParams {
         0.0
     }
     fn default_pressure_advance() -> f64 {
+        0.0
+    }
+    fn default_acceleration() -> f64 {
+        0.0
+    }
+    fn default_first_layer_acceleration() -> f64 {
+        0.0
+    }
+    fn default_top_surface_acceleration() -> f64 {
         0.0
     }
     fn default_disable_fan_first_layers() -> usize {


### PR DESCRIPTION
## Summary

Part 2 of 3 addressing the motion-control tickets (#7, #18). Builds on #119 (pressure advance).

Emits per-layer / per-role acceleration so the firmware motion system can be tuned for adhesion, surface finish, and speed — the core of the "Adaptive Motion Control (`SET_VELOCITY_LIMIT`)" request.

## Changes

- New `SlicingParams` fields (all default `0` = disabled):
  - `acceleration` — normal printing acceleration.
  - `first_layer_acceleration` — lower value for bed adhesion (applies to every role on layer 0).
  - `top_surface_acceleration` — distinct value for a smoother top finish.
- New `set_acceleration` on the `GcodeDialect` trait:
  - Marlin default: `M204 P<accel>`
  - Klipper override: `SET_VELOCITY_LIMIT ACCEL=<accel>`
- The generator resolves a per-path target (first layer → top surface → normal) and emits the firmware command **only when the target changes**, persisting across layers to avoid redundant lines.

## Behaviour

- With nothing configured, every role resolves to `None` → **no acceleration commands, output unchanged**.
- Example (Marlin): first layer `M204 P2000`, then `M204 P6000` for the body, `M204 P9000` on top surfaces.

## Tests

Dialect formatting, first-layer→normal transition, top-surface switch, the disabled case, and the no-redundant-emission guarantee. All lib tests pass; `clippy -D warnings` clean.

Refs #7, #18.

---
🤖 Part of a stacked series: Phase 1 (pressure advance) → **Phase 2 (this)** → Phase 3 (geometry-aware accel). Base branch is `feat/motion-pressure-advance`; review after Phase 1 merges.
