### PR TITLE
feat(gcode): geometry-aware acceleration for walls and bridges (Phase 3)

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -22,6 +22,13 @@ these notes and acknowledges contributors. `scripts/gen-changelog-draft.sh` and
 
 ### Added
 
+- **Geometry-aware acceleration** — new `outer_wall_acceleration` and
+  `bridge_acceleration` slicing parameters extend layer-type acceleration with
+  role-specific limits: a lower outer-wall value cuts ringing on visible
+  surfaces, and a low bridge/overhang value keeps flow steady over unsupported
+  spans. Precedence is first layer → bridge/overhang → top surface → outer wall
+  → normal, each falling back to `acceleration`. Both default to `0` (use the
+  normal value), so existing output is unchanged.
 - **Layer-type acceleration control** — new `acceleration`, `first_layer_acceleration`,
   and `top_surface_acceleration` slicing parameters. When set, the slicer emits a
   firmware acceleration command whenever the target changes — Klipper

--- a/src/gcode/generator.rs
+++ b/src/gcode/generator.rs
@@ -465,12 +465,15 @@ impl GcodeGenerator {
     /// Resolve the target acceleration (mm/s²) for a path, or `None` when
     /// acceleration control is disabled for it.
     ///
-    /// Precedence (Phase 2 — layer-type acceleration):
-    /// 1. **First layer** → `first_layer_acceleration` (falls back to
-    ///    `acceleration`), applied to every role for adhesion.
-    /// 2. **Top surface** → `top_surface_acceleration` (falls back to
-    ///    `acceleration`).
-    /// 3. Everything else → `acceleration`.
+    /// Precedence (first match wins; each falls back to `acceleration`):
+    /// 1. **First layer** → `first_layer_acceleration`, applied to every role
+    ///    for adhesion.
+    /// 2. **Bridge / overhang** → `bridge_acceleration` (Phase 3 — geometry
+    ///    aware): strands printed into air get a low, steady acceleration.
+    /// 3. **Top surface** → `top_surface_acceleration`.
+    /// 4. **Outer wall** → `outer_wall_acceleration` (Phase 3): the visible
+    ///    perimeter gets a dedicated limit to reduce ringing.
+    /// 5. Everything else → `acceleration`.
     ///
     /// A resolved value of `0` (nothing configured) yields `None`, so no
     /// firmware command is emitted and existing output is unchanged.
@@ -481,20 +484,25 @@ impl GcodeGenerator {
     ) -> Option<f64> {
         use crate::core::ExtrusionRole;
         let normal = params.acceleration;
+        // Pick a role-specific override, falling back to the normal value when
+        // the override is unset (`0`).
+        let or_normal = |override_val: f64| {
+            if override_val > 0.0 {
+                override_val
+            } else {
+                normal
+            }
+        };
         if is_first_layer {
-            let a = params.first_layer_acceleration;
-            let a = if a > 0.0 { a } else { normal };
+            let a = or_normal(params.first_layer_acceleration);
             return (a > 0.0).then_some(a);
         }
         let a = match role {
-            ExtrusionRole::TopSurface => {
-                let t = params.top_surface_acceleration;
-                if t > 0.0 {
-                    t
-                } else {
-                    normal
-                }
+            ExtrusionRole::Bridge | ExtrusionRole::OverhangPerimeter => {
+                or_normal(params.bridge_acceleration)
             }
+            ExtrusionRole::TopSurface => or_normal(params.top_surface_acceleration),
+            ExtrusionRole::OuterWall => or_normal(params.outer_wall_acceleration),
             _ => normal,
         };
         (a > 0.0).then_some(a)
@@ -1856,6 +1864,76 @@ mod tests {
         assert_eq!(
             count, 1,
             "acceleration should only be emitted on change:\n{gcode}"
+        );
+    }
+
+    // ── Acceleration (Phase 3 — geometry aware) ─────────────────────────────────
+
+    #[test]
+    fn test_bridge_acceleration_applies_to_bridge_and_overhang() {
+        use crate::core::ExtrusionRole;
+        let mut params = SlicingParams::default();
+        params.acceleration = 6000.0;
+        params.bridge_acceleration = 1500.0;
+        for role in [ExtrusionRole::Bridge, ExtrusionRole::OverhangPerimeter] {
+            let layers = [layer_with_role(0.4, role)];
+            let gcode = GcodeGenerator::new(GcodeFlavor::Marlin).generate(&layers, &params);
+            assert!(
+                gcode.contains("M204 P1500"),
+                "bridge acceleration not applied to {role:?}:\n{gcode}"
+            );
+        }
+    }
+
+    #[test]
+    fn test_outer_wall_acceleration_applies_to_outer_wall_only() {
+        use crate::core::ExtrusionRole;
+        let mut params = SlicingParams::default();
+        params.acceleration = 6000.0;
+        params.outer_wall_acceleration = 3000.0;
+        // Outer wall → dedicated accel; inner wall → normal accel.
+        let mut layer = SliceLayer::new(0.4);
+        let sq1: clipper2::Path = vec![(0.0, 0.0), (10.0, 0.0), (10.0, 10.0), (0.0, 10.0)].into();
+        let sq2: clipper2::Path = vec![(1.0, 1.0), (9.0, 1.0), (9.0, 9.0), (1.0, 9.0)].into();
+        layer.paths.push(sq1);
+        layer.path_roles.push(ExtrusionRole::OuterWall);
+        layer.paths.push(sq2);
+        layer.path_roles.push(ExtrusionRole::InnerWall);
+        let gcode = GcodeGenerator::new(GcodeFlavor::Marlin).generate(&[layer], &params);
+        let outer = gcode.find("M204 P3000").expect("outer-wall accel");
+        let inner = gcode.find("M204 P6000").expect("inner-wall normal accel");
+        assert!(
+            outer < inner,
+            "outer-wall accel must precede inner-wall normal accel:\n{gcode}"
+        );
+    }
+
+    #[test]
+    fn test_first_layer_acceleration_overrides_bridge() {
+        use crate::core::ExtrusionRole;
+        let mut params = SlicingParams::default();
+        params.acceleration = 6000.0;
+        params.bridge_acceleration = 1500.0;
+        params.first_layer_acceleration = 2000.0;
+        // A bridge on the first layer must still use the first-layer accel.
+        let layers = [layer_with_role(0.2, ExtrusionRole::Bridge)];
+        let gcode = GcodeGenerator::new(GcodeFlavor::Marlin).generate(&layers, &params);
+        assert!(
+            gcode.contains("M204 P2000") && !gcode.contains("M204 P1500"),
+            "first-layer accel must win over bridge accel on the first layer:\n{gcode}"
+        );
+    }
+
+    #[test]
+    fn test_bridge_acceleration_falls_back_to_normal() {
+        use crate::core::ExtrusionRole;
+        let mut params = SlicingParams::default();
+        params.acceleration = 6000.0; // bridge_acceleration left at 0
+        let layers = [layer_with_role(0.4, ExtrusionRole::Bridge)];
+        let gcode = GcodeGenerator::new(GcodeFlavor::Marlin).generate(&layers, &params);
+        assert!(
+            gcode.contains("M204 P6000"),
+            "bridge role should fall back to the normal acceleration:\n{gcode}"
         );
     }
 

--- a/src/settings/params.rs
+++ b/src/settings/params.rs
@@ -1150,6 +1150,29 @@ smoother finish. Applies to top-surface solid infill.
     pub top_surface_acceleration: f64,
 
     #[schemars(
+        description = "Outer-wall acceleration in mm/s². `0` = use `acceleration`.
+
+The outermost perimeter defines the visible surface; a lower, dedicated
+acceleration reduces ringing and ghosting on external walls.
+**Typical:** 2000–6000.",
+        extend("x-group" = "Speed")
+    )]
+    #[serde(default = "SlicingParams::default_outer_wall_acceleration")]
+    pub outer_wall_acceleration: f64,
+
+    #[schemars(
+        description = "Bridge / overhang acceleration in mm/s². `0` = use `acceleration`.
+
+Strands printed into air (bridge infill and overhang perimeters) cool and sag
+without support below; a low acceleration keeps flow steady and lets each strand
+tension before the nozzle moves on.
+**Typical:** 1000–3000.",
+        extend("x-group" = "Speed")
+    )]
+    #[serde(default = "SlicingParams::default_bridge_acceleration")]
+    pub bridge_acceleration: f64,
+
+    #[schemars(
         description = "Number of initial layers with the part-cooling fan forced off.
 
 Improves adhesion of the first few layers.
@@ -1322,6 +1345,8 @@ impl Default for SlicingParams {
             acceleration: Self::default_acceleration(),
             first_layer_acceleration: Self::default_first_layer_acceleration(),
             top_surface_acceleration: Self::default_top_surface_acceleration(),
+            outer_wall_acceleration: Self::default_outer_wall_acceleration(),
+            bridge_acceleration: Self::default_bridge_acceleration(),
             disable_fan_first_layers: Self::default_disable_fan_first_layers(),
             max_volumetric_speed: Self::default_max_volumetric_speed(),
             extruder_count: Self::default_extruder_count(),
@@ -1377,6 +1402,12 @@ impl SlicingParams {
         0.0
     }
     fn default_top_surface_acceleration() -> f64 {
+        0.0
+    }
+    fn default_outer_wall_acceleration() -> f64 {
+        0.0
+    }
+    fn default_bridge_acceleration() -> f64 {
         0.0
     }
     fn default_disable_fan_first_layers() -> usize {


### PR DESCRIPTION
## Summary

Part 3 of 3 addressing the motion-control tickets (#7, #18). Builds on #120 (layer-type acceleration).

Extends acceleration control with **geometry-aware, role-specific** limits — the "dynamic speed/motion adjustment for bridges and walls" part of the adaptive-motion request.

## Changes

- New `SlicingParams` fields (both default `0` = use the normal `acceleration`):
  - `outer_wall_acceleration` — lower limit on the visible perimeter to cut ringing/ghosting.
  - `bridge_acceleration` — low, steady limit for bridge infill **and** overhang perimeters (strands printed into air).
- `effective_acceleration` now resolves in priority order:

  `first layer → bridge/overhang → top surface → outer wall → normal`

  Each role falls back to the normal `acceleration` when its override is `0`, so a bridge on the first layer still uses the first-layer value.

## Behaviour

- Nothing configured → output unchanged (same guarantee as Phase 2).
- Bridges/overhangs and outer walls each get their own `M204 P…` / `SET_VELOCITY_LIMIT ACCEL=…` when set.

## Tests

Bridge + overhang application, outer-wall-only application (inner walls stay on normal accel), first-layer-overrides-bridge precedence, and bridge→normal fallback. All lib tests pass; `clippy -D warnings` clean.

Closes #7. Closes #18.

---
🤖 Part of a stacked series: Phase 1 (pressure advance) → Phase 2 (layer-type accel) → **Phase 3 (this)**. Base branch is `feat/motion-layer-acceleration`; review after Phases 1 & 2 merge.
