### PR TITLE
analysis: track gcode diagnostic scripts & repro configs

### DIFF
--- a/analysis/.gitignore
+++ b/analysis/.gitignore
@@ -1,0 +1,7 @@
+# Regenerable slicing artifacts — reproduce with the workflow in
+# tools/gcode-analysis/README.md. Only the diagnostic scripts and the A/B repro
+# configs are tracked.
+gcode/
+logs/
+renders/
+__pycache__/

--- a/analysis/arachne.toml
+++ b/analysis/arachne.toml
@@ -1,0 +1,2 @@
+[slicing]
+wall_generator = "arachne"

--- a/analysis/classic.toml
+++ b/analysis/classic.toml
@@ -1,0 +1,2 @@
+[slicing]
+wall_generator = "classic"

--- a/analysis/overlay_support.py
+++ b/analysis/overlay_support.py
@@ -1,0 +1,47 @@
+#!/usr/bin/env python3
+"""Overlay layer L's Bridge/target-role beads on layer L-1's full footprint.
+
+Answers "is this extrusion laid over thin air?": grey = everything printed on the
+layer below (the support), colored = the role of interest on layer L. Any colored
+bead not sitting on grey is extruding into space.
+
+Usage: overlay_support.py <gcode> <layer> [role=Bridge] [out.png]
+"""
+import sys
+import numpy as np
+import matplotlib
+matplotlib.use("Agg")
+import matplotlib.pyplot as plt
+
+sys.path.insert(0, __file__.rsplit("/", 1)[0] + "/../tools/gcode-analysis")
+from voids import parse_layers
+
+path = sys.argv[1]
+L = int(sys.argv[2])
+role = sys.argv[3] if len(sys.argv) > 3 else "Bridge"
+out = sys.argv[4] if len(sys.argv) > 4 else "/tmp/overlay.png"
+
+layers = parse_layers(path)
+below = layers[L - 1] if L > 0 else []
+cur = layers[L]
+
+fig, ax = plt.subplots(figsize=(12, 12))
+# Support from the layer below: every deposited bead, thick pale grey.
+for (x0, y0, x1, y1, w, typ) in below:
+    ax.plot([x0, x1], [y0, y1], color="0.80", lw=4, solid_capstyle="round", zorder=1)
+# Current layer's walls for reference (thin dark outline).
+for (x0, y0, x1, y1, w, typ) in cur:
+    if typ in ("Outer wall", "Inner wall", "Overhang wall"):
+        ax.plot([x0, x1], [y0, y1], color="navy", lw=0.6, zorder=2)
+# The role of interest on the current layer, bright red.
+n = 0
+for (x0, y0, x1, y1, w, typ) in cur:
+    if typ == role:
+        ax.plot([x0, x1], [y0, y1], color="red", lw=1.4, solid_capstyle="round", zorder=3)
+        n += 1
+ax.set_aspect("equal")
+ax.invert_yaxis()
+ax.set_title(f"{path.split('/')[-1]} L{L}: {role} (red, {n} segs) over L{L-1} footprint (grey)")
+plt.tight_layout()
+plt.savefig(out, dpi=130)
+print(f"wrote {out}  ({role} segs on L{L}: {n})")

--- a/analysis/probe_layers.py
+++ b/analysis/probe_layers.py
@@ -1,0 +1,52 @@
+#!/usr/bin/env python3
+"""Per-layer probe: bridge presence, and whether a point is covered by material.
+
+Usage: probe_layers.py <gcode> <lo> <hi> [cx cy]
+Prints, per layer: Z, #bridge segs, bridge length, and whether (cx,cy) is inside
+any extrusion footprint (material) on that layer and the one below.
+"""
+import sys
+import math
+
+sys.path.insert(0, __file__.rsplit("/", 1)[0] + "/../tools/gcode-analysis")
+from voids import parse_layers
+
+path = sys.argv[1]
+lo = int(sys.argv[2])
+hi = int(sys.argv[3])
+cx = float(sys.argv[4]) if len(sys.argv) > 4 else None
+cy = float(sys.argv[5]) if len(sys.argv) > 5 else None
+
+layers = parse_layers(path)
+
+
+def near_point(segs, px, py, tol=0.6):
+    """True if any bead centerline passes within tol mm of (px,py)."""
+    for (x0, y0, x1, y1, w, typ) in segs:
+        dx, dy = x1 - x0, y1 - y0
+        L2 = dx * dx + dy * dy
+        if L2 < 1e-9:
+            d = math.hypot(px - x0, py - y0)
+        else:
+            t = max(0.0, min(1.0, ((px - x0) * dx + (py - y0) * dy) / L2))
+            d = math.hypot(px - (x0 + t * dx), py - (y0 + t * dy))
+        if d <= tol:
+            return typ
+    return None
+
+
+print(f"{path.split('/')[-1]}  layers {lo}..{hi}")
+hdr = "  L    Z     #brg  brgLen"
+if cx is not None:
+    hdr += f"   mat@({cx:.0f},{cy:.0f})  matBelow"
+print(hdr)
+for i in range(lo, min(hi + 1, len(layers))):
+    segs = layers[i]
+    brg = [s for s in segs if s[5] == "Bridge"]
+    blen = sum(math.hypot(s[2] - s[0], s[3] - s[1]) for s in brg)
+    row = f"  {i:<4} ---   {len(brg):<4} {blen:6.1f}"
+    if cx is not None:
+        here = near_point(segs, cx, cy)
+        below = near_point(layers[i - 1], cx, cy) if i > 0 else None
+        row += f"   {str(here or '-'):>10}  {str(below or '-'):>10}"
+    print(row)

--- a/analysis/scan_coincident.py
+++ b/analysis/scan_coincident.py
@@ -1,0 +1,42 @@
+#!/usr/bin/env python3
+"""All-layer wall-coincidence scan reusing coincident.py's geometry.
+
+Usage: scan_coincident.py <gcode> [gap_mm=0.10]
+Prints per-layer non-zero coincidence and a whole-model total.
+"""
+import sys
+import importlib.util
+
+HERE = __file__.rsplit("/", 1)[0]
+TOOLS = HERE + "/../tools/gcode-analysis"
+path = sys.argv[1]
+gap = float(sys.argv[2]) if len(sys.argv) > 2 else 0.10
+
+# Load coincident.py with argv primed so its module-level globals resolve.
+sys.argv = [TOOLS + "/coincident.py", path, "0", str(gap)]
+spec = importlib.util.spec_from_file_location("coinc", TOOLS + "/coincident.py")
+coinc = importlib.util.module_from_spec(spec)
+spec.loader.exec_module(coinc)
+
+layers = coinc.parse()
+anywall = lambda t: t in ("Inner wall", "Outer wall", "Overhang wall")
+
+tot_pairs = 0
+tot_len = 0.0
+worst = (0, 0, 0.0)
+bad_layers = 0
+for i, layer in enumerate(layers):
+    n, c, tl = coinc.analyze(layer, anywall)
+    if c > 0:
+        bad_layers += 1
+        tot_pairs += c
+        tot_len += tl
+        if tl > worst[2]:
+            worst = (i, c, tl)
+        print(f"  L{i:>3}: {c:>3} pairs, {tl:7.2f}mm overlap")
+
+name = path.split("/")[-1]
+print(f"\n{name}: {len(layers)} layers  |  {bad_layers} layers with coincidence")
+print(f"  total: {tot_pairs} pairs, {tot_len:.2f}mm wall-on-wall overlap")
+if worst[1]:
+    print(f"  worst: L{worst[0]} ({worst[1]} pairs, {worst[2]:.2f}mm)")

--- a/tests/qa/mod.rs
+++ b/tests/qa/mod.rs
@@ -55,7 +55,7 @@ pub struct Fixture {
     pub fast_gate: bool,
 }
 
-/// The prepared corpus, mirroring `analysis/REPORT.md`.
+/// The prepared fixture corpus (Voron cube, hinge, caddy, Benchy).
 pub fn corpus() -> Vec<Fixture> {
     vec![
         Fixture {


### PR DESCRIPTION
## What

Tracks the ancillary G-code diagnostic scripts that complement the committed [`tools/gcode-analysis/`](tools/gcode-analysis) toolkit, plus the two A/B repro configs.

| File | Purpose |
|---|---|
| `analysis/overlay_support.py` | Overlay a role's beads on the layer below to spot **extrude-over-air** (phantom bridges) |
| `analysis/probe_layers.py` | Per-layer bridge presence + point-coverage probe (reuses `tools/gcode-analysis/voids.py`) |
| `analysis/scan_coincident.py` | All-layer wall-coincidence scan (reuses `coincident.py`) |
| `analysis/{arachne,classic}.toml` | The two-generator A/B repro configs |

## Why

The three scripts are reusable diagnostics that extend the tracked `tools/gcode-analysis/` toolkit (they `import` from it) but weren't committed. This tracks them so the tooling isn't lost.

Also drops the stale `analysis/REPORT.md` mention in [`tests/qa/mod.rs`](tests/qa/mod.rs) — that point-in-time audit report is intentionally not tracked, so the reference is removed to keep the repo consistent.

## Not included (gitignored)

The regenerable artifacts these produce — `analysis/gcode/`, `analysis/renders/`, `analysis/logs/`, `__pycache__/` — are gitignored. Reproduce them with the workflow in `tools/gcode-analysis/README.md`.

## Notes

- Pure tooling; only other change is the one-line comment cleanup in `tests/qa/mod.rs`.
- All three scripts pass `python3 -m py_compile`.
