### PR TITLE
fix(ui): resolve TypeScript type errors in printer parameter groups

### DIFF
--- a/ui/src/app/pages/settings/printers.ts
+++ b/ui/src/app/pages/settings/printers.ts
@@ -93,7 +93,7 @@ const PRINTER_PARAM_GROUPS = SETTING_CONTRACTS.find((c) => c.id === 'printer')!.
  * left with no renderable field are dropped entirely.
  */
 const PARAM_GROUPS: SchemaGroup[] = (() => {
-  const order = new Map(PRINTER_PARAM_GROUPS.map((name, index) => [name, index]));
+  const order = new Map<string, number>(PRINTER_PARAM_GROUPS.map((name, index) => [name, index]));
   return parseSchema(SLICING_PARAMS_SCHEMA)
     .groups.filter((g) => order.has(g.name))
     .map((g) => ({
@@ -107,7 +107,7 @@ const PARAM_GROUPS: SchemaGroup[] = (() => {
       ),
     }))
     .filter((g) => g.fields.length > 0)
-    .sort((a, b) => order.get(a.name)! - order.get(b.name)!);
+    .sort((a, b) => (order.get(a.name) ?? 0) - (order.get(b.name) ?? 0));
 })();
 
 @Component({


### PR DESCRIPTION
## Summary
Fixes the failing GitHub Actions deployment workflow by resolving TypeScript compilation errors in the printer settings component.

## Problem
The 'Deploy Web Slicer + Docs to GitHub Pages' workflow was failing with:
```
TS2345: Argument of type 'string' is not assignable to parameter of type '"Hardware" | "Retraction"'.
```

This error occurred at lines 98 and 110 of `ui/src/app/pages/settings/printers.ts` when accessing Map keys from dynamically parsed schema groups. The issue prevented the Angular build from completing, blocking all web deployments.

## Root Cause
The `PRINTER_PARAM_GROUPS` array is filtered to only contain 'Hardware' and 'Retraction' strings, but TypeScript couldn't infer this constraint when using the array to populate a Map. When the code later accessed that Map with keys from the parsed schema (which are typed as plain `string`), TypeScript flagged a type mismatch.

## Solution
- Added explicit `Map<string, number>` type annotation to resolve type inference issues
- Changed non-null assertions (`!`) to nullish coalescing (`??`) for safer fallback behavior

## Verification
✅ UI builds successfully (`pnpm ui:build`)
✅ Web-slicer configuration builds successfully (`pnpm ui:build:web-slicer`)
✅ No TypeScript compilation errors
✅ No runtime warnings

## Impact
This fix unblocks the automated deployment to GitHub Pages which was stuck on the failing Angular build step. The deployment workflow should now complete successfully.