### PR TITLE
feat(gcode,cli): bed-type tracking & slice diagnostics (#11)

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -28,6 +28,10 @@ these notes and acknowledges contributors. `scripts/gen-changelog-draft.sh` and
   layer count, model height, filament usage (mm / cm³ / g), an estimated print
   time, and the model bounding box. A new `filament_density_g_cm3` setting
   (defaulting to PLA) drives the weight calculation. ([#15](https://github.com/max-scopp/slicer-engine/issues/15))
+- **Slice diagnostics & bed-type tracking** — a new `bed_type` setting is
+  recorded in the header (`; bed_type:`) for printer integration, and the `slice`
+  CLI now reports model height, filament usage, and the estimated print time in
+  both its human and JSON output. ([#11](https://github.com/max-scopp/slicer-engine/issues/11))
 - **Live versioning** — every build now reports its true version, derived from
   git tags at build time. Local development builds report `development` instead of
   a misleading fixed number.

--- a/src/cli/commands/slice.rs
+++ b/src/cli/commands/slice.rs
@@ -215,6 +215,10 @@ struct SliceResult {
     layer_count: usize,
     output_path: Option<PathBuf>,
     gcode_flavor: String,
+    /// Aggregate diagnostics for the slice (issue #11).
+    stats: crate::gcode::SliceStatistics,
+    /// Build-plate surface, when the profile specified one.
+    bed_type: Option<String>,
 }
 
 impl EmitPayload for SliceResult {
@@ -227,6 +231,18 @@ impl EmitPayload for SliceResult {
             "✓ Sliced {} into {} layers\n  Layer height: {} mm\n  G-code flavor: {}",
             self.input_name, self.layer_count, self.layer_height, self.gcode_flavor
         );
+        s.push_str(&format!("\n  Model height: {:.2} mm", self.stats.max_z_mm));
+        s.push_str(&format!(
+            "\n  Filament: {:.2} mm ({:.2} g)",
+            self.stats.filament_mm, self.stats.filament_g
+        ));
+        s.push_str(&format!(
+            "\n  Estimated print time: {}",
+            self.stats.estimated_time_human()
+        ));
+        if let Some(bed) = &self.bed_type {
+            s.push_str(&format!("\n  Bed type: {}", bed));
+        }
         if let Some(path) = &self.output_path {
             s.push_str(&format!("\n  Output: {}", path.display()));
         }
@@ -241,6 +257,17 @@ impl EmitPayload for SliceResult {
             "layer_count": self.layer_count,
             "gcode_flavor": self.gcode_flavor,
             "output": self.output_path.as_ref().map(|p| p.display().to_string()),
+            "bed_type": self.bed_type,
+            "statistics": {
+                "max_z_mm": self.stats.max_z_mm,
+                "filament_mm": self.stats.filament_mm,
+                "filament_cm3": self.stats.filament_cm3,
+                "filament_g": self.stats.filament_g,
+                "estimated_print_time_s": self.stats.estimated_print_time_s,
+                "estimated_print_time_human": self.stats.estimated_time_human(),
+                "bbox_min_mm": self.stats.bbox_min,
+                "bbox_max_mm": self.stats.bbox_max,
+            },
         })
     }
 }
@@ -550,7 +577,7 @@ impl SliceCommand {
         }
 
         let t_gcode = PhaseTimer::start(phases::GCODE_GENERATION, &logger);
-        let gcode = generator.generate(&layers, &slice_params);
+        let (gcode, stats) = generator.generate_with_stats(&layers, &slice_params);
         t_gcode.finish();
 
         // Determine output path
@@ -586,6 +613,8 @@ impl SliceCommand {
             layer_count: layers.len(),
             output_path,
             gcode_flavor: flavor.to_string(),
+            bed_type: Some(slice_params.bed_type.clone()).filter(|b| !b.trim().is_empty()),
+            stats,
         };
 
         emitter.emit(&result);
@@ -600,6 +629,21 @@ impl SliceCommand {
 #[cfg(test)]
 mod tests {
     use super::*;
+
+    /// A non-zero sample statistics bundle for `SliceResult` tests.
+    fn sample_stats() -> crate::gcode::SliceStatistics {
+        crate::gcode::SliceStatistics {
+            layer_count: 5,
+            max_z_mm: 1.0,
+            filament_mm: 123.45,
+            filament_cm3: 0.3,
+            filament_g: 0.37,
+            estimated_print_time_s: 65.0,
+            bbox_min: [0.0, 0.0, 0.1],
+            bbox_max: [10.0, 10.0, 1.0],
+            model_name: Some("model".to_string()),
+        }
+    }
 
     #[test]
     fn test_slice_command_creation() {
@@ -793,6 +837,8 @@ mod tests {
             layer_count: 5,
             output_path: None,
             gcode_flavor: "marlin".to_string(),
+            bed_type: None,
+            stats: sample_stats(),
         };
         assert_eq!(r.schema(), "slicer-engine/slice-result-v1");
     }
@@ -805,12 +851,24 @@ mod tests {
             layer_count: 5,
             output_path: None,
             gcode_flavor: "marlin".to_string(),
+            bed_type: Some("Textured PEI Plate".to_string()),
+            stats: sample_stats(),
         };
         let s = r.display_human();
         assert!(s.contains("model.stl"));
         assert!(s.contains("0.2"));
         assert!(s.contains('5'));
         assert!(s.contains("marlin"));
+        // Diagnostics (issue #11) surface in the human output.
+        assert!(
+            s.contains("Estimated print time: 1m 5s"),
+            "missing time: {s}"
+        );
+        assert!(s.contains("Filament:"), "missing filament: {s}");
+        assert!(
+            s.contains("Bed type: Textured PEI Plate"),
+            "missing bed type: {s}"
+        );
     }
 
     #[test]
@@ -821,9 +879,13 @@ mod tests {
             layer_count: 5,
             output_path: None,
             gcode_flavor: "klipper".to_string(),
+            bed_type: None,
+            stats: sample_stats(),
         };
         let s = r.display_human();
         assert!(s.contains("klipper"));
+        // No bed type selected → no bed-type line.
+        assert!(!s.contains("Bed type:"), "unexpected bed type line: {s}");
     }
 
     #[test]
@@ -834,6 +896,8 @@ mod tests {
             layer_count: 5,
             output_path: Some(PathBuf::from("/some/path/model.gcode")),
             gcode_flavor: "marlin".to_string(),
+            bed_type: None,
+            stats: sample_stats(),
         };
         let s = r.display_human();
         assert!(s.contains("model.gcode"));
@@ -847,6 +911,8 @@ mod tests {
             layer_count: 5,
             output_path: None,
             gcode_flavor: "marlin".to_string(),
+            bed_type: Some("Cool Plate".to_string()),
+            stats: sample_stats(),
         };
         let v = r.to_json();
         assert_eq!(v["status"], "success");
@@ -854,6 +920,13 @@ mod tests {
         assert_eq!(v["layer_height"], 0.2);
         assert_eq!(v["layer_count"], 5);
         assert_eq!(v["gcode_flavor"], "marlin");
+        // Diagnostics (issue #11).
+        assert_eq!(v["bed_type"], "Cool Plate");
+        assert_eq!(v["statistics"]["filament_mm"], 123.45);
+        assert_eq!(v["statistics"]["filament_g"], 0.37);
+        assert_eq!(v["statistics"]["estimated_print_time_s"], 65.0);
+        assert_eq!(v["statistics"]["estimated_print_time_human"], "1m 5s");
+        assert_eq!(v["statistics"]["max_z_mm"], 1.0);
     }
 
     #[test]

--- a/src/gcode/generator.rs
+++ b/src/gcode/generator.rs
@@ -2303,6 +2303,29 @@ CHAMBER={chamber_temp} MATERIAL={filament_type}"
         );
     }
 
+    #[test]
+    fn test_bed_type_tracked_in_header_when_set() {
+        let params = SlicingParams {
+            bed_type: "Textured PEI Plate".to_string(),
+            ..SlicingParams::default()
+        };
+        let gcode = GcodeGenerator::new(GcodeFlavor::Marlin).generate(&[], &params);
+        assert!(
+            gcode.contains("; bed_type: Textured PEI Plate"),
+            "missing bed_type line: {gcode}"
+        );
+    }
+
+    #[test]
+    fn test_bed_type_omitted_when_empty() {
+        let gcode =
+            GcodeGenerator::new(GcodeFlavor::Marlin).generate(&[], &SlicingParams::default());
+        assert!(
+            !gcode.contains("; bed_type:"),
+            "bed_type line must be absent when unset: {gcode}"
+        );
+    }
+
     // ── resolve_gcode_source ───────────────────────────────────────────────────
 
     #[test]

--- a/src/gcode/stats.rs
+++ b/src/gcode/stats.rs
@@ -179,10 +179,17 @@ pub(crate) fn metadata_lines(flavor_name: &str, stats: &SliceStatistics) -> Vec<
 /// Kept as plain `; key: value` comments (terminated by `; ---`) so existing
 /// post-processors that grepped the original header keep working.
 pub(crate) fn settings_summary_lines(params: &SlicingParams) -> Vec<String> {
-    vec![
+    let mut lines = vec![
         format!("; layer_height: {} mm", params.layer_height),
         format!("; nozzle_temp: {} °C", params.nozzle_temp),
         format!("; bed_temp: {} °C", params.bed_temp),
+    ];
+    // Bed/plate surface is tracked for printer integration (issue #11); only
+    // emitted when the user actually selected one.
+    if !params.bed_type.trim().is_empty() {
+        lines.push(format!("; bed_type: {}", params.bed_type));
+    }
+    lines.extend([
         format!(
             "; print_speed: {} mm/s | perimeter: {} | infill: {} | bridge: {} | first_layer: {}",
             params.print_speed,
@@ -198,7 +205,8 @@ pub(crate) fn settings_summary_lines(params: &SlicingParams) -> Vec<String> {
         ),
         format!("; infill_density: {:.0}%", params.infill_density * 100.0),
         "; ---".to_string(),
-    ]
+    ]);
+    lines
 }
 
 #[cfg(test)]

--- a/src/settings/params.rs
+++ b/src/settings/params.rs
@@ -839,6 +839,14 @@ Affects minimum feature resolution and all line-width calculations.
     #[serde(default = "SlicingParams::default_nozzle_diameter_mm")]
     pub nozzle_diameter_mm: f64,
 
+    #[schemars(description = "Build-plate surface type recorded in the G-code metadata header.
+
+Free-form label (e.g. `Textured PEI Plate`, `Cool Plate`, `Engineering Plate`).
+Purely informational: it is tracked for printer integration / diagnostics and
+does **not** affect slicing. Empty = omit the `; bed_type:` header line.", extend("x-group" = "Hardware"))]
+    #[serde(default)]
+    pub bed_type: String,
+
     #[schemars(description = "Non-print (travel) move speed in **mm/min**.
 
 Convert from mm/s by multiplying by 60. Fast travel reduces print time without affecting print quality.
@@ -1250,6 +1258,7 @@ impl Default for SlicingParams {
             filament_diameter_mm: Self::default_filament_diameter_mm(),
             filament_density_g_cm3: Self::default_filament_density_g_cm3(),
             nozzle_diameter_mm: Self::default_nozzle_diameter_mm(),
+            bed_type: String::new(),
             travel_speed_mm_min: Self::default_travel_speed_mm_min(),
             z_hop_mm: Self::default_z_hop_mm(),
             retract_mm: Self::default_retract_mm(),


### PR DESCRIPTION
Closes #11.

> **Stacked on #118 (`feat/15-header-metadata-block`).** This PR targets that branch, so its diff shows only the #11-specific changes. Please merge #118 first (or retarget this to `main` afterwards).

## What & why

Issue #11 (Enhanced Metadata & Diagnostics) has five deliverables. Three were already present (`LAYER_CHANGE` markers, layer-height comments) or landed via the metadata-header work in #118 (total **print-time estimate**, **filament usage** calculations). The remaining gap was **bed-type tracking**, plus making the diagnostics visible to the user. This PR closes both.

## Changes

- **`bed_type` setting** — a free-form build-plate label (e.g. `Textured PEI Plate`, `Cool Plate`). It's purely informational (does not affect slicing) and is recorded in the header as `; bed_type: <x>` when set, omitted when empty. Flows through profile resolution like any other param.
- **CLI diagnostics** — the `slice` command now calls `generate_with_stats` and surfaces the results:
  - **Human**: adds `Model height`, `Filament: <mm> (<g>)`, `Estimated print time`, and `Bed type` (when set).
  - **JSON**: adds a `statistics` object (`max_z_mm`, `filament_mm/cm3/g`, `estimated_print_time_s` + human, bbox) and a top-level `bed_type`.

## Example

```
✓ Sliced simple-cube.stl into 5 layers
  Layer height: 0.2 mm
  G-code flavor: marlin
  Model height: 0.90 mm
  Filament: 0.37 mm (0.00 g)
  Estimated print time: 0s
  Output: /tmp/out.gcode
```

## Validation

- `cargo test --lib` -> 503 passed (incl. new bed-type + CLI-diagnostics tests).
- `cargo clippy --lib --all-features -- -D warnings` -> clean.
- `cargo fmt --check` -> clean.
- CLI smoke-tested in both `--output-format human` and `json`.

## Scope notes

- Surfacing these stats over the **WebSocket** `SliceComplete` (for the web UI) would require extending the `gcode_cache` table so cache hits also carry them — that's a DB migration outside #11's checklist, so it's left as a follow-up.
