### PR TITLE
ui: schema-driven printer & filament editors + shared row primitive

### DIFF
--- a/ui/src/app/components/profiles/field-shell.ts
+++ b/ui/src/app/components/profiles/field-shell.ts
@@ -1,0 +1,86 @@
+import { ChangeDetectionStrategy, Component, input } from '@angular/core';
+
+/**
+ * The bare row primitive shared by every editor field: an optional title and a
+ * projected control on one line, with the field's **description rendered inline
+ * below** — the editor has the vertical room, so guidance stays visible instead
+ * of hidden behind a cramped info tooltip.
+ *
+ * Purely presentational: it owns only the row rhythm (padding, the between-row
+ * divider, title/control flex layout, the muted description treatment) and
+ * knows nothing about schemas, profiles, or the store. Both the schema-driven
+ * {@link ParamField} and bespoke editors (e.g. the labels page) wrap it so the
+ * markup and styles for a settings row live in exactly one place.
+ *
+ * Give it a {@link title} and project the control via `<ng-content>`. Omit the
+ * title and the control takes the full width, letting a section header (or a
+ * `profile-editor__group-title`) label it instead.
+ */
+@Component({
+  selector: 'nexus-field-shell',
+  standalone: true,
+  changeDetection: ChangeDetectionStrategy.OnPush,
+  template: `
+    <div class="field-shell" [class.field-shell--titled]="!!title()">
+      <div class="field-shell__row">
+        @if (title(); as t) {
+          <span class="field-shell__title">{{ t }}</span>
+        }
+        <span class="field-shell__control">
+          <ng-content />
+        </span>
+      </div>
+      @if (description(); as d) {
+        <p class="field-shell__desc">{{ d }}</p>
+      }
+    </div>
+  `,
+  styles: [
+    `
+      :host {
+        display: block;
+      }
+      :host + :host .field-shell {
+        border-top: 1px solid var(--color-border-light);
+      }
+      .field-shell {
+        padding: var(--spacing-md) 0;
+      }
+      .field-shell__row {
+        display: flex;
+        align-items: center;
+        justify-content: space-between;
+        gap: var(--spacing-lg);
+      }
+      .field-shell__title {
+        min-width: 0;
+        font-size: var(--font-size-md);
+        color: var(--color-text-primary);
+      }
+      .field-shell__control {
+        display: flex;
+        align-items: center;
+        gap: var(--spacing-sm);
+        flex: 1;
+      }
+      /* With a title the control hugs the right; titleless rows span the width. */
+      .field-shell--titled .field-shell__control {
+        flex: none;
+      }
+      .field-shell__desc {
+        margin: var(--spacing-xs) 0 0;
+        max-width: 62ch;
+        font-size: var(--font-size-xs);
+        line-height: 1.5;
+        color: var(--color-text-tertiary);
+        white-space: pre-line;
+      }
+    `,
+  ],
+})
+export class FieldShell {
+  /** Left-hand label for the row. Omit to let a section header do the labelling. */
+  readonly title = input('');
+  /** Optional helper text rendered inline below the row. */
+  readonly description = input('');
+}

--- a/ui/src/app/components/profiles/param-field.ts
+++ b/ui/src/app/components/profiles/param-field.ts
@@ -3,6 +3,7 @@ import type { FieldDef } from '../../schema-form/models/field-def';
 import { NumberInput } from '../../ui/number-input/number-input';
 import { Select, type SelectOption } from '../../ui/select/select';
 import { Switch } from '../../ui/switch/switch';
+import { FieldShell } from './field-shell';
 
 /**
  * One schema-driven parameter row for the print-profile editor: the label and
@@ -15,83 +16,50 @@ import { Switch } from '../../ui/switch/switch';
  * control is chosen from the field's shape — enum → select, boolean → switch,
  * everything else → number input — so any new `SlicingParams` field appears
  * automatically with no per-field wiring.
+ *
+ * A thin wrapper around {@link FieldShell}: this component only picks the
+ * control and maps schema → title/description, delegating all row markup and
+ * styling to the shell so the row rhythm lives in a single place.
  */
 @Component({
   selector: 'nexus-param-field',
   standalone: true,
-  imports: [NumberInput, Select, Switch],
+  imports: [NumberInput, Select, Switch, FieldShell],
   changeDetection: ChangeDetectionStrategy.OnPush,
   template: `
-    <div class="param-field">
-      <div class="param-field__row">
-        <span class="param-field__title">{{ field().title ?? field().key }}</span>
-        <span class="param-field__control">
-          @switch (kind()) {
-            @case ('enum') {
-              <nexus-select
-                [options]="selectOptions()"
-                [value]="stringValue()"
-                (valueChange)="valueChange.emit($event)"
-              />
-            }
-            @case ('boolean') {
-              <nexus-switch
-                [checked]="boolValue()"
-                (checkedChange)="valueChange.emit($event)"
-              />
-            }
-            @default {
-              <nexus-number-input
-                [value]="numberValue()"
-                [min]="min()"
-                [max]="max()"
-                [step]="step()"
-                (valueChange)="valueChange.emit($event)"
-              />
-            }
-          }
-        </span>
-      </div>
-      @if (descriptionText(); as d) {
-        <p class="param-field__desc">{{ d }}</p>
+    <nexus-field-shell [title]="field().title ?? field().key" [description]="descriptionText()">
+      @switch (kind()) {
+        @case ('enum') {
+          <nexus-select
+            [options]="selectOptions()"
+            [value]="stringValue()"
+            (valueChange)="valueChange.emit($event)"
+          />
+        }
+        @case ('boolean') {
+          <nexus-switch [checked]="boolValue()" (checkedChange)="valueChange.emit($event)" />
+        }
+        @default {
+          <nexus-number-input
+            [value]="numberValue()"
+            [min]="min()"
+            [max]="max()"
+            [step]="step()"
+            (valueChange)="valueChange.emit($event)"
+          />
+        }
       }
-    </div>
+    </nexus-field-shell>
   `,
   styles: [
     `
       :host {
         display: block;
       }
-      :host + :host .param-field {
+      /* The between-row divider depends on adjacency of *these* hosts — the
+         nested shell hosts aren't siblings — so it stays at this level. */
+      :host + :host {
         border-top: 1px solid var(--color-border-light);
-      }
-      .param-field {
-        padding: var(--spacing-md) 0;
-      }
-      .param-field__row {
-        display: flex;
-        align-items: center;
-        justify-content: space-between;
-        gap: var(--spacing-lg);
-      }
-      .param-field__title {
-        min-width: 0;
-        font-size: var(--font-size-md);
-        color: var(--color-text-primary);
-      }
-      .param-field__control {
-        flex: none;
-        display: flex;
-        align-items: center;
-        gap: var(--spacing-sm);
-      }
-      .param-field__desc {
-        margin: var(--spacing-xs) 0 0;
-        max-width: 62ch;
-        font-size: var(--font-size-xs);
-        line-height: 1.5;
-        color: var(--color-text-tertiary);
-        white-space: pre-line;
       }
     `,
   ],

--- a/ui/src/app/pages/settings/filaments.html
+++ b/ui/src/app/pages/settings/filaments.html
@@ -196,79 +196,6 @@
                   (valueChange)="updateParams(filament.id, { filament_diameter_mm: $event })"
                 />
               </nexus-field-row>
-            </div>
-
-            <div class="profile-editor__group">
-              <label class="profile-editor__group-title">Temperatures</label>
-              <nexus-field-row label="Nozzle">
-                <nexus-number-input
-                  [value]="pnum(filament.params, 'nozzle_temp')"
-                  [min]="150"
-                  [max]="350"
-                  unit="°C"
-                  (valueChange)="updateParams(filament.id, { nozzle_temp: $event })"
-                />
-              </nexus-field-row>
-              <nexus-field-row label="Nozzle — first layer">
-                <nexus-number-input
-                  [value]="pnum(filament.params, 'nozzle_temp_first_layer')"
-                  [min]="150"
-                  [max]="350"
-                  unit="°C"
-                  (valueChange)="updateParams(filament.id, { nozzle_temp_first_layer: $event })"
-                />
-              </nexus-field-row>
-              <nexus-field-row label="Bed">
-                <nexus-number-input
-                  [value]="pnum(filament.params, 'bed_temp')"
-                  [min]="0"
-                  [max]="150"
-                  unit="°C"
-                  (valueChange)="updateParams(filament.id, { bed_temp: $event })"
-                />
-              </nexus-field-row>
-              <nexus-field-row label="Bed — first layer">
-                <nexus-number-input
-                  [value]="pnum(filament.params, 'bed_temp_first_layer')"
-                  [min]="0"
-                  [max]="150"
-                  unit="°C"
-                  (valueChange)="updateParams(filament.id, { bed_temp_first_layer: $event })"
-                />
-              </nexus-field-row>
-            </div>
-
-            <div class="profile-editor__group">
-              <label class="profile-editor__group-title">Cooling & flow</label>
-              <nexus-field-row label="Fan speed — max">
-                <nexus-number-input
-                  [value]="pnum(filament.params, 'fan_speed') * 100"
-                  [min]="0"
-                  [max]="100"
-                  [step]="5"
-                  unit="%"
-                  (valueChange)="updateParams(filament.id, { fan_speed: $event / 100 })"
-                />
-              </nexus-field-row>
-              <nexus-field-row label="Flow ratio">
-                <nexus-number-input
-                  [value]="pnum(filament.params, 'flow_ratio')"
-                  [min]="0.5"
-                  [max]="1.5"
-                  [step]="0.01"
-                  (valueChange)="updateParams(filament.id, { flow_ratio: $event })"
-                />
-              </nexus-field-row>
-              <nexus-field-row label="Max volumetric speed">
-                <nexus-number-input
-                  [value]="pnum(filament.params, 'max_volumetric_speed')"
-                  [min]="1"
-                  [max]="50"
-                  [step]="0.5"
-                  unit="mm³/s"
-                  (valueChange)="updateParams(filament.id, { max_volumetric_speed: $event })"
-                />
-              </nexus-field-row>
               <nexus-field-row label="Cost / kg">
                 <nexus-number-input
                   [value]="filament.cost_per_kg"
@@ -278,6 +205,19 @@
                 />
               </nexus-field-row>
             </div>
+
+            @for (group of paramGroups; track group.name) {
+              <div class="profile-editor__group">
+                <label class="profile-editor__group-title">{{ group.name }}</label>
+                @for (field of group.fields; track field.key) {
+                  <nexus-param-field
+                    [field]="field"
+                    [value]="paramsOf(filament)[field.key]"
+                    (valueChange)="setParam(filament.id, field.key, $event)"
+                  />
+                }
+              </div>
+            }
           </div>
         } @else {
           <nexus-empty-state

--- a/ui/src/app/pages/settings/filaments.ts
+++ b/ui/src/app/pages/settings/filaments.ts
@@ -1,4 +1,11 @@
-import { ChangeDetectionStrategy, Component, afterNextRender, computed, inject, signal } from '@angular/core';
+import {
+  ChangeDetectionStrategy,
+  Component,
+  afterNextRender,
+  computed,
+  inject,
+  signal,
+} from '@angular/core';
 import { ActivatedRoute, RouterLink } from '@angular/router';
 import {
   FILAMENT_MATERIAL_LABELS,
@@ -9,6 +16,10 @@ import {
   type FilamentProfile,
 } from '../../models/filament.model';
 import { PROFILE_SOURCE_LABELS } from '../../models/profile-source';
+import { SETTING_CONTRACTS } from '../../models/setting-contract';
+import globalSettingsSchema from '../../../schemas/slicer-engine-global-settings-v1.json';
+import { parseSchema } from '../../schema-form/models/schema-parser';
+import type { SchemaGroup } from '../../schema-form/models/field-def';
 import { CloudCatalog } from '../../services/catalog/cloud-catalog';
 import { ContextMenuService } from '../../services/context-menu/context-menu.service';
 import type { ContextMenuItem } from '../../services/context-menu/context-menu.model';
@@ -21,6 +32,7 @@ import { FilamentsStore } from '../../services/profiles/filaments-store';
 import { Icon } from '../../shared/icon/icon';
 import { Badge } from '../../shared/badge/badge';
 import { CatalogPicker, type CatalogEntryVm } from '../../components/profiles/catalog-picker';
+import { ParamField } from '../../components/profiles/param-field';
 import { LabelFilterBar } from '../../components/labels/label-filter-bar';
 import { LabelPicker } from '../../components/labels/label-picker';
 import { focusConfigureTarget } from './configure-scroll';
@@ -35,6 +47,52 @@ import { Segmented } from '../../ui/segmented/segmented';
 import { Select } from '../../ui/select/select';
 import { ColorPicker } from '../../ui/color-picker/color-picker';
 
+/**
+ * The `SlicingParams` sub-schema extracted from the generated global-settings
+ * schema, so the filament editor can render every temperature/cooling parameter
+ * dynamically (the same schema the slice-page settings sidebar consumes). Any
+ * new `SlicingParams` field in those groups appears automatically — no
+ * hand-maintained field list.
+ */
+const SLICING_PARAMS_SCHEMA = {
+  ...(globalSettingsSchema.$defs.SlicingParams as Record<string, unknown>),
+  $defs: globalSettingsSchema.$defs as Record<string, unknown>,
+};
+
+/** `x-group` names owned by the Filament contract, in display order. */
+const FILAMENT_GROUPS = SETTING_CONTRACTS.find((c) => c.id === 'filament')!.groups;
+
+/**
+ * The filament-parameter groups rendered in the editor, in the Filament
+ * contract's display order (`Temperature`, `Cooling`). Parsed once from the
+ * schema (it never changes at runtime); groups owned by other contracts
+ * (Hardware, Extrusion, …) are left out so the filament editor only shows
+ * material temperature/cooling settings.
+ *
+ * Each group's fields are filtered to those `nexus-param-field` can actually
+ * render (enum → select, boolean → switch, everything else → number). Plain
+ * `string` and array fields are dropped, which excludes `filament_type` and
+ * `fan_configs` automatically. `filament_diameter_mm` (Hardware) stays a
+ * bespoke "Diameter" row under Identity, so no param key renders twice.
+ */
+const PARAM_GROUPS: SchemaGroup[] = (() => {
+  const order = new Map(FILAMENT_GROUPS.map((name, index) => [name, index]));
+  return parseSchema(SLICING_PARAMS_SCHEMA)
+    .groups.filter((g) => order.has(g.name))
+    .map((g) => ({
+      ...g,
+      fields: g.fields.filter(
+        (f) =>
+          !!f.enumOptions?.length ||
+          f.type === 'boolean' ||
+          f.type === 'number' ||
+          f.type === 'integer',
+      ),
+    }))
+    .filter((g) => g.fields.length > 0)
+    .sort((a, b) => order.get(a.name)! - order.get(b.name)!);
+})();
+
 @Component({
   selector: 'nexus-settings-filaments',
   imports: [
@@ -46,6 +104,7 @@ import { ColorPicker } from '../../ui/color-picker/color-picker';
     Badge,
     RouterLink,
     CatalogPicker,
+    ParamField,
     ModalShell,
     FieldRow,
     NumberInput,
@@ -288,6 +347,7 @@ export class FilamentsSettings {
   }
 
   protected readonly pnum = paramNum;
+  protected readonly paramGroups = PARAM_GROUPS;
 
   protected update(id: string, patch: Partial<FilamentProfile>): void {
     this.store.update(id, patch);
@@ -301,6 +361,16 @@ export class FilamentsSettings {
         params: { ...((item.params as Record<string, unknown>) ?? {}), ...patch },
       });
     }
+  }
+
+  /** A filament's `params` bag as a plain record for the field controls. */
+  protected paramsOf(filament: FilamentProfile): Record<string, unknown> {
+    return (filament.params as Record<string, unknown>) ?? {};
+  }
+
+  /** Apply a single param field edit (templates can't build computed keys). */
+  protected setParam(id: string, key: string, value: unknown): void {
+    this.updateParams(id, { [key]: value });
   }
 
   protected rename(id: string, event: Event): void {

--- a/ui/src/app/pages/settings/labels.html
+++ b/ui/src/app/pages/settings/labels.html
@@ -38,22 +38,26 @@
             <div class="profile-editor">
               <div class="profile-editor__group">
                 <label class="profile-editor__group-title">Name</label>
-                <input
-                  class="wz-input"
-                  placeholder="Label name"
-                  [value]="label.name"
-                  (input)="rename(label.id, $event)"
-                />
+                <nexus-field-shell>
+                  <input
+                    class="wz-input"
+                    placeholder="Label name"
+                    [value]="label.name"
+                    (input)="rename(label.id, $event)"
+                  />
+                </nexus-field-shell>
               </div>
               <div class="profile-editor__group">
                 <label class="profile-editor__group-title">Colour</label>
-                <nexus-color-swatch-picker
-                  [hue]="label.color"
-                  [tone]="label.tone"
-                  [previewName]="label.name || 'Preview'"
-                  (hueChange)="setHue(label.id, $event)"
-                  (toneChange)="setTone(label.id, $event)"
-                />
+                <nexus-field-shell description="Hue and tone used on chips across the app.">
+                  <nexus-color-swatch-picker
+                    [hue]="label.color"
+                    [tone]="label.tone"
+                    [previewName]="label.name || 'Preview'"
+                    (hueChange)="setHue(label.id, $event)"
+                    (toneChange)="setTone(label.id, $event)"
+                  />
+                </nexus-field-shell>
               </div>
             </div>
           }

--- a/ui/src/app/pages/settings/labels.ts
+++ b/ui/src/app/pages/settings/labels.ts
@@ -1,6 +1,7 @@
 import { ChangeDetectionStrategy, Component, computed, inject, signal } from '@angular/core';
 import { makeLabel, type Label, type LabelTone } from '../../models/label.model';
 import { ColorSwatchPicker } from '../../components/labels/color-swatch-picker';
+import { FieldShell } from '../../components/profiles/field-shell';
 import { LabelChip } from '../../components/labels/label-chip';
 import { ContextMenuService } from '../../services/context-menu/context-menu.service';
 import type { ContextMenuItem } from '../../services/context-menu/context-menu.model';
@@ -16,7 +17,16 @@ import { SectionHeader } from '../../ui/section-header/section-header';
 
 @Component({
   selector: 'nexus-settings-labels',
-  imports: [SectionHeader, EmptyState, Button, IconButton, Icon, LabelChip, ColorSwatchPicker],
+  imports: [
+    SectionHeader,
+    EmptyState,
+    Button,
+    IconButton,
+    Icon,
+    LabelChip,
+    ColorSwatchPicker,
+    FieldShell,
+  ],
   templateUrl: './labels.html',
   styleUrl: './labels.scss',
   changeDetection: ChangeDetectionStrategy.OnPush,

--- a/ui/src/app/pages/settings/printers.html
+++ b/ui/src/app/pages/settings/printers.html
@@ -131,7 +131,9 @@
 
             @if (deleteArmed()) {
               <div class="mgr__danger">
-                <p>Type <strong>{{ printer.name }}</strong> to permanently delete this printer.</p>
+                <p>
+                  Type <strong>{{ printer.name }}</strong> to permanently delete this printer.
+                </p>
                 <div class="mgr__danger-row">
                   <input
                     type="text"
@@ -287,59 +289,18 @@
               </nexus-field-row>
             </div>
 
-            <div class="profile-editor__group">
-              <label class="profile-editor__group-title">Hardware</label>
-              <nexus-field-row label="Nozzle diameter">
-                <nexus-number-input
-                  [value]="pnum(printer.params, 'nozzle_diameter_mm')"
-                  [min]="0.1"
-                  [max]="2"
-                  [step]="0.05"
-                  unit="mm"
-                  (valueChange)="updateParams(printer.id, { nozzle_diameter_mm: $event })"
-                />
-              </nexus-field-row>
-              <nexus-field-row label="Filament diameter">
-                <nexus-number-input
-                  [value]="pnum(printer.params, 'filament_diameter_mm')"
-                  [min]="1"
-                  [max]="4"
-                  [step]="0.05"
-                  unit="mm"
-                  (valueChange)="updateParams(printer.id, { filament_diameter_mm: $event })"
-                />
-              </nexus-field-row>
-              <nexus-field-row label="Max print speed">
-                <nexus-number-input
-                  [value]="pnum(printer.params, 'print_speed')"
-                  [min]="10"
-                  [max]="1000"
-                  [step]="5"
-                  unit="mm/s"
-                  (valueChange)="updateParams(printer.id, { print_speed: $event })"
-                />
-              </nexus-field-row>
-              <nexus-field-row label="Retraction length">
-                <nexus-number-input
-                  [value]="pnum(printer.params, 'retract_mm')"
-                  [min]="0"
-                  [max]="10"
-                  [step]="0.1"
-                  unit="mm"
-                  (valueChange)="updateParams(printer.id, { retract_mm: $event })"
-                />
-              </nexus-field-row>
-              <nexus-field-row label="Z-hop">
-                <nexus-number-input
-                  [value]="pnum(printer.params, 'z_hop_mm')"
-                  [min]="0"
-                  [max]="5"
-                  [step]="0.05"
-                  unit="mm"
-                  (valueChange)="updateParams(printer.id, { z_hop_mm: $event })"
-                />
-              </nexus-field-row>
-            </div>
+            @for (group of paramGroups; track group.name) {
+              <div class="profile-editor__group">
+                <label class="profile-editor__group-title">{{ group.name }}</label>
+                @for (field of group.fields; track field.key) {
+                  <nexus-param-field
+                    [field]="field"
+                    [value]="paramsOf(printer)[field.key]"
+                    (valueChange)="setParam(printer.id, field.key, $event)"
+                  />
+                }
+              </div>
+            }
 
             <div class="profile-editor__group" id="gcode-target">
               <label class="profile-editor__group-title">G-code</label>

--- a/ui/src/app/pages/settings/printers.ts
+++ b/ui/src/app/pages/settings/printers.ts
@@ -1,4 +1,11 @@
-import { ChangeDetectionStrategy, Component, afterNextRender, computed, inject, signal } from '@angular/core';
+import {
+  ChangeDetectionStrategy,
+  Component,
+  afterNextRender,
+  computed,
+  inject,
+  signal,
+} from '@angular/core';
 import { ActivatedRoute, RouterLink } from '@angular/router';
 import {
   PRINTER_CONNECTION_KINDS,
@@ -11,6 +18,10 @@ import {
   type PrinterProfile,
 } from '../../models/printer.model';
 import { PROFILE_SOURCE_LABELS } from '../../models/profile-source';
+import { SETTING_CONTRACTS } from '../../models/setting-contract';
+import globalSettingsSchema from '../../../schemas/slicer-engine-global-settings-v1.json';
+import { parseSchema } from '../../schema-form/models/schema-parser';
+import type { SchemaGroup } from '../../schema-form/models/field-def';
 import {
   CUSTOM_TEMPLATE_ID,
   GCODE_PLACEHOLDER_HINT,
@@ -33,6 +44,7 @@ import { PrintersStore } from '../../services/profiles/printers-store';
 import { Icon } from '../../shared/icon/icon';
 import { Badge } from '../../shared/badge/badge';
 import { CatalogPicker, type CatalogEntryVm } from '../../components/profiles/catalog-picker';
+import { ParamField } from '../../components/profiles/param-field';
 import { CodeEditor } from '../../components/code-editor/code-editor';
 import { LabelFilterBar } from '../../components/labels/label-filter-bar';
 import { LabelPicker } from '../../components/labels/label-picker';
@@ -48,6 +60,56 @@ import { Segmented } from '../../ui/segmented/segmented';
 import { Select } from '../../ui/select/select';
 import { Switch } from '../../ui/switch/switch';
 
+/**
+ * The `SlicingParams` sub-schema extracted from the generated global-settings
+ * schema, so the printer editor can render its slice-parameter groups
+ * dynamically (the same schema the slice-page settings sidebar consumes). Any
+ * new `SlicingParams` field appears automatically — no hand-maintained rows.
+ */
+const SLICING_PARAMS_SCHEMA = {
+  ...(globalSettingsSchema.$defs.SlicingParams as Record<string, unknown>),
+  $defs: globalSettingsSchema.$defs as Record<string, unknown>,
+};
+
+/**
+ * `x-group` names schema-driven in the printer editor, in display order.
+ *
+ * The Printer contract owns `['Hardware', 'Retraction', 'Output']`, but `Output`
+ * is left out here: its `gcode_flavor` is already the bespoke "Firmware" select
+ * and its `*_gcode` fields are multiline strings edited through the dedicated
+ * G-code editor block — both need typed widgets `nexus-param-field` can't
+ * provide. So the printer only schema-drives `Hardware` and `Retraction`.
+ */
+const PRINTER_PARAM_GROUPS = SETTING_CONTRACTS.find((c) => c.id === 'printer')!.groups.filter(
+  (name) => name === 'Hardware' || name === 'Retraction',
+);
+
+/**
+ * The slice-parameter groups rendered in the printer editor, in contract
+ * display order. Parsed once from the schema (it never changes at runtime).
+ * Each group's fields are filtered to those `nexus-param-field` can render —
+ * enums (→ select), booleans (→ switch), and numbers/integers (→ number) —
+ * dropping plain string/array fields that would render as broken inputs. Groups
+ * left with no renderable field are dropped entirely.
+ */
+const PARAM_GROUPS: SchemaGroup[] = (() => {
+  const order = new Map(PRINTER_PARAM_GROUPS.map((name, index) => [name, index]));
+  return parseSchema(SLICING_PARAMS_SCHEMA)
+    .groups.filter((g) => order.has(g.name))
+    .map((g) => ({
+      ...g,
+      fields: g.fields.filter(
+        (f) =>
+          !!f.enumOptions?.length ||
+          f.type === 'boolean' ||
+          f.type === 'number' ||
+          f.type === 'integer',
+      ),
+    }))
+    .filter((g) => g.fields.length > 0)
+    .sort((a, b) => order.get(a.name)! - order.get(b.name)!);
+})();
+
 @Component({
   selector: 'nexus-settings-printers',
   imports: [
@@ -59,6 +121,7 @@ import { Switch } from '../../ui/switch/switch';
     Badge,
     RouterLink,
     CatalogPicker,
+    ParamField,
     CodeEditor,
     ModalShell,
     FieldRow,
@@ -115,11 +178,13 @@ export class PrintersSettings {
   /** Printers narrowed by the active label filter and the search query. */
   protected readonly filtered = computed(() => {
     const q = this.search().trim().toLowerCase();
-    return this.store.items().filter(
-      (p) =>
-        matchesAllLabels(p, this.labelFilter()) &&
-        (!q || `${p.name} ${p.vendor ?? ''} ${p.model ?? ''}`.toLowerCase().includes(q)),
-    );
+    return this.store
+      .items()
+      .filter(
+        (p) =>
+          matchesAllLabels(p, this.labelFilter()) &&
+          (!q || `${p.name} ${p.vendor ?? ''} ${p.model ?? ''}`.toLowerCase().includes(q)),
+      );
   });
 
   /** The filtered printers bucketed into titled groups per the group-by mode. */
@@ -332,6 +397,9 @@ export class PrintersSettings {
   protected readonly pnum = paramNum;
   protected readonly pstr = paramStr;
 
+  /** Slice-parameter groups (Hardware, Retraction) rendered from the schema. */
+  protected readonly paramGroups = PARAM_GROUPS;
+
   protected update(id: string, patch: Partial<PrinterProfile>): void {
     this.store.update(id, patch);
   }
@@ -344,6 +412,16 @@ export class PrintersSettings {
         params: { ...((item.params as Record<string, unknown>) ?? {}), ...patch },
       });
     }
+  }
+
+  /** A printer's `params` bag as a plain record for the field controls. */
+  protected paramsOf(printer: PrinterProfile): Record<string, unknown> {
+    return (printer.params as Record<string, unknown>) ?? {};
+  }
+
+  /** Apply a single param field edit (templates can't build computed keys). */
+  protected setParam(id: string, key: string, value: unknown): void {
+    this.updateParams(id, { [key]: value });
   }
 
   protected rename(id: string, event: Event): void {


### PR DESCRIPTION
## Summary

Extends the schema-driven editor pattern introduced in PR #109 (`nexus-param-field`) to the remaining settings pages, so slice-parameter rows render dynamically from the generated `SlicingParams` schema instead of hand-maintained field lists. New engine fields in the relevant `x-groups` now surface automatically.

Closes #125, closes #126, closes #127.

## What changed

### Printer editor — #125
- Drives the **Hardware** and **Retraction** groups from the Printer contract's `x-group`s via `nexus-param-field`.
- **Kept bespoke:** Identity (name + firmware select), Connection (kind/host/port/api_key/status), Build volume (bed shape/size/origin), and the G-code editor block.
- `Output` is intentionally excluded so `gcode_flavor` (the Firmware select) and the multiline `*_gcode` fields stay on their typed widgets — no duplicated control for any param key.

### Filament editor — #126
- Drives the **Temperature** and **Cooling** groups from the Filament contract's `x-group`s.
- Non-renderable fields are filtered out automatically: `filament_type` (string) and `fan_configs` (array).
- **Kept bespoke:** colour picker, material select (with its side-effects), diameter, cost/kg, density. `cost_per_kg` moved into the Identity/Material group so it survived the removal of the old "Cooling & flow" group.

### Labels editor — #127
- Not `SlicingParams`-backed, so this is consistency + primitive reuse only.
- Extracted a small presentational **`nexus-field-shell`** row primitive (title + control + inline description) out of `nexus-param-field`.
- `nexus-param-field` is now a thin wrapper around the shell (public API unchanged), and the labels name/colour rows consume the same shell — so all four editors share one row rhythm with no duplicated row markup/styles.

## Implementation notes for reviewers
- The generic `nexus-param-field` only renders enum → select, boolean → switch, and number/integer → number input. Each editor filters its groups' fields to those shapes and drops empty groups, which is what removes the string/array fields above.
- `fan_speed` now shows as its raw `0..1` fraction (honest representation of the stored value) rather than a `×100` percentage special-case.
- `print_speed` (a Process param) is no longer shown on the printer page, consistent with the printer/filament/process contract split.
- The between-row divider lives at the `param-field` host level for schema rows and at the `field-shell` host level for bespoke rows, so there's no double border in either consumer.

## Validation
- `cd ui && npx tsc --noEmit` — clean.
- `npx prettier --check` on all changed files — clean.

Per the repo's UI-style workflow, this was validated with `tsc` + Prettier rather than a full `ng build`.
