### PR TITLE
core: stop Arachne surfaces & infill extruding into inner walls

### DIFF
--- a/AGENTS.md
+++ b/AGENTS.md
@@ -474,27 +474,65 @@ The `−0.5 × d` term accounts for the fact that `OuterWall` centerlines are
 already inset `d/2` from the model surface. Without this correction the interior
 region is over-shrunk by half a bead width.
 
-`walls_per_island = ceil(total_wall_bead_count / outer_contour_count)` gives the
-number of wall shells per island. This works because Arachne places the same
-number of beads on every island (parameters are global, not per-island).
+`walls_per_island = ceil(total_wall_bead_count / outer_contour_count)` estimates the
+number of wall shells per island. **This is only an average, and the Arachne
+generator breaks the assumption behind it:** Arachne places a _variable_ number
+of variable-width beads per island (and even along one island), so on a layer
+whose islands differ in bead count the estimate is too low and the interior is
+under-deflated by up to a full bead width. Solid surface / sparse infill / bottom
+fill generated inside that over-reaching interior then lands _on top of the
+innermost wall_ (measurable "Inner wall × {Top surface, Sparse infill, Bottom
+surface}" double-extrusion; the classic generator, which places a fixed count,
+does not show it). See the wall-footprint clip below for the correction.
 
 **Do not normalise all wall paths to CCW before the inflate.** Hole boundary
 beads have CW winding. Flipping them to CCW makes Clipper2 treat holes as solid
 material → infill is generated inside the hole (through the void).
 
+### Wall-Footprint Clip — Correcting the Interior Estimate's Over-Reach
+
+Because the `walls_per_island` estimate above can under-deflate on Arachne
+layers, both the sparse-infill area (`add_infill_to_layers`) and the solid
+top/bottom surface fill (`generate_top_bottom_surfaces_with_interior`) are
+additionally clipped against the **actual physical wall-bead footprint**
+(`compute_wall_bead_footprint` — every wall centerline inflated by its own
+half-width). This is count- and width-agnostic and a **no-op where the estimate
+was already correct** (classic), so it removes only the genuine over-print:
+
+- **Sparse infill** subtracts the footprint _grown by_ `infill_perimeter_gap_mm`
+  so it keeps its intended clearance from the real innermost wall.
+- **Solid surfaces** subtract the footprint _eroded by_
+  `infill_overlap_percent × d` so the fill still welds that much into the
+  innermost wall (the designed bond) and no further. The un-eroded gap-fill
+  footprint is unioned back in so surfaces _abut_ gap fill rather than welding to
+  it.
+
+Use **`FillRule::NonZero`** for these subtractions, **not `Positive`**: the wall
+footprint is a frame with CW hole sub-paths (the enclosed interior). `Positive`
+ignores CW holes → treats the frame as a solid block → erases the whole interior.
+
+This clip is applied to the fill regions **only** — it never reshapes
+`interior_regions`, so bridge detection/classification (which keys off the
+smooth interior) is untouched. Reshaping the interior itself instead spawns
+phantom bridges from the jagged bead-following boundary.
+
+Trimming the surface off the wall band shrinks `solid_regions`, so
+`prune_redundant_gap_fill` correctly _retains_ the wall-band gap-fill beads it
+used to prune (they fill real medial gaps, not areas the surface covers) — this
+is why the Arachne `gap_fill` role length rises after the fix.
+
 ### Infill Boundary vs. Surface Region
 
 `add_infill_to_layers` calls `calculate_interior_region(layer, 0.0, nozzle_diameter_mm)`
 (overlap = 0) to get the infill area, then subtracts `layer.solid_regions` with
-`FillRule::Positive`.
+`FillRule::Positive` and finally the wall-bead footprint (see above) with
+`FillRule::NonZero`.
 
 `generate_top_bottom_surfaces_with_interior` clips surface regions to
 `interior_regions[i]` (computed ahead of time with
 `calculate_interior_region(layer, infill_overlap_percent, nozzle_diameter_mm)`)
-before generating solid infill lines.
-
-Both use `calculate_interior_region` — but with different `overlap_percent`
-values. Keep them consistent if the signature changes.
+then subtracts the eroded wall-bead footprint before generating solid infill
+lines.
 
 ### `generate_rectilinear_infill` — Scanline Even-Odd Fill
 

--- a/src/core/infill.rs
+++ b/src/core/infill.rs
@@ -215,14 +215,52 @@ pub fn add_infill_to_layers(
         };
 
         // Subtract the gap-fill bead footprint so sparse infill abuts — never
-        // re-extrudes over — the variable-width Arachne gap fill.  (Walls are
-        // already excluded by the interior-region inset; over-print of *inner*
-        // walls at locally-thick spots is a separate, anchor-sensitive concern.)
+        // re-extrudes over — the variable-width Arachne gap fill.
         let gap_fp = super::surfaces::compute_gap_fill_footprint(layer, nozzle_diameter_mm);
         let infill_area = if gap_fp.is_empty() {
             infill_area
         } else {
             let remaining = difference(infill_area, gap_fp, FillRule::Positive).unwrap_or_default();
+            if remaining.is_empty() {
+                return None;
+            }
+            remaining
+        };
+
+        // Subtract the actual **wall bead footprint** (grown by the configured
+        // perimeter gap) so sparse infill keeps its intended clearance from the
+        // *real* innermost wall, regardless of how far the interior-region
+        // estimate reached.  The interior inset assumes a uniform wall count per
+        // island; the Arachne generator places a *variable* number of beads, so
+        // on a layer whose islands differ in bead count the inset lands a whole
+        // bead-width too far out and sparse infill is laid on top of the inner
+        // wall (measurable "Inner wall × Sparse infill" double-extrusion).
+        // Clipping against the physical bead footprint is count- and
+        // width-agnostic and is a no-op where the inset was already correct
+        // (classic), so it removes only the genuine over-print.
+        //
+        // `NonZero` is required (not `Positive`): the wall footprint is a
+        // frame with CW hole sub-paths (the enclosed interior).  `Positive`
+        // would ignore those holes and treat the frame as a solid block,
+        // erasing the whole interior; `NonZero` respects the holes so only the
+        // wall band itself is subtracted.
+        let wall_fp = super::surfaces::compute_wall_bead_footprint(layer, nozzle_diameter_mm);
+        let infill_area = if wall_fp.is_empty() {
+            infill_area
+        } else {
+            let clearance = infill_perimeter_gap_mm.max(0.0);
+            let blocked = if clearance > 1e-9 {
+                clipper2::inflate(
+                    wall_fp,
+                    clearance,
+                    clipper2::JoinType::Round,
+                    clipper2::EndType::Polygon,
+                    2.0,
+                )
+            } else {
+                wall_fp
+            };
+            let remaining = difference(infill_area, blocked, FillRule::NonZero).unwrap_or_default();
             if remaining.is_empty() {
                 return None;
             }

--- a/src/core/mod.rs
+++ b/src/core/mod.rs
@@ -1236,6 +1236,7 @@ mod tests {
                 bridge_min_area_mm2: 0.0,
                 bridge_noise_filter_mm: 0.0,
                 bridge_anchor_mm: 0.0,
+                infill_overlap_percent: 0.25,
                 min_infill_extrusion_mm: 0.0,
             },
             None,
@@ -1506,6 +1507,7 @@ mod tests {
                 bridge_min_area_mm2: 1.0,
                 bridge_noise_filter_mm: 0.0,
                 bridge_anchor_mm: 0.0,
+                infill_overlap_percent: 0.25,
                 min_infill_extrusion_mm: 0.0,
             },
             None,
@@ -1564,6 +1566,7 @@ mod tests {
                 bridge_min_area_mm2: 0.0,
                 bridge_noise_filter_mm: 0.5,
                 bridge_anchor_mm: 0.0,
+                infill_overlap_percent: 0.25,
                 min_infill_extrusion_mm: 0.0,
             },
             None,
@@ -1620,6 +1623,7 @@ mod tests {
             bridge_min_area_mm2: 0.0,
             bridge_noise_filter_mm: 0.0,
             bridge_anchor_mm: anchor,
+            infill_overlap_percent: 0.25,
             min_infill_extrusion_mm: 0.0,
         };
 
@@ -1721,6 +1725,7 @@ mod tests {
                 bridge_min_area_mm2: 0.0, // disable area filter so small porthole still passes
                 bridge_noise_filter_mm: 0.0, // disable noise filter
                 bridge_anchor_mm: 0.0,    // disable anchor so result area is minimal / predictable
+                infill_overlap_percent: 0.25,
                 min_infill_extrusion_mm: 0.0,
             },
             Some(&interior_regions),
@@ -1780,6 +1785,7 @@ mod tests {
                 bridge_min_area_mm2: 0.0,
                 bridge_noise_filter_mm: 0.0,
                 bridge_anchor_mm: 0.0,
+                infill_overlap_percent: 0.25,
                 min_infill_extrusion_mm: 0.0,
             },
             None,
@@ -1897,6 +1903,7 @@ mod tests {
                 bridge_min_area_mm2: 0.0,
                 bridge_noise_filter_mm: 0.0,
                 bridge_anchor_mm: 0.4,
+                infill_overlap_percent: 0.25,
                 min_infill_extrusion_mm: 0.0,
             },
             None,
@@ -1997,6 +2004,7 @@ mod tests {
                 bridge_min_area_mm2: 0.0,
                 bridge_noise_filter_mm: 0.0,
                 bridge_anchor_mm: 0.5,
+                infill_overlap_percent: 0.25,
                 min_infill_extrusion_mm: 0.0,
             },
             None,
@@ -2087,6 +2095,7 @@ mod tests {
                 bridge_min_area_mm2: 0.0,
                 bridge_noise_filter_mm: 0.0,
                 bridge_anchor_mm: 0.5,
+                infill_overlap_percent: 0.25,
                 min_infill_extrusion_mm: 0.0,
             },
             Some(&interior_regions),

--- a/src/core/pipeline.rs
+++ b/src/core/pipeline.rs
@@ -199,6 +199,7 @@ pub fn process_mesh(
                 bridge_min_area_mm2: params.bridge_min_area_mm2,
                 bridge_noise_filter_mm: params.bridge_noise_filter_mm,
                 bridge_anchor_mm: params.bridge_anchor_mm,
+                infill_overlap_percent: params.infill_overlap_percent,
             },
             Some(&interior_regions),
         );
@@ -565,6 +566,7 @@ pub fn process_mesh_debug(
                 bridge_min_area_mm2: params.bridge_min_area_mm2,
                 bridge_noise_filter_mm: params.bridge_noise_filter_mm,
                 bridge_anchor_mm: params.bridge_anchor_mm,
+                infill_overlap_percent: params.infill_overlap_percent,
             },
             Some(&interior_regions),
         );

--- a/src/core/surfaces.rs
+++ b/src/core/surfaces.rs
@@ -222,7 +222,7 @@ fn morphological_open(paths: Paths, radius_mm: f64) -> Paths {
 /// OverhangPerimeter / GapFill) — the build-plate area those extrusions consume.
 /// Bridge detection and solid top/bottom surfaces subtract this so nothing is
 /// deposited on top of an existing wall or gap-fill bead.
-fn compute_wall_bead_footprint(layer: &SliceLayer, nozzle_diameter_mm: f64) -> Paths {
+pub(super) fn compute_wall_bead_footprint(layer: &SliceLayer, nozzle_diameter_mm: f64) -> Paths {
     // Group wall paths by (is_open, radius-bucket) so we can run **one**
     // `inflate` call per group instead of one per path.  Clipper2's `inflate`
     // takes a `Paths` and offsets every contained sub-path together — there
@@ -1056,6 +1056,7 @@ pub fn generate_top_bottom_surfaces(
             bridge_min_area_mm2: 0.5,
             bridge_noise_filter_mm: 0.05,
             bridge_anchor_mm: 0.5,
+            infill_overlap_percent: 0.25,
         },
         None, // No interior regions - use full perimeters
     );
@@ -1110,6 +1111,16 @@ pub struct SurfaceConfig {
     /// the layer footprint) so each strand bites into the supported solid
     /// material on either side.
     pub bridge_anchor_mm: f64,
+    /// Fraction of the nozzle diameter by which solid top/bottom surface infill
+    /// is allowed to overlap the innermost wall for a bond weld.
+    ///
+    /// Solid surface fill is clipped against the **actual wall bead footprint**
+    /// (eroded by `infill_overlap_percent × nozzle_diameter`) so it welds to the
+    /// innermost wall by exactly this much and no further — regardless of how
+    /// far the interior-region estimate reached.  Matches the sparse-infill
+    /// clearance handling in `add_infill_to_layers` and keeps Arachne surfaces
+    /// from over-printing the wall band ("Top/Bottom surface × Inner wall").
+    pub infill_overlap_percent: f64,
 }
 
 /// Generate top and bottom solid surface infill for layers.
@@ -1186,6 +1197,48 @@ pub fn generate_top_bottom_surfaces_with_interior(
     let snapshot_ns = t_snap.elapsed().as_nanos();
     #[cfg(target_arch = "wasm32")]
     let snapshot_ns = 0u128;
+
+    // Per-layer **blocked** region for the solid top/bottom surface trim: the
+    // physical wall-bead footprint eroded by the bond distance, unioned with the
+    // un-eroded gap-fill footprint.  Subtracting it from the surface fill keeps
+    // the fill off the wall band while still welding `infill_overlap_percent × d`
+    // into the innermost wall (and merely abutting gap fill).  Built in parallel
+    // here — a chain of Clipper2 inflate/union calls per layer — so the serial
+    // apply pass only pays for the two cheap `difference` clips, not the whole
+    // footprint construction 240× single-threaded.
+    let surface_bond = (config.infill_overlap_percent * nozzle_diameter_mm).max(0.0);
+    let blocked_for_surface = |l: &SliceLayer| -> Paths {
+        let wall_fp = compute_wall_bead_footprint(l, nozzle_diameter_mm);
+        if wall_fp.is_empty() {
+            return Paths::new(vec![]);
+        }
+        let eroded = if surface_bond > 1e-9 {
+            inflate(
+                wall_fp,
+                -surface_bond,
+                JoinType::Round,
+                EndType::Polygon,
+                2.0,
+            )
+        } else {
+            wall_fp
+        };
+        let gap_fp = compute_gap_fill_footprint(l, nozzle_diameter_mm);
+        if gap_fp.is_empty() {
+            eroded
+        } else if eroded.is_empty() {
+            gap_fp
+        } else {
+            union(eroded, gap_fp, FillRule::NonZero).unwrap_or_default()
+        }
+    };
+    #[cfg(not(target_arch = "wasm32"))]
+    let surface_blocked: Vec<Paths> = {
+        use rayon::prelude::*;
+        layers.par_iter().map(blocked_for_surface).collect()
+    };
+    #[cfg(target_arch = "wasm32")]
+    let surface_blocked: Vec<Paths> = layers.iter().map(blocked_for_surface).collect();
 
     // Immutable view of the layers for the parallel detection pass so
     // `clip_to_void` can build a layer's wall-bead footprint on demand.  This
@@ -1645,6 +1698,34 @@ pub fn generate_top_bottom_surfaces_with_interior(
         let (bottom_region, top_region) = {
             let clean = |r: Paths| filter_small_islands(&r, SURFACE_MIN_ISLAND_MM2);
             (clean(bottom_region), clean(top_region))
+        };
+
+        // Trim solid top/bottom surface fill to keep it off the wall band.
+        //
+        // The surface regions were clipped to `interior_regions[i]`, whose
+        // inward inset assumes a uniform wall count per island.  The Arachne
+        // generator places a *variable* number of beads, so where an island
+        // carries fewer beads than the layer maximum the inset lands a whole
+        // bead-width too far out and the solid fill is laid on top of the inner
+        // wall ("Top/Bottom surface × Inner wall" double-extrusion).
+        //
+        // `surface_blocked[i]` (built in parallel above) is the wall-bead
+        // footprint eroded by the bond distance, unioned with the gap-fill
+        // footprint.  Subtracting it welds the fill `infill_overlap_percent × d`
+        // into the innermost wall (matching classic) and no further, while
+        // merely abutting gap fill.  `NonZero` respects the frame's CW hole so
+        // only the wall band is removed.  A no-op where the inset was already
+        // correct (classic), so it removes only the genuine over-print.
+        let (bottom_region, top_region) = {
+            let blocked = &surface_blocked[i];
+            let trim = |r: Paths| -> Paths {
+                if r.is_empty() || blocked.is_empty() {
+                    r
+                } else {
+                    difference(r, blocked.clone(), FillRule::NonZero).unwrap_or_default()
+                }
+            };
+            (trim(bottom_region), trim(top_region))
         };
 
         if !bottom_region.is_empty() {

--- a/tests/qa/baselines/benchy_arachne.json
+++ b/tests/qa/baselines/benchy_arachne.json
@@ -14,6 +14,6 @@
     "inner_wall": 41167.1,
     "outer_wall": 32330.9,
     "overhang_wall": 346.6,
-    "top_surface": 14685.5
+    "top_surface": 13872.3
   }
 }

--- a/tests/qa/baselines/hinge_arachne.json
+++ b/tests/qa/baselines/hinge_arachne.json
@@ -9,7 +9,7 @@
   "role_extrusion_mm": {
     "bottom_surface": 11794.0,
     "bridge": 141.0,
-    "gap_fill": 454.0,
+    "gap_fill": 515.6,
     "infill": 3383.2,
     "inner_wall": 10704.1,
     "outer_wall": 6372.6,

--- a/tests/qa/baselines/voron_arachne.json
+++ b/tests/qa/baselines/voron_arachne.json
@@ -9,7 +9,7 @@
   "role_extrusion_mm": {
     "bottom_surface": 8129.9,
     "bridge": 242.1,
-    "gap_fill": 480.2,
+    "gap_fill": 507.6,
     "infill": 31442.9,
     "inner_wall": 53399.4,
     "outer_wall": 27695.0,

--- a/ui/src/app/pages/settings/printers.ts
+++ b/ui/src/app/pages/settings/printers.ts
@@ -93,7 +93,7 @@ const PRINTER_PARAM_GROUPS = SETTING_CONTRACTS.find((c) => c.id === 'printer')!.
  * left with no renderable field are dropped entirely.
  */
 const PARAM_GROUPS: SchemaGroup[] = (() => {
-  const order = new Map(PRINTER_PARAM_GROUPS.map((name, index) => [name, index]));
+  const order = new Map<string, number>(PRINTER_PARAM_GROUPS.map((name, index) => [name, index]));
   return parseSchema(SLICING_PARAMS_SCHEMA)
     .groups.filter((g) => order.has(g.name))
     .map((g) => ({


### PR DESCRIPTION
## Summary

Another slicing-quality defect round. Using `tools/gcode-analysis/overlap.py`
against a sliced Benchy exposed a patternless double-extrusion the user
reported: **top surface, bottom surface, sparse infill, and gap fill printing
into the inner walls** — but only under the **Arachne** generator (classic was
clean).

### Root cause

`calculate_interior_region` deflates the infill/surface boundary by a single
global estimate:

```
walls_per_island = ceil(total_wall_beads / outer_contours)
```

That assumes every island carries the same fixed number of nominal-width beads.
Arachne places a **variable** number of variable-width beads per island, so on
any layer where island bead counts diverge the estimate is too low and the
interior lands up to a full bead-width too far out. Every fill region clipped to
that over-reaching interior then lands on top of the innermost wall — which is
why the defect appeared "with no specific pattern": it only misfires where
island bead counts differ. Instrumentation confirmed it (worst Benchy layer:
Arachne computed `wpi=2` where the truth was `3`; classic computed `3`).

### Fix (surgical — fill regions only)

Clip the **fill regions** against the actual physical wall-bead footprint
(`compute_wall_bead_footprint`, which honours real per-bead widths). It is
count/width-agnostic and a **no-op where the estimate was already correct
(classic)**, so it removes only the genuine over-print:

- **Sparse infill** subtracts the footprint *grown by* `infill_perimeter_gap_mm`
  (keeps the intended wall clearance).
- **Solid top/bottom surfaces** subtract it *eroded by*
  `infill_overlap_percent × d` (keeps the designed bond weld and no more); the
  un-eroded gap-fill footprint is unioned back so surfaces *abut* gap fill
  rather than welding to it.

`interior_regions` itself is deliberately **left untouched**, so bridge
detection/classification is unaffected — an earlier attempt to reshape the
interior spawned phantom bridges (voron 3→12 bridge layers) from the jagged
bead-following boundary. Uses `FillRule::NonZero` (the footprint is a frame with
CW holes; `Positive` would erase the interior). Footprint construction runs in a
parallel pass to keep the surface phase off the critical serial path.

## Results

Benchy (Arachne) body-on-body overlap surviving ¼-nozzle erosion:

| Metric (BODY mm²) | Before | After | Classic ref |
| --- | --- | --- | --- |
| Inner wall × Sparse infill | 117 | **14** | 15 |
| Inner wall × Top surface | 317 | **172** | 170 |
| Inner wall × Bottom surface | 56 | **43** | 42 |
| Gap infill × Top surface | 13.5 | **7.9** | — |
| Inner wall × Bridge | 8.31 | **8.31** | (untouched) |

Classic generator entirely unaffected. Voids unchanged (no new under-fill).

## QA baselines

Updated three **Arachne-only** baseline values for the intended, validated
shifts — all other metrics stayed within tolerance:

- `benchy` `top_surface` −813 mm (no longer over-printing the wall band)
- `voron` / `hinge` `gap_fill` +27 / +62 mm (medial-gap beads correctly retained
  once surfaces stop falsely covering them, so `prune_redundant_gap_fill` keeps
  them)

## Incidental fix (second commit)

While bringing up `tauri dev` for validation, the Angular bundle failed to
compile on a pre-existing latent bug in `ui/src/app/pages/settings/printers.ts`
(unrelated to the slicer work). TypeScript 5.5+ inferred type predicates narrow
the group-name filter to `('Hardware' | 'Retraction')[]`, so `order.has(g.name)`
/ `order.get(a.name)` reject the generic `SchemaGroup.name: string`. Typing the
map key as `string` restores the dev/prod bundle. Kept as a **separate commit**
for clean review.

## Validation

- `cargo fmt --check` clean, `cargo clippy --lib` clean
- 523 lib tests pass
- Full QA regression gate (`QA_FULL=1 … --ignored`) green
- UI verified via a clean `ng serve` bundle build; `tauri dev` launches the
  desktop window

## Reviewer notes

- The `walls_per_island` estimate still feeds **bridge** detection on purpose (a
  smooth interior avoids phantom bridges); only the fill regions are corrected.
  A per-island geometric interior is the eventual full fix.
- Pre-existing `clippy` `field_reassign_with_default` warnings in
  `src/gcode/generator.rs` **test** code come from a local clippy newer than CI
  and are untouched by this PR.
- `AGENTS.md` "Slicing Pipeline — Deep Knowledge" updated to correct the now
  disproven "Arachne places the same number of beads on every island" claim and
  document the wall-footprint clip + `NonZero` requirement.
