### PR TITLE
feat(adhesion): generate skirt, brim & raft bed adhesion

### DIFF
--- a/.github/instructions/angular-component-structure.instructions.md
+++ b/.github/instructions/angular-component-structure.instructions.md
@@ -23,14 +23,14 @@ not before.
 
 ## Smart (container) vs. Dumb (presentational)
 
-| | Smart / container | Dumb / presentational |
-|---|---|---|
-| Lives in | `pages/`, feature roots in `components/` | `ui/`, `shared/`, leaf `components/` |
-| Knows about | services, routing, WASM, state | nothing but its `input()`s |
-| Gets data via | `inject()`ing services/signals | `input()` only |
-| Talks back via | calling service methods | `output()` only |
-| Reused across features | rarely | freely |
-| Selector | element `nexus-*` | attribute (`[nexusButton]`) or element |
+|                        | Smart / container                        | Dumb / presentational                  |
+| ---------------------- | ---------------------------------------- | -------------------------------------- |
+| Lives in               | `pages/`, feature roots in `components/` | `ui/`, `shared/`, leaf `components/`   |
+| Knows about            | services, routing, WASM, state           | nothing but its `input()`s             |
+| Gets data via          | `inject()`ing services/signals           | `input()` only                         |
+| Talks back via         | calling service methods                  | `output()` only                        |
+| Reused across features | rarely                                   | freely                                 |
+| Selector               | element `nexus-*`                        | attribute (`[nexusButton]`) or element |
 
 - **Dumb components should be pure functions of their inputs.** As a rule they
   don't `inject()` app services, HTTP, the router, or `NotificationService`. If
@@ -45,7 +45,7 @@ not before.
 ```ts
 // dumb: pure, reusable, testable without a TestBed harness
 @Component({
-  selector: 'nexus-slice-summary',
+  selector: "nexus-slice-summary",
   changeDetection: ChangeDetectionStrategy.OnPush,
 })
 export class SliceSummary {
@@ -54,11 +54,13 @@ export class SliceSummary {
 }
 
 // smart: owns the service, feeds the dumb child
-@Component({ selector: 'nexus-slice-viewer', /* ... */ })
+@Component({ selector: "nexus-slice-viewer" /* ... */ })
 export class SliceViewer {
   readonly #slicer = inject(SlicerService);
   readonly stats = this.#slicer.stats; // signal
-  rerun() { this.#slicer.rerun(); }
+  rerun() {
+    this.#slicer.rerun();
+  }
 }
 ```
 
@@ -106,6 +108,34 @@ Reusability comes from a **small, honest contract**, not from options.
   `SliceStats` value, never reaches into `SlicerService`. That is what makes it
   drop-in across features.
 
+## Exceptions beside a generic resolver
+
+When a **generic, data-driven renderer** (a schema form, a dynamic table, a
+component-outlet host) needs a handful of items treated specially, do **not**
+branch inside the generic path — that is how a clean resolver rots into a pile of
+`if (key === …)`. Instead keep the generic path clean and add a **parallel
+registry keyed by item id** for the exceptions.
+
+Canonical example — the schema-form has **two independent maps**:
+
+- `field-registry.ts` — `key → widget` ("_which_ control renders this field").
+- `field-exceptions.ts` — `key → exception` ("does this field need extra
+  treatment", e.g. a conditional caution notice).
+
+The widget-choosing never learns about notices, and vice-versa; each map stays a
+one-liner per entry. Guidelines:
+
+- **Render the exception at the point of use** (inside the per-item host), so it
+  works everywhere that item renders — grouped view, search results, anywhere —
+  with zero duplication.
+- **Drive any container-level aggregate from the same registry** via a
+  `computed` (e.g. an accordion header that flags "something inside needs a look"
+  reuses the exceptions predicate), so the summary and the detail can't drift.
+- **Shape the exception for extension, not just today's need.** An exception
+  object with an optional `notice?()` leaves room for future kinds (badge, hidden,
+  disabled) without reshaping call sites — but add those only when a real second
+  case appears.
+
 ## Conventions (match the existing codebase)
 
 - **Standalone, `ChangeDetectionStrategy.OnPush`, signals throughout.** Use
@@ -136,3 +166,4 @@ Reusability comes from a **small, honest contract**, not from options.
 - `.github/instructions/ui-design-language.instructions.md` — visual language.
 - `ui/src/app/ui/button/button.ts` — canonical dumb primitive.
 - `ui/src/app/pages/slice-viewer/slice-viewer.ts` — canonical smart container.
+- `ui/src/app/schema-form/field-registry/field-registry.ts` + `field-exceptions/field-exceptions.ts` — the "exceptions beside a generic resolver" pattern.

--- a/.github/instructions/ui-design-language.instructions.md
+++ b/.github/instructions/ui-design-language.instructions.md
@@ -112,7 +112,7 @@ All values live in `ui/src/styles/theme/` — `_light.scss`, `_dark.scss`
 
 - **Accent = single source of truth.** `--accent` (amber `#e0730f` light /
   `#f5883a` dark). Every shade — `--accent-hover/-active/-soft/-softer/-border/
-  -contrast` — is derived via `color-mix(in oklab, ...)`. Overriding `--accent`
+-contrast` — is derived via `color-mix(in oklab, ...)`. Overriding `--accent`
   alone (what `AccentService` does with the OS accent) recolors the whole UI.
   `--color-primary*` are legacy aliases of the accent — keep them aliased.
 - **Neutrals:** warm **graphite** backgrounds/surfaces/text/borders
@@ -123,7 +123,7 @@ All values live in `ui/src/styles/theme/` — `_light.scss`, `_dark.scss`
 - **Focus:** `--color-focus-ring` (tracks accent) + `--color-focus-ring-glow`.
 - **Spacing:** `--spacing-xs..2xl` (4/8/12/16/24/32). **Radius:** `--radius-sm/md/lg`
   (4/6/8). **Shadows:** `--shadow-xs..lg`. **Motion:** `--duration-fast/normal/slow`
-  + `--ease-standard/decelerate/accelerate`. **Icons:** `--icon-stroke-width: 1.8`.
+  - `--ease-standard/decelerate/accelerate`. **Icons:** `--icon-stroke-width: 1.8`.
 
 ## Layout & Component Patterns
 
@@ -132,7 +132,8 @@ All values live in `ui/src/styles/theme/` — `_light.scss`, `_dark.scss`
   border only when the card needs contrast (floating over the 3D scene) rather
   than as a reflex.
 - **Use the UI primitives** in `ui/src/app/ui/` — `button[nexusButton]`,
-  `icon-button`, `nexus-section-header`, `empty-state` — instead of ad-hoc markup.
+  `icon-button`, `nexus-section-header`, `empty-state`, `inline-notice` — instead
+  of ad-hoc markup.
 - **`nexus-section-header` has fixed `height: 48px; flex: none`** with nowrap
   title/desc — do not let it reflow.
 - **Fixed-height chrome uses `flex: none`** (titlebar, section headers). A
@@ -142,6 +143,34 @@ All values live in `ui/src/styles/theme/` — `_light.scss`, `_dark.scss`
 - **Accent usage:** primary/CTA buttons use `--accent` bg + `--accent-contrast`
   text; active/selected states use `--accent-soft`; ghost buttons on hover use
   `--color-surface-hover`.
+
+## Contextual Notices & Cautions
+
+When a control needs a note, hint, or caution, use the **`nexus-inline-notice`**
+primitive — never hand-roll a coloured box. It is a solid **tinted surface (no
+blur)** with a `tone` input (`info` teal / `warning` amber / `danger` red) that
+drives its icon and border via one `--notice-tone` custom property.
+
+Follow the **"detail at the source, neutral hint on the container"** pattern for
+surfacing these (canonical: the schema-form settings sidebar):
+
+- **Put the tone-coloured detail right next to the offending control**, not at
+  the bottom of a section. The reader should see _which_ setting the caution is
+  about without hunting.
+- **Aggregate a single colour-_neutral_ cue on the collapsible container** (an
+  accordion header, a tab) whenever anything inside currently has a notice —
+  a `warning-triangle` held at `--color-text-tertiary`, so a collapsed section
+  still says "look inside." Keep it neutral: it is a calm "double-check" nudge,
+  **not** a second alarm competing with the tone-coloured detail.
+- **Drive the container cue from the same source as the detail** (a `computed`
+  over the same predicate), so the hint and the note can never drift apart.
+- Notices are **conditional on live state** — show them only while the risky
+  value is actually selected (e.g. raft adhesion), and let them disappear
+  reactively when it changes.
+
+For schema-driven settings specifically, declare the caution in the
+**field-exceptions registry** rather than special-casing the generic form — see
+the component-structure instruction's "Exceptions beside a generic resolver."
 
 ## Angular Styling Gotchas (this project)
 
@@ -165,6 +194,8 @@ asks or for a major new feature.
 ## See also
 
 - `ui/src/styles/theme/` — token definitions (`_light.scss`, `_dark.scss`, `_root.scss`)
-- `ui/src/app/ui/` — shared primitives (button, icon-button, section-header, empty-state)
+- `ui/src/app/ui/` — shared primitives (button, icon-button, section-header, empty-state, inline-notice)
+- `ui/src/app/ui/inline-notice/inline-notice.ts` — the contextual-notice primitive
+- `ui/src/app/schema-form/` — the "detail at the source, neutral hint on the container" pattern in practice
 - `ui/src/app/services/accent.ts` — OS-accent inheritance (`AccentService`)
 - `.github/instructions/ui-style-no-build.instructions.md` — build-verification policy

--- a/AGENTS.md
+++ b/AGENTS.md
@@ -405,11 +405,16 @@ apply_single_wall_restrictions()     — strips inner walls from first/last laye
 interior_regions computed            — per-layer interior (for surfaces), post-strip
 generate_top_bottom_surfaces_with_interior()  — top/bottom solid infill within interior
 add_infill_to_layers()               — sparse infill using pre-strip regions minus solid regions
+path ordering + flow compensation    — greedy-TSP per role group, then wall-overlap flow scaling
+apply_adhesion()                     — skirt/brim prepended to first layer(s); raft prepends layers + Z-shifts object (src/adhesion/)
 ```
 
 Order matters critically. Surfaces are computed **after** Arachne walls so that
 `calculate_interior_region` sees the correct bead geometry. Infill is computed
-**after** surfaces so it can subtract `solid_regions`.
+**after** surfaces so it can subtract `solid_regions`. **Bed adhesion runs dead
+last**, after ordering and flow compensation, so its loops are appended cleanly
+and the object's own toolpaths are provably unperturbed — see
+[src/adhesion/README.md](src/adhesion/README.md).
 
 **`pre_strip_infill_regions` must be computed before `apply_single_wall_restrictions`.**
 `apply_single_wall_restrictions` now operates **per island**: an outer-wall path P at

--- a/src/adhesion/README.md
+++ b/src/adhesion/README.md
@@ -1,0 +1,100 @@
+# Adhesion — Skirt, Brim & Raft Generation
+
+This module exists to answer one question: *how do we help the first layer stick
+to the bed?* It turns the
+[`AdhesionType`](../settings/params.rs) selection (plus its sub-parameters) into
+extra geometry, and it obeys a single rule: **it runs last and never touches the
+object's own toolpaths.** Skirt/brim loops are *prepended* to the first layer(s);
+a raft *prepends whole layers* and lifts the object in Z. Nothing the object
+already generated (walls, surfaces, infill, ordering, flow) is reshaped.
+
+---
+
+## Why a separate, last-stage module
+
+Bed adhesion is *additive scaffolding*, not part of the part. Slicing it inside
+the wall/infill passes would entangle it with the very geometry it must stay
+clear of (separation gaps, wall-footprint clips, seam ordering). Mature slicers
+(PrusaSlicer, OrcaSlicer, CuraEngine) all generate adhesion from the finished
+first-layer outline as a distinct step for exactly this reason. Running after
+path ordering and flow compensation means the loops are appended cleanly and the
+object is provably unperturbed.
+
+```mermaid
+flowchart LR
+  A[process_mesh: walls → surfaces → infill] --> B[path ordering]
+  B --> C[flow compensation]
+  C --> D[apply_adhesion]
+  D -->|skirt/brim| E[prepend loops to first layers]
+  D -->|raft| F[prepend layers + Z-shift object]
+```
+
+## The contract
+
+- **Footprint from `OuterWall` centerlines.** The wall generator emits
+  centerlines inset `d/2` from the true surface (`d` = nozzle diameter), so the
+  object outline is recovered by unioning the layer-0 `OuterWall` paths and
+  inflating outward by `d/2`. **Winding is preserved** (CCW solids, CW holes) so
+  Clipper2 treats holes as voids — see `AGENTS.md` § "Clipper2 Fill Rules".
+- **Loops print first.** Skirt/brim paths are prepended so the nozzle primes on
+  them before the part. They carry the `Skirt` role (a closed-loop role in the
+  G-code generator, Orca-compatible `;TYPE:Skirt`).
+- **Raft is a base, not a part.** Raft layers carry the `Support` role, sit on
+  the bed (Z from `layer_height/2`), and the object is shifted up by
+  `raft_layers · layer_height + raft_air_gap` so it lands on the raft top.
+
+## The catalog
+
+| Type  | Geometry | Role | Key params |
+| ----- | -------- | ---- | ---------- |
+| Skirt | `skirt_loops` outward loops from the outline, over the first `skirt_height` layers | `Skirt` | `skirt_loops`, `skirt_distance`, `skirt_height` |
+| Brim  | apron loops hugging the object on layer 0 | `Skirt` | `brim_width`, `brim_type`, `brim_separation` |
+| Raft  | coarse base + finer interface layers under the object | `Support` | `raft_layers`, `raft_air_gap` |
+
+`brim_type` (`BrimType`): `outer_only` offsets outward; `inner_only` steps into
+each hole; `outer_and_inner` does both; `ears` stamps concentric discs only at
+sharp convex corners (interior angle < 120°) where warping actually starts —
+detected on a **miter** footprint so the round offset doesn't bevel the corners
+away first.
+
+## Geometry primitives
+
+- **`offset` / `offset_join`** — the polygon-offset workhorse. `Round` for
+  skirt/brim/raft outlines; `Miter` only for ears corner detection.
+- **`outward_loops` / `hole_loops`** — concentric loops stepping out from the
+  object or into each hole. Loop `k` sits at `gap + d/2 + k·d`.
+- **`concentric_loops`** — fills an arbitrary region (the ears disc-minus-object)
+  with `d`-spaced loops from its boundary inward.
+- **`convex_corners`** — signed exterior turn via `atan2(cross, dot)`; positive
+  turn on a CCW contour is a convex corner.
+
+## Lifecycle
+
+`apply_adhesion` is called once at the tail of
+[`process_mesh`](../core/pipeline.rs), gated on `adhesion_type != None`. It
+mutates the layer vector in place (skirt/brim) or replaces it with
+`[raft…, object…]` (raft). There is no persistence and no per-layer state — it is
+a pure function of the finished layers plus params.
+
+## Non-goals
+
+- **No brim-to-part fusion tuning beyond `brim_separation`.** The brim abuts the
+  wall at the configured gap; it does not model inter-bead flow welding.
+- **No variable raft layer heights.** Raft layers use `layer_height` because the
+  G-code generator computes extrusion `E` from the global `layer_height`; a
+  thicker base would mis-estimate flow. This is a deliberate, honest limitation.
+- **No bed-bounds clamping.** Skirt/raft expansion is not clipped to the build
+  plate here; that belongs to a bed-aware validation pass, not adhesion.
+- **No support generation.** Rafts reuse the `Support` role for annotation only;
+  actual support structures are a separate, unimplemented feature.
+
+## See also
+
+- [`mod.rs`](./mod.rs) — the implementation.
+- [`../settings/params.rs`](../settings/params.rs) — `AdhesionType`, `BrimType`,
+  and the sub-parameters.
+- [`../core/pipeline.rs`](../core/pipeline.rs) — where `apply_adhesion` is called.
+- `AGENTS.md` § "Slicing Pipeline — Deep Knowledge" and § "Clipper2 Fill Rules".
+- Issue [#93](https://github.com/max-scopp/slicer-engine/issues/93) — the
+  originating feature; part of [#92](https://github.com/max-scopp/slicer-engine/issues/92)
+  (profile import).

--- a/src/adhesion/mod.rs
+++ b/src/adhesion/mod.rs
@@ -1,0 +1,582 @@
+//! Bed-adhesion helpers — skirt, brim, and raft generation.
+//!
+//! This module is the single place that turns the
+//! [`AdhesionType`](crate::settings::params::AdhesionType) selection (plus its
+//! sub-parameters) into extra first-layer / sub-object geometry.  It runs at the
+//! very end of [`process_mesh`](crate::core::process_mesh), after walls,
+//! surfaces, infill, path ordering, and flow compensation, so it never perturbs
+//! the object's own toolpaths.
+//!
+//! # What each helper produces
+//!
+//! | Type  | Geometry | Role | Where |
+//! | ----- | -------- | ---- | ----- |
+//! | Skirt | `skirt_loops` concentric loops offset out from the object outline, over the first `skirt_height` layers | [`Skirt`](crate::core::ExtrusionRole::Skirt) | prepended to those layers |
+//! | Brim  | apron loops hugging the object (outer, hole, or corner-only) on the first layer | [`Skirt`](crate::core::ExtrusionRole::Skirt) | prepended to layer 0 |
+//! | Raft  | sacrificial base + interface layers under the object; object shifted up by raft height + air gap | [`Support`](crate::core::ExtrusionRole::Support) | prepended as whole layers |
+//!
+//! # Coordinate conventions
+//!
+//! All geometry is in millimetres (Clipper2 `Centi` precision).  The wall
+//! generator emits `OuterWall` **centerlines** inset `d/2` from the true model
+//! surface, so the object footprint is reconstructed by inflating the unioned
+//! `OuterWall` paths outward by `d/2` (`d` = nozzle diameter).  Winding is
+//! preserved throughout (CCW solids, CW holes) so Clipper2 treats holes as
+//! voids — see `AGENTS.md` § "Clipper2 Fill Rules".
+
+use clipper2::*;
+
+use crate::core::{ExtrusionRole, SliceLayer};
+use crate::settings::params::{AdhesionType, BrimType, SlicingParams};
+
+/// Round-join polygon inflate — the offset primitive used throughout this
+/// module.  A positive `delta` grows the solid region outward (and shrinks
+/// CW holes inward); a negative `delta` does the reverse.
+fn offset(paths: &Paths, delta: f64) -> Paths {
+    offset_join(paths, delta, JoinType::Round)
+}
+
+/// [`offset`] with an explicit join type.  `Miter` keeps sharp corners sharp
+/// (needed for "ears" corner detection); `Round` bevels them.
+fn offset_join(paths: &Paths, delta: f64, join: JoinType) -> Paths {
+    if paths.is_empty() {
+        return Paths::default();
+    }
+    inflate(paths.clone(), delta, join, EndType::Polygon, 2.0)
+}
+
+/// Merge a set of contours into a clean region, preserving winding so holes
+/// stay voids.  `NonZero` is correct here because the input already carries
+/// Clipper2-consistent winding (CCW solids, CW holes) from the wall generator.
+fn clean_union(paths: Paths) -> Paths {
+    if paths.is_empty() {
+        return Paths::default();
+    }
+    union(paths, Paths::default(), FillRule::NonZero).unwrap_or_default()
+}
+
+/// Keep only the outer (positive-area, CCW) contours of a region, dropping hole
+/// sub-paths.  Used for skirt loops, which enclose the whole object and must
+/// never appear inside a hole.
+fn outer_only(paths: Paths) -> Paths {
+    Paths::new(
+        paths
+            .iter()
+            .filter(|p| p.signed_area() > 0.0)
+            .cloned()
+            .collect(),
+    )
+}
+
+/// Extract the object footprint on `layer` as a filled region (with holes).
+///
+/// Unions every `OuterWall` centerline, then inflates by `d/2` to recover the
+/// true model outline.  Returns an empty region when the layer has no walls.
+fn object_footprint(layer: &SliceLayer, d: f64) -> Paths {
+    let outer = Paths::new(
+        layer
+            .paths
+            .iter()
+            .enumerate()
+            .filter(|(i, _)| layer.role_for_path(*i) == ExtrusionRole::OuterWall)
+            .map(|(_, p)| p.clone())
+            .collect(),
+    );
+    if outer.is_empty() {
+        return Paths::default();
+    }
+    let merged = clean_union(outer);
+    offset(&merged, d / 2.0)
+}
+
+/// Like [`object_footprint`] but with a **miter** join, so sharp model corners
+/// stay sharp instead of being bevelled by the round offset.  Used only for
+/// "ears" brim corner detection, where a rounded corner would erase the very
+/// feature we are looking for.
+fn object_footprint_sharp(layer: &SliceLayer, d: f64) -> Paths {
+    let outer = Paths::new(
+        layer
+            .paths
+            .iter()
+            .enumerate()
+            .filter(|(i, _)| layer.role_for_path(*i) == ExtrusionRole::OuterWall)
+            .map(|(_, p)| p.clone())
+            .collect(),
+    );
+    if outer.is_empty() {
+        return Paths::default();
+    }
+    let merged = clean_union(outer);
+    offset_join(&merged, d / 2.0, JoinType::Miter)
+}
+
+/// Append a closed loop path to a layer's parallel path arrays.
+fn push_loop(layer: &mut SliceLayer, path: Path, role: ExtrusionRole, width: f64) {
+    if path.len() < 3 {
+        return;
+    }
+    layer.paths.push(path);
+    layer.path_roles.push(role);
+    layer.path_widths.push(Some(width));
+    layer.path_vertex_widths.push(None);
+    layer.path_is_open.push(false);
+}
+
+/// Pad every parallel per-path array on `layer` up to `layer.paths.len()` so a
+/// subsequent prepend keeps all arrays aligned.
+fn normalise(layer: &mut SliceLayer) {
+    let n = layer.paths.len();
+    while layer.path_roles.len() < n {
+        layer.path_roles.push(ExtrusionRole::OuterWall);
+    }
+    while layer.path_widths.len() < n {
+        layer.path_widths.push(None);
+    }
+    while layer.path_vertex_widths.len() < n {
+        layer.path_vertex_widths.push(None);
+    }
+    while layer.path_is_open.len() < n {
+        layer.path_is_open.push(false);
+    }
+}
+
+/// Prepend `additions` (a fully-populated adhesion layer) in front of `layer`'s
+/// existing paths so the adhesion loops print **first**.
+fn prepend(layer: &mut SliceLayer, additions: SliceLayer) {
+    if additions.paths.is_empty() {
+        return;
+    }
+    normalise(layer);
+    let mut paths = additions.paths;
+    let mut roles = additions.path_roles;
+    let mut widths = additions.path_widths;
+    let mut vwidths = additions.path_vertex_widths;
+    let mut is_open = additions.path_is_open;
+
+    for p in layer.paths.iter() {
+        paths.push(p.clone());
+    }
+    roles.extend(layer.path_roles.iter().copied());
+    widths.extend(layer.path_widths.iter().copied());
+    vwidths.extend(layer.path_vertex_widths.iter().cloned());
+    is_open.extend(layer.path_is_open.iter().copied());
+
+    layer.paths = paths;
+    layer.path_roles = roles;
+    layer.path_widths = widths;
+    layer.path_vertex_widths = vwidths;
+    layer.path_is_open = is_open;
+}
+
+/// Concentric offset loops stepping **outward** from `footprint`, keeping only
+/// outer contours.  Loop `k` sits at `start_gap + d/2 + k·d` from the object.
+fn outward_loops(footprint: &Paths, start_gap: f64, count: usize, d: f64) -> Vec<Path> {
+    let mut out = Vec::new();
+    for k in 0..count {
+        let delta = start_gap + d / 2.0 + k as f64 * d;
+        let ring = outer_only(offset(footprint, delta));
+        for c in ring.iter() {
+            if c.len() >= 3 {
+                out.push(c.clone());
+            }
+        }
+    }
+    out
+}
+
+/// Concentric loops stepping **inward** into each hole of `footprint` (inner
+/// brim).  Each hole is treated as its own CCW polygon and deflated.
+fn hole_loops(footprint: &Paths, start_gap: f64, count: usize, d: f64) -> Vec<Path> {
+    let mut out = Vec::new();
+    for hole in footprint.iter().filter(|p| p.signed_area() < 0.0) {
+        // Flip the CW hole to a CCW polygon so a negative offset steps inward.
+        let mut pts: Vec<(f64, f64)> = hole.iter().map(|p| (p.x(), p.y())).collect();
+        pts.reverse();
+        let poly: Path = pts.into();
+        let poly_paths = Paths::new(vec![poly]);
+        for k in 0..count {
+            let delta = -(start_gap + d / 2.0 + k as f64 * d);
+            let ring = offset(&poly_paths, delta);
+            for c in ring.iter() {
+                if c.len() >= 3 {
+                    out.push(c.clone());
+                }
+            }
+        }
+    }
+    out
+}
+
+/// Build a regular polygon approximating a circle of `radius` at `center`.
+fn circle(center: (f64, f64), radius: f64, segments: usize) -> Path {
+    let mut pts = Vec::with_capacity(segments);
+    for i in 0..segments {
+        let a = 2.0 * std::f64::consts::PI * i as f64 / segments as f64;
+        pts.push((center.0 + radius * a.cos(), center.1 + radius * a.sin()));
+    }
+    pts.into()
+}
+
+/// Fill an arbitrary region with concentric loops spaced `d`, from the region
+/// boundary inward.  Used for "ears" brim discs.
+fn concentric_loops(region: &Paths, d: f64, max_loops: usize) -> Vec<Path> {
+    let mut out = Vec::new();
+    let mut inset = d / 2.0;
+    for _ in 0..max_loops {
+        let ring = offset(region, -inset);
+        if ring.is_empty() {
+            break;
+        }
+        for c in ring.iter() {
+            if c.len() >= 3 {
+                out.push(c.clone());
+            }
+        }
+        inset += d;
+    }
+    out
+}
+
+/// Detect sharp convex corners on the outer contours of `footprint`.
+///
+/// A corner is "sharp convex" when the left-turn exterior angle at a vertex of
+/// a CCW contour exceeds `min_turn` radians.  Returns the corner points.
+fn convex_corners(footprint: &Paths, min_turn: f64) -> Vec<(f64, f64)> {
+    let mut corners = Vec::new();
+    for contour in footprint.iter().filter(|p| p.signed_area() > 0.0) {
+        let pts: Vec<(f64, f64)> = contour.iter().map(|p| (p.x(), p.y())).collect();
+        let n = pts.len();
+        if n < 3 {
+            continue;
+        }
+        for i in 0..n {
+            let prev = pts[(i + n - 1) % n];
+            let cur = pts[i];
+            let next = pts[(i + 1) % n];
+            let e1 = (cur.0 - prev.0, cur.1 - prev.1);
+            let e2 = (next.0 - cur.0, next.1 - cur.1);
+            let l1 = (e1.0 * e1.0 + e1.1 * e1.1).sqrt();
+            let l2 = (e2.0 * e2.0 + e2.1 * e2.1).sqrt();
+            if l1 < 1e-6 || l2 < 1e-6 {
+                continue;
+            }
+            let cross = e1.0 * e2.1 - e1.1 * e2.0;
+            let dot = e1.0 * e2.0 + e1.1 * e2.1;
+            // Signed exterior turn angle; positive = left turn = convex on CCW.
+            let signed_turn = cross.atan2(dot);
+            if signed_turn > min_turn {
+                corners.push(cur);
+            }
+        }
+    }
+    corners
+}
+
+/// Generate skirt loops around the object outline on the first `skirt_height`
+/// layers.
+fn generate_skirt(layers: &mut [SliceLayer], params: &SlicingParams, d: f64) {
+    if params.skirt_loops == 0 || layers.is_empty() {
+        return;
+    }
+    let footprint = object_footprint(&layers[0], d);
+    if footprint.is_empty() {
+        return;
+    }
+    let loops = outward_loops(&footprint, params.skirt_distance, params.skirt_loops, d);
+    if loops.is_empty() {
+        return;
+    }
+    let height = params.skirt_height.max(1).min(layers.len());
+    for layer in layers.iter_mut().take(height) {
+        let mut adds = SliceLayer::new(layer.z);
+        // Outermost loop first so the skirt closes toward the object.
+        for path in loops.iter().rev() {
+            push_loop(&mut adds, path.clone(), ExtrusionRole::Skirt, d);
+        }
+        prepend(layer, adds);
+    }
+}
+
+/// Generate brim loops on the first layer per the configured [`BrimType`].
+fn generate_brim(layers: &mut [SliceLayer], params: &SlicingParams, d: f64) {
+    if layers.is_empty() || params.brim_width <= 0.0 {
+        return;
+    }
+    let footprint = object_footprint(&layers[0], d);
+    if footprint.is_empty() {
+        return;
+    }
+    let count = (params.brim_width / d).ceil() as usize;
+    if count == 0 {
+        return;
+    }
+    let sep = params.brim_separation;
+
+    let mut loops: Vec<Path> = Vec::new();
+    match params.brim_type {
+        BrimType::OuterOnly => {
+            loops.extend(outward_loops(&footprint, sep, count, d));
+        }
+        BrimType::InnerOnly => {
+            loops.extend(hole_loops(&footprint, sep, count, d));
+        }
+        BrimType::OuterAndInner => {
+            loops.extend(outward_loops(&footprint, sep, count, d));
+            loops.extend(hole_loops(&footprint, sep, count, d));
+        }
+        BrimType::Ears => {
+            // Detect corners on a sharp (miter) footprint so the round offset
+            // doesn't bevel away the very corners we're looking for.
+            let sharp = object_footprint_sharp(&layers[0], d);
+            // Exterior turn > 60° (π/3) ⇒ interior angle < 120°: a sharp corner.
+            let corners = convex_corners(&sharp, std::f64::consts::FRAC_PI_3);
+            if !corners.is_empty() {
+                let radius = sep + params.brim_width;
+                let discs = Paths::new(corners.iter().map(|&c| circle(c, radius, 48)).collect());
+                let disc_region = clean_union(discs);
+                // Keep only the material outside the object (+ separation).
+                let keepout = offset(&footprint, sep);
+                let ear_region =
+                    difference(disc_region, keepout, FillRule::NonZero).unwrap_or_default();
+                loops.extend(concentric_loops(&ear_region, d, count));
+            }
+        }
+    }
+
+    if loops.is_empty() {
+        return;
+    }
+    let mut adds = SliceLayer::new(layers[0].z);
+    // Outermost first so the brim finishes adjacent to the wall.
+    for path in loops.iter().rev() {
+        push_loop(&mut adds, path.clone(), ExtrusionRole::Skirt, d);
+    }
+    prepend(&mut layers[0], adds);
+}
+
+/// Build the raft: sacrificial base + interface layers under the object, and
+/// return them; the caller shifts the object layers up.
+fn build_raft(object: &[SliceLayer], params: &SlicingParams, d: f64) -> Vec<SliceLayer> {
+    if object.is_empty() {
+        return Vec::new();
+    }
+    let n = if params.raft_layers > 0 {
+        params.raft_layers
+    } else {
+        2
+    };
+    let footprint = object_footprint(&object[0], d);
+    if footprint.is_empty() {
+        return Vec::new();
+    }
+    // Expand the raft outline generously beyond the object for grip.
+    let expansion = (params.brim_width.max(3.0)).max(2.0 * d);
+    let outline = outer_only(offset(&footprint, expansion));
+    if outline.is_empty() {
+        return Vec::new();
+    }
+
+    let lh = params.layer_height;
+    // Density → line spacing maps through the infill module's fixed 0.4 mm ref.
+    let base_spacing = (2.5 * d).max(d);
+    let base_density = (0.4 / base_spacing).clamp(0.05, 1.0);
+    let iface_density = (0.4 / d).clamp(0.05, 1.0);
+
+    let mut raft = Vec::with_capacity(n);
+    for i in 0..n {
+        let z = lh * 0.5 + i as f64 * lh;
+        let mut layer = SliceLayer::new(z);
+        // First layer = coarse base; remaining = finer interface.
+        let (density, angle, width) = if i == 0 {
+            (base_density, 0.0_f64, base_spacing.min(2.0 * d))
+        } else {
+            let a = if i % 2 == 1 {
+                std::f64::consts::FRAC_PI_2
+            } else {
+                0.0
+            };
+            (iface_density, a, d)
+        };
+        let lines = crate::infill::generate_infill(
+            &outline,
+            crate::infill::InfillPattern::Rectilinear,
+            density,
+            angle,
+            z,
+        );
+        for line in lines.iter() {
+            if line.len() < 2 {
+                continue;
+            }
+            layer.paths.push(line.clone());
+            layer.path_roles.push(ExtrusionRole::Support);
+            layer.path_widths.push(Some(width));
+            layer.path_vertex_widths.push(None);
+            layer.path_is_open.push(true);
+        }
+        if !layer.paths.is_empty() {
+            raft.push(layer);
+        }
+    }
+    raft
+}
+
+/// Apply the configured bed-adhesion helper to `layers` in place.
+///
+/// Dispatches on [`SlicingParams::adhesion_type`].  Skirt/brim mutate the first
+/// layer(s); raft prepends new layers and shifts every object layer up by the
+/// raft height plus [`SlicingParams::raft_air_gap`].
+pub fn apply_adhesion(layers: &mut Vec<SliceLayer>, params: &SlicingParams) {
+    let d = if params.nozzle_diameter_mm > 0.0 {
+        params.nozzle_diameter_mm
+    } else {
+        0.4
+    };
+
+    match params.adhesion_type {
+        AdhesionType::None => {}
+        AdhesionType::Skirt => generate_skirt(layers, params, d),
+        AdhesionType::Brim => generate_brim(layers, params, d),
+        AdhesionType::Raft => {
+            let raft = build_raft(layers, params, d);
+            if raft.is_empty() {
+                return;
+            }
+            let raft_height = raft.len() as f64 * params.layer_height;
+            let z_shift = raft_height + params.raft_air_gap.max(0.0);
+            for layer in layers.iter_mut() {
+                layer.z += z_shift;
+            }
+            let mut combined = raft;
+            combined.append(layers);
+            *layers = combined;
+        }
+    }
+}
+
+#[cfg(test)]
+mod tests {
+    use super::*;
+
+    /// A layer with a single 20×20 mm CCW square `OuterWall` centered at origin.
+    fn square_layer(z: f64) -> SliceLayer {
+        let mut layer = SliceLayer::new(z);
+        let sq: Path = vec![(-10.0, -10.0), (10.0, -10.0), (10.0, 10.0), (-10.0, 10.0)].into();
+        layer.paths.push(sq);
+        layer.path_roles.push(ExtrusionRole::OuterWall);
+        layer
+    }
+
+    fn base_params() -> SlicingParams {
+        SlicingParams {
+            nozzle_diameter_mm: 0.4,
+            layer_height: 0.2,
+            adhesion_type: AdhesionType::None,
+            ..Default::default()
+        }
+    }
+
+    #[test]
+    fn skirt_adds_loops_to_first_layer() {
+        let mut layers = vec![square_layer(0.1), square_layer(0.3)];
+        let mut p = base_params();
+        p.adhesion_type = AdhesionType::Skirt;
+        p.skirt_loops = 2;
+        p.skirt_distance = 2.0;
+        p.skirt_height = 1;
+        apply_adhesion(&mut layers, &p);
+        let skirts = layers[0]
+            .path_roles
+            .iter()
+            .filter(|r| **r == ExtrusionRole::Skirt)
+            .count();
+        assert_eq!(skirts, 2, "expected two skirt loops on layer 0");
+        // skirt_height = 1 ⇒ layer 1 untouched.
+        assert!(!layers[1].path_roles.contains(&ExtrusionRole::Skirt));
+        // Skirt loops print first.
+        assert_eq!(layers[0].role_for_path(0), ExtrusionRole::Skirt);
+    }
+
+    #[test]
+    fn skirt_height_spans_multiple_layers() {
+        let mut layers = vec![square_layer(0.1), square_layer(0.3), square_layer(0.5)];
+        let mut p = base_params();
+        p.adhesion_type = AdhesionType::Skirt;
+        p.skirt_loops = 1;
+        p.skirt_height = 2;
+        apply_adhesion(&mut layers, &p);
+        for l in layers.iter().take(2) {
+            assert!(l.path_roles.contains(&ExtrusionRole::Skirt));
+        }
+        assert!(!layers[2].path_roles.contains(&ExtrusionRole::Skirt));
+    }
+
+    #[test]
+    fn brim_outer_adds_expected_loop_count() {
+        let mut layers = vec![square_layer(0.1)];
+        let mut p = base_params();
+        p.adhesion_type = AdhesionType::Brim;
+        p.brim_type = BrimType::OuterOnly;
+        p.brim_width = 2.0; // 2.0 / 0.4 = 5 loops
+        p.brim_separation = 0.0;
+        apply_adhesion(&mut layers, &p);
+        let brim = layers[0]
+            .path_roles
+            .iter()
+            .filter(|r| **r == ExtrusionRole::Skirt)
+            .count();
+        assert_eq!(brim, 5, "expected ceil(2.0/0.4)=5 outer brim loops");
+    }
+
+    #[test]
+    fn raft_prepends_layers_and_shifts_object() {
+        let mut layers = vec![square_layer(0.1), square_layer(0.3)];
+        let mut p = base_params();
+        p.adhesion_type = AdhesionType::Raft;
+        p.raft_layers = 3;
+        p.raft_air_gap = 0.1;
+        let orig_first_z = layers[0].z;
+        apply_adhesion(&mut layers, &p);
+        assert!(layers.len() > 2, "raft layers must be prepended");
+        // Raft base sits on the bed.
+        assert!(layers[0].z < orig_first_z + 1e-9);
+        // Raft uses Support role.
+        assert!(layers[0]
+            .path_roles
+            .iter()
+            .all(|r| *r == ExtrusionRole::Support));
+        // Object layer shifted up by raft height + air gap.
+        let raft_count = layers.len() - 2;
+        let shift = raft_count as f64 * p.layer_height + p.raft_air_gap;
+        let obj_first = &layers[raft_count];
+        assert!((obj_first.z - (orig_first_z + shift)).abs() < 1e-6);
+    }
+
+    #[test]
+    fn brim_ears_stamps_corner_discs() {
+        let mut layers = vec![square_layer(0.1)];
+        let mut p = base_params();
+        p.adhesion_type = AdhesionType::Brim;
+        p.brim_type = BrimType::Ears;
+        p.brim_width = 3.0;
+        apply_adhesion(&mut layers, &p);
+        let ears = layers[0]
+            .path_roles
+            .iter()
+            .filter(|r| **r == ExtrusionRole::Skirt)
+            .count();
+        assert!(
+            ears > 0,
+            "ears brim must stamp loops at the square's corners"
+        );
+    }
+
+    #[test]
+    fn none_is_a_noop() {
+        let mut layers = vec![square_layer(0.1)];
+        let before = layers[0].paths.len();
+        let p = base_params();
+        apply_adhesion(&mut layers, &p);
+        assert_eq!(layers[0].paths.len(), before);
+    }
+}

--- a/src/core/pipeline.rs
+++ b/src/core/pipeline.rs
@@ -446,6 +446,20 @@ pub fn process_mesh(
     crate::flow::compensate(&mut layers, params);
     t_flow.finish();
 
+    // Bed-adhesion helpers (skirt / brim / raft).  Runs after the object's own
+    // toolpaths are fully ordered and flow-compensated so it never perturbs
+    // them: skirt/brim loops are prepended to the first layer(s); raft prepends
+    // sacrificial layers and shifts the object up.
+    if params.adhesion_type != crate::settings::params::AdhesionType::None {
+        let t_adhesion = PhaseTimer::start("Bed Adhesion", logger);
+        logger.log_debug(&format!(
+            "generating bed adhesion ({:?})",
+            params.adhesion_type
+        ));
+        crate::adhesion::apply_adhesion(&mut layers, params);
+        t_adhesion.finish();
+    }
+
     layers
 }
 

--- a/src/lib.rs
+++ b/src/lib.rs
@@ -12,6 +12,8 @@
 //! - User-friendly CLI layer for command-line usage
 
 #[cfg(any(not(target_arch = "wasm32"), feature = "web-slicer"))]
+pub mod adhesion;
+#[cfg(any(not(target_arch = "wasm32"), feature = "web-slicer"))]
 pub mod core;
 #[cfg(any(not(target_arch = "wasm32"), feature = "web-slicer"))]
 pub mod flow;

--- a/src/settings/mod.rs
+++ b/src/settings/mod.rs
@@ -10,7 +10,7 @@ pub mod params;
 pub mod validator;
 
 pub use diff::{compare_settings, SettingsDiff};
-pub use params::{AdhesionType, SupportType};
+pub use params::{AdhesionType, BrimType, SupportType};
 pub use params::{
     AuxFanOverrides, FanConfig, LifecycleMarkerConfig, MeshQuality, ObjectSettings, SlicingParams,
 };

--- a/src/settings/params.rs
+++ b/src/settings/params.rs
@@ -403,13 +403,20 @@ pub enum SupportType {
 /// First-layer bed-adhesion helper.
 ///
 /// Drives skirt / brim / raft generation in [`crate::adhesion`].
+///
+/// The enum default is [`None`](Self::None): a bare
+/// [`SlicingParams::default()`](crate::settings::params::SlicingParams) slice
+/// produces only the object, with no adhesion geometry. Product intent (a skirt
+/// on the standard PLA profile) is expressed by the process profiles in
+/// [`crate::profiles::defaults`], which set `adhesion_type` explicitly, not by
+/// this struct default.
 #[derive(Debug, Clone, Copy, PartialEq, Eq, Default, Serialize, Deserialize, JsonSchema)]
 #[serde(rename_all = "snake_case")]
 pub enum AdhesionType {
     /// No adhesion helper.
+    #[default]
     None,
     /// A loop of filament traced around the object (priming / draft shield).
-    #[default]
     Skirt,
     /// A flat apron fused to the object's first layer for extra bed grip.
     Brim,

--- a/src/settings/params.rs
+++ b/src/settings/params.rs
@@ -402,8 +402,7 @@ pub enum SupportType {
 
 /// First-layer bed-adhesion helper.
 ///
-/// Carried through so profiles can express intent.  Generation of skirt / brim
-/// / raft geometry is not yet implemented — see `TODO(profiles): adhesion`.
+/// Drives skirt / brim / raft generation in [`crate::adhesion`].
 #[derive(Debug, Clone, Copy, PartialEq, Eq, Default, Serialize, Deserialize, JsonSchema)]
 #[serde(rename_all = "snake_case")]
 pub enum AdhesionType {
@@ -416,6 +415,25 @@ pub enum AdhesionType {
     Brim,
     /// A full sacrificial base printed under the object.
     Raft,
+}
+
+/// Where brim material is placed relative to the object footprint.
+///
+/// Consumed by [`crate::adhesion`] when `adhesion_type = brim`.
+#[derive(Debug, Clone, Copy, PartialEq, Eq, Default, Serialize, Deserialize, JsonSchema)]
+#[serde(rename_all = "snake_case")]
+pub enum BrimType {
+    /// Loops around the outer contour of every island (the common case).
+    #[default]
+    OuterOnly,
+    /// Loops inside every hole / concavity only (frees the outer edge, e.g.
+    /// when the outside must stay dimensionally clean).
+    InnerOnly,
+    /// Both outer contours and holes get brim loops.
+    OuterAndInner,
+    /// Small brim discs ("mouse ears") stamped only at sharp convex corners —
+    /// minimal material where warping actually starts.
+    Ears,
 }
 
 /// Parameters that control how a model is sliced and printed.
@@ -1221,25 +1239,67 @@ Caps print speed so the hotend can keep up with the flow.
     pub support_density: f64,
 
     #[schemars(
-        description = "Bed-adhesion helper: `none`, `skirt`, `brim`, or `raft`. Generation pending.",
+        description = "Bed-adhesion helper: `none`, `skirt`, `brim`, or `raft`.",
         extend("x-group" = "Adhesion")
     )]
     #[serde(default)]
     pub adhesion_type: AdhesionType,
 
     #[schemars(
-        description = "Brim width in mm (when `adhesion_type = brim`). Generation pending.",
+        description = "Brim width in mm (when `adhesion_type = brim`).",
         extend("x-group" = "Adhesion")
     )]
     #[serde(default = "SlicingParams::default_brim_width")]
     pub brim_width: f64,
 
     #[schemars(
-        description = "Number of skirt loops (when `adhesion_type = skirt`). Generation pending.",
+        description = "Where brim material is placed: `outer_only`, `inner_only`, `outer_and_inner`, or `ears`.",
+        extend("x-group" = "Adhesion")
+    )]
+    #[serde(default)]
+    pub brim_type: BrimType,
+
+    #[schemars(
+        description = "Gap in mm between the brim and the object's first-layer contour (a.k.a. brim separation / offset). `0` fuses the brim directly onto the wall.",
+        extend("x-group" = "Adhesion")
+    )]
+    #[serde(default = "SlicingParams::default_brim_separation")]
+    pub brim_separation: f64,
+
+    #[schemars(
+        description = "Number of skirt loops (when `adhesion_type = skirt`).",
         extend("x-group" = "Adhesion")
     )]
     #[serde(default = "SlicingParams::default_skirt_loops")]
     pub skirt_loops: usize,
+
+    #[schemars(
+        description = "Gap in mm between the object and the innermost skirt loop.",
+        extend("x-group" = "Adhesion")
+    )]
+    #[serde(default = "SlicingParams::default_skirt_distance")]
+    pub skirt_distance: f64,
+
+    #[schemars(
+        description = "Number of layers the skirt spans (≥1). Values >1 act as a draft shield around the print.",
+        extend("x-group" = "Adhesion")
+    )]
+    #[serde(default = "SlicingParams::default_skirt_height")]
+    pub skirt_height: usize,
+
+    #[schemars(
+        description = "Raft layer count: sacrificial base + interface layers printed under the object (when `adhesion_type = raft`, or any value >0).",
+        extend("x-group" = "Adhesion")
+    )]
+    #[serde(default = "SlicingParams::default_raft_layers")]
+    pub raft_layers: usize,
+
+    #[schemars(
+        description = "Vertical air gap in mm between the top of the raft and the object's first layer (eases raft removal).",
+        extend("x-group" = "Adhesion")
+    )]
+    #[serde(default = "SlicingParams::default_raft_air_gap")]
+    pub raft_air_gap: f64,
 
     #[schemars(
         description = "Iron top surfaces for a smoother finish. Ironing pass pending.",
@@ -1355,7 +1415,13 @@ impl Default for SlicingParams {
             support_density: Self::default_support_density(),
             adhesion_type: AdhesionType::default(),
             brim_width: Self::default_brim_width(),
+            brim_type: BrimType::default(),
+            brim_separation: Self::default_brim_separation(),
             skirt_loops: Self::default_skirt_loops(),
+            skirt_distance: Self::default_skirt_distance(),
+            skirt_height: Self::default_skirt_height(),
+            raft_layers: Self::default_raft_layers(),
+            raft_air_gap: Self::default_raft_air_gap(),
             ironing_enabled: Self::default_ironing_enabled(),
             start_gcode: None,
             end_gcode: None,
@@ -1428,8 +1494,23 @@ impl SlicingParams {
     fn default_brim_width() -> f64 {
         5.0
     }
+    fn default_brim_separation() -> f64 {
+        0.0
+    }
     fn default_skirt_loops() -> usize {
         1
+    }
+    fn default_skirt_distance() -> f64 {
+        2.0
+    }
+    fn default_skirt_height() -> usize {
+        1
+    }
+    fn default_raft_layers() -> usize {
+        0
+    }
+    fn default_raft_air_gap() -> f64 {
+        0.1
     }
     fn default_ironing_enabled() -> bool {
         false
@@ -1446,7 +1527,6 @@ impl SlicingParams {
     /// (future) implementation site.
     ///
     /// Implementation checklist (remove the branch here when each lands):
-    /// - `TODO(profiles): adhesion` — skirt / brim / raft generation.
     /// - `TODO(profiles): ironing` — top-surface ironing pass.
     /// - `TODO(profiles): supports` — support generation (`normal`/`tree`,
     ///   density). Only `support_threshold_angle` is honoured today.
@@ -1454,12 +1534,6 @@ impl SlicingParams {
     /// - `TODO(profiles): multimaterial` — more than one extruder.
     pub fn unsupported_feature_warnings(&self) -> Vec<String> {
         let mut w = Vec::new();
-        if self.adhesion_type != AdhesionType::None {
-            w.push(format!(
-                "adhesion '{:?}' is selected but skirt/brim/raft generation is not yet implemented — ignored",
-                self.adhesion_type
-            ));
-        }
         if self.ironing_enabled {
             w.push(
                 "ironing is enabled but the ironing pass is not yet implemented — ignored".into(),

--- a/tests/adhesion_slice.rs
+++ b/tests/adhesion_slice.rs
@@ -1,0 +1,114 @@
+//! End-to-end verification for bed-adhesion generation (issue #93).
+//!
+//! Mirrors the server slice path (`read_stl` → `process_mesh` →
+//! `GcodeGenerator::generate`) so skirt / brim / raft are exercised exactly as
+//! a remote slice would produce them, then asserts on the emitted G-code.
+
+use std::path::Path;
+
+use slicer_engine::core::process_mesh;
+use slicer_engine::gcode::{GcodeFlavor, GcodeGenerator};
+use slicer_engine::logging::NullLogger;
+use slicer_engine::mesh::io::read_stl;
+use slicer_engine::settings::params::{AdhesionType, BrimType, SlicingParams};
+
+fn cube_params() -> SlicingParams {
+    SlicingParams {
+        layer_height: 0.2,
+        nozzle_diameter_mm: 0.4,
+        top_layers: 3,
+        bottom_layers: 3,
+        infill_density: 0.15,
+        adhesion_type: AdhesionType::None,
+        ..Default::default()
+    }
+}
+
+fn slice_to_gcode(params: &SlicingParams) -> String {
+    let mesh = read_stl(Path::new("tests/fixtures/simple-cube.stl")).expect("load cube fixture");
+    let layers = process_mesh(&mesh, params, &NullLogger);
+    let generator = GcodeGenerator::new(GcodeFlavor::Marlin);
+    generator.generate(&layers, params)
+}
+
+/// Count G-code lines emitted under a given `;TYPE:` role block.
+fn count_role_extrusions(gcode: &str, type_name: &str) -> usize {
+    let mut count = 0;
+    let mut in_block = false;
+    for line in gcode.lines() {
+        if let Some(rest) = line.strip_prefix(";TYPE:") {
+            in_block = rest.trim() == type_name;
+            continue;
+        }
+        if line.starts_with(";TYPE:") {
+            in_block = false;
+        }
+        if in_block && line.starts_with("G1 ") && line.contains('E') {
+            count += 1;
+        }
+    }
+    count
+}
+
+#[test]
+fn skirt_emits_skirt_extrusions() {
+    let mut p = cube_params();
+    p.adhesion_type = AdhesionType::Skirt;
+    p.skirt_loops = 3;
+    p.skirt_distance = 3.0;
+    p.skirt_height = 1;
+    let gcode = slice_to_gcode(&p);
+    assert!(gcode.contains(";TYPE:Skirt"), "skirt must emit ;TYPE:Skirt");
+    assert!(
+        count_role_extrusions(&gcode, "Skirt") >= 3,
+        "expected at least 3 skirt extrusion moves"
+    );
+}
+
+#[test]
+fn brim_outer_emits_more_loops_than_skirt() {
+    let mut p = cube_params();
+    p.adhesion_type = AdhesionType::Brim;
+    p.brim_type = BrimType::OuterOnly;
+    p.brim_width = 4.0; // ~10 loops at 0.4 mm
+    let gcode = slice_to_gcode(&p);
+    assert!(
+        gcode.contains(";TYPE:Skirt"),
+        "brim emits ;TYPE:Skirt lines"
+    );
+    assert!(
+        count_role_extrusions(&gcode, "Skirt") >= 8,
+        "wide brim should emit many loop extrusions"
+    );
+}
+
+#[test]
+fn raft_emits_support_and_lifts_object() {
+    let mut base = cube_params();
+    base.adhesion_type = AdhesionType::None;
+    let no_raft = slice_to_gcode(&base);
+
+    let mut p = cube_params();
+    p.adhesion_type = AdhesionType::Raft;
+    p.raft_layers = 3;
+    p.raft_air_gap = 0.2;
+    let gcode = slice_to_gcode(&p);
+
+    assert!(
+        gcode.contains(";TYPE:Support material"),
+        "raft must emit ;TYPE:Support material"
+    );
+
+    // The raft adds layers, so the total layer count must grow.
+    let count_layers = |g: &str| g.matches(";LAYER_CHANGE").count();
+    assert!(
+        count_layers(&gcode) > count_layers(&no_raft),
+        "raft must add layers below the object"
+    );
+}
+
+#[test]
+fn none_emits_no_adhesion_roles() {
+    let gcode = slice_to_gcode(&cube_params());
+    assert!(!gcode.contains(";TYPE:Skirt"));
+}

--- a/ui/src/app/schema-form/field-exceptions/field-exceptions.ts
+++ b/ui/src/app/schema-form/field-exceptions/field-exceptions.ts
@@ -1,0 +1,63 @@
+import type { InlineNoticeTone } from '../../ui/inline-notice/inline-notice';
+import type { FieldDef } from '../models/field-def';
+
+/**
+ * A contextual notice rendered directly beneath a single field's control.
+ */
+export interface FieldNotice {
+  /** Severity; defaults to `'info'`. */
+  tone?: InlineNoticeTone;
+  /** Optional icon-name override; defaults to the tone's icon. */
+  icon?: string;
+  /** Optional bold lead line. */
+  title?: string;
+  /** Body text. */
+  text: string;
+}
+
+/**
+ * Per-field special-casing that layers **on top of** the widget registry.
+ *
+ * The widget registry ([`resolveWidget`](../field-registry/field-registry.ts))
+ * answers "which control renders this field" and stays deliberately generic.
+ * This registry answers the orthogonal question "does this specific field need
+ * extra treatment" — today only a conditional {@link FieldNotice}, but the shape
+ * leaves room for future exception kinds without touching the widget-choosing
+ * path. Keeping the two concerns in separate maps is what stops either from
+ * accreting special cases.
+ */
+export interface FieldException {
+  /**
+   * Produce a notice to show beneath the field for its current `value`, or
+   * `null` for none. `value` is the field's own value; wire in siblings here if
+   * a future exception needs cross-field conditions.
+   */
+  notice?(value: unknown): FieldNotice | null;
+}
+
+/**
+ * Field-key → exception. Add an entry to give a specific setting bespoke
+ * treatment; every other field is unaffected.
+ */
+export const FIELD_EXCEPTIONS: Record<string, FieldException> = {
+  // Raft shifts the model up in Z (raft height + air gap) and prints a base
+  // beneath it, so the sliced G-code no longer lines up with the object preview.
+  adhesion_type: {
+    notice: (value) =>
+      value === 'raft'
+        ? {
+            tone: 'warning',
+            title: 'Sliced result will differ from the object preview',
+            text:
+              'A raft prints a sacrificial base under the model and lifts it by the raft ' +
+              'height plus the air gap, so the model sits higher in the sliced G-code ' +
+              'preview than it does in the object view.',
+          }
+        : null,
+  },
+};
+
+/** Resolve the notice (if any) that applies to `field` at its current `value`. */
+export function noticeForField(field: FieldDef, value: unknown): FieldNotice | null {
+  return FIELD_EXCEPTIONS[field.key]?.notice?.(value) ?? null;
+}

--- a/ui/src/app/schema-form/field-host/field-host.ts
+++ b/ui/src/app/schema-form/field-host/field-host.ts
@@ -3,6 +3,7 @@ import {
   Component,
   ComponentRef,
   DestroyRef,
+  computed,
   effect,
   inject,
   input,
@@ -12,6 +13,8 @@ import {
   ViewContainerRef,
 } from '@angular/core';
 import { Subscription } from 'rxjs';
+import { InlineNotice } from '../../ui/inline-notice/inline-notice';
+import { noticeForField } from '../field-exceptions/field-exceptions';
 import { resolveWidget } from '../field-registry/field-registry';
 import { FieldDef } from '../models/field-def';
 import { FieldWidget } from '../widgets/base-field';
@@ -22,17 +25,42 @@ import { FieldWidget } from '../widgets/base-field';
  *
  * This approach is required (rather than `NgComponentOutlet`) because
  * `NgComponentOutlet` does not support binding to outputs dynamically.
+ *
+ * Beneath the widget it renders any field-specific {@link noticeForField}
+ * exception (e.g. the raft-adhesion caution) so the note sits directly against
+ * the control it refers to, without the widget-choosing path knowing about it.
  */
 @Component({
   selector: 'se-field-host',
   standalone: true,
+  imports: [InlineNotice],
   changeDetection: ChangeDetectionStrategy.OnPush,
-  template: `<ng-container #host />`,
+  template: `
+    <ng-container #host />
+    @if (notice(); as n) {
+      <nexus-inline-notice
+        class="field-notice"
+        [tone]="n.tone ?? 'info'"
+        [icon]="n.icon"
+        [title]="n.title"
+      >
+        {{ n.text }}
+      </nexus-inline-notice>
+    }
+  `,
+  styles: `
+    .field-notice {
+      margin-top: var(--spacing-sm);
+    }
+  `,
 })
 export class FieldHost {
   readonly field = input.required<FieldDef>();
   readonly value = input<unknown>(undefined);
   readonly fieldChange = output<unknown>();
+
+  /** Field-specific caution/hint to render under the control, if any. */
+  protected readonly notice = computed(() => noticeForField(this.field(), this.value()));
 
   private readonly vcr = viewChild.required('host', { read: ViewContainerRef });
   private readonly destroyRef = inject(DestroyRef);

--- a/ui/src/app/schema-form/schema-form.component.html
+++ b/ui/src/app/schema-form/schema-form.component.html
@@ -70,6 +70,16 @@
                 <nexus-icon [name]="groupIcon" class="schema-form-group-icon" aria-hidden="true" />
               }
               <span class="schema-form-group-title">{{ group.name }}</span>
+              @if (groupsWithNotice().has(group.name)) {
+                <span
+                  class="schema-form-group-notice-hint"
+                  role="img"
+                  aria-label="Some settings in this section may need a second look"
+                  title="Some settings in this section may need a second look"
+                >
+                  <nexus-icon name="warning-triangle" aria-hidden="true" />
+                </span>
+              }
             </span>
             <nexus-icon
               name="nav-arrow-down"

--- a/ui/src/app/schema-form/schema-form.component.scss
+++ b/ui/src/app/schema-form/schema-form.component.scss
@@ -230,6 +230,18 @@
   --icon-size: 16px;
 }
 
+// Neutral "double-check this section" hint on a group that contains an active
+// field notice. Deliberately colour-neutral (not the notice's tone) and held at
+// tertiary even when the header is accented/expanded — it's a calm cue to look,
+// not an alarm; the tone-coloured detail lives on the field notice inside.
+.schema-form-group-notice-hint {
+  display: inline-grid;
+  place-items: center;
+  flex-shrink: 0;
+  color: var(--color-text-tertiary);
+  --icon-size: 15px;
+}
+
 .schema-form-group-chevron {
   flex-shrink: 0;
   color: currentColor;

--- a/ui/src/app/schema-form/schema-form.ts
+++ b/ui/src/app/schema-form/schema-form.ts
@@ -20,6 +20,7 @@ import { KeyboardShortcuts } from '../services/keyboard-shortcuts/keyboard-short
 import { Icon } from '../shared/icon/icon';
 import { UserInputModality } from '../shared/input-modality/input-modality';
 import { FieldHost } from './field-host/field-host';
+import { noticeForField } from './field-exceptions/field-exceptions';
 import { FieldDef, SchemaGroup } from './models/field-def';
 import { parseSchema } from './models/schema-parser';
 
@@ -182,6 +183,23 @@ export class SchemaForm {
   private readonly flatFields = computed<FieldDefIndexed[]>(() =>
     this.allGroups().flatMap((g) => g.fields.map((f) => ({ ...f, groupName: g.name }))),
   );
+
+  /**
+   * Names of groups that currently contain at least one field with an active
+   * {@link noticeForField} exception (given the live values). Drives the neutral
+   * "double-check this section" hint on the accordion header, so a collapsed
+   * group still advertises that something inside wants a second look.
+   */
+  protected readonly groupsWithNotice = computed<ReadonlySet<string>>(() => {
+    const values = this.value();
+    const names = new Set<string>();
+    for (const group of this.allGroups()) {
+      if (group.fields.some((f) => noticeForField(f, values[f.key]) !== null)) {
+        names.add(group.name);
+      }
+    }
+    return names;
+  });
 
   /**
    * Ranked search results when the user has typed a query.

--- a/ui/src/app/ui/index.ts
+++ b/ui/src/app/ui/index.ts
@@ -17,3 +17,5 @@ export type { RadioOption } from './radio-group/radio-group';
 export { Segmented } from './segmented/segmented';
 export type { SegmentOption } from './segmented/segmented';
 export { ColorPicker } from './color-picker/color-picker';
+export { InlineNotice } from './inline-notice/inline-notice';
+export type { InlineNoticeTone } from './inline-notice/inline-notice';

--- a/ui/src/app/ui/inline-notice/inline-notice.scss
+++ b/ui/src/app/ui/inline-notice/inline-notice.scss
@@ -1,0 +1,52 @@
+// Compact inline callout. Tone drives a single --notice-tone custom property
+// that the base rule mixes into the surface, border, and icon colour — so each
+// severity is one line, not a repeated block.
+:host {
+  --notice-tone: var(--color-secondary);
+
+  display: flex;
+  gap: var(--spacing-sm);
+  align-items: flex-start;
+  padding: var(--spacing-sm) var(--spacing-md);
+  border: 1px solid color-mix(in oklab, var(--notice-tone) 28%, transparent);
+  border-radius: var(--radius-md);
+  background: color-mix(in oklab, var(--notice-tone) 8%, var(--color-surface));
+  color: var(--color-text-secondary);
+}
+
+:host(.inline-notice--info) {
+  --notice-tone: var(--color-secondary);
+}
+
+:host(.inline-notice--warning) {
+  --notice-tone: var(--color-warning);
+}
+
+:host(.inline-notice--danger) {
+  --notice-tone: var(--color-danger);
+}
+
+.inline-notice-icon {
+  flex: none;
+  margin-top: 1px;
+  --icon-size: 15px;
+  color: var(--notice-tone);
+}
+
+.inline-notice-body {
+  min-width: 0;
+}
+
+.inline-notice-title {
+  margin: 0 0 2px;
+  font-size: var(--font-size-xs);
+  font-weight: var(--font-weight-semibold);
+  color: var(--color-text-primary);
+}
+
+.inline-notice-text {
+  margin: 0;
+  font-size: var(--font-size-xs);
+  line-height: 1.5;
+  color: var(--color-text-tertiary);
+}

--- a/ui/src/app/ui/inline-notice/inline-notice.ts
+++ b/ui/src/app/ui/inline-notice/inline-notice.ts
@@ -1,0 +1,47 @@
+import { ChangeDetectionStrategy, Component, computed, input } from '@angular/core';
+import { Icon } from '../../shared/icon/icon';
+
+/** Visual severity of an {@link InlineNotice}. */
+export type InlineNoticeTone = 'info' | 'warning' | 'danger';
+
+const TONE_ICONS: Record<InlineNoticeTone, string> = {
+  info: 'info-circle',
+  warning: 'warning-triangle',
+  danger: 'warning-triangle',
+};
+
+/**
+ * Compact inline callout — an icon, an optional bold title, and projected body
+ * text — for surfacing a contextual note or caution next to the controls it
+ * refers to. Sits on a solid tinted surface (no blur), tone-coloured by
+ * severity. Purely presentational: it renders its inputs and nothing else.
+ */
+@Component({
+  selector: 'nexus-inline-notice',
+  imports: [Icon],
+  template: `
+    <nexus-icon class="inline-notice-icon" [name]="resolvedIcon()" aria-hidden="true" />
+    <div class="inline-notice-body">
+      @if (title(); as t) {
+        <p class="inline-notice-title">{{ t }}</p>
+      }
+      <p class="inline-notice-text"><ng-content /></p>
+    </div>
+  `,
+  styleUrl: './inline-notice.scss',
+  host: {
+    role: 'note',
+    '[class]': '"inline-notice inline-notice--" + tone()',
+  },
+  changeDetection: ChangeDetectionStrategy.OnPush,
+})
+export class InlineNotice {
+  /** Severity; drives the accent colour and default icon. */
+  readonly tone = input<InlineNoticeTone>('info');
+  /** Optional icon-name override; defaults to the tone's icon. */
+  readonly icon = input<string>();
+  /** Optional bold lead line above the projected body text. */
+  readonly title = input<string>();
+
+  protected readonly resolvedIcon = computed(() => this.icon() ?? TONE_ICONS[this.tone()]);
+}


### PR DESCRIPTION
## What

Implements bed-adhesion generation (issue #93): **skirt**, **brim**, and **raft**. The `adhesion_type` / `skirt_loops` / `brim_width` fields already existed on `SlicingParams` but nothing was generated — imported values were accepted then ignored. This adds a dedicated `src/adhesion/` module that turns the `AdhesionType` selection (plus new sub-parameters) into geometry.

## How

`apply_adhesion` runs as the **final** stage of `process_mesh` — after wall/surface/infill generation, path ordering, and flow compensation — so it appends adhesion loops cleanly and **never perturbs the object's own toolpaths**.

- **Skirt** — `skirt_loops` outward loops from the object outline, over the first `skirt_height` layers. Role `Skirt`.
- **Brim** — `outer_only` / `inner_only` / `outer_and_inner` offset loops, plus **`ears`** (concentric discs stamped at sharp convex corners, interior angle < 120°). Role `Skirt`.
- **Raft** — coarse base + finer interface layers under the object; the object is shifted up by `raft_layers · layer_height + raft_air_gap`. Role `Support`.

The object footprint is rebuilt from the layer-0 `OuterWall` centerlines (unioned with `NonZero`, inflated `d/2` back to the true surface), **winding preserved** so Clipper2 keeps holes as voids (per the fill-rule contract in AGENTS.md). Ears corner detection uses a **miter** footprint so the round offset doesn't bevel the corners away.

## New parameters

Added to `SlicingParams` (group `Adhesion`):

| param | purpose |
| --- | --- |
| `brim_type` (`BrimType` enum) | `outer_only` / `inner_only` / `outer_and_inner` / `ears` |
| `brim_separation` | gap between brim and object |
| `skirt_distance` | gap between object and innermost skirt loop |
| `skirt_height` | layers the skirt spans (draft-shield) |
| `raft_layers` | base + interface layer count |
| `raft_air_gap` | Z gap between raft top and object |

The `unsupported_feature_warnings` adhesion branch is removed.

## Verification (remote slicing)

Ran the actual WS server slice path (`POST /api/upload` → `Slice` over `/ws` → `GET /api/download`) on `simple-cube.stl` for every adhesion type. Extrusion moves by role:

| config | layers | roles |
| --- | --- | --- |
| none | 5 | Outer wall 31 |
| skirt (3 loops, dist 3) | 5 | **Skirt 96** + walls |
| brim outer+inner (w 4) | 5 | **Skirt 222** + walls |
| brim ears (w 4) | 5 | **Skirt 228** + walls |
| raft (3 layers, gap 0.2) | **8** | **Support 203** + walls |

Geometric checks: skirt bbox −4…5 sits well outside the object walls (0.2…0.8); raft lifts the object's first `Outer wall` from Z 0.1 → 0.9 (= 3·0.2 + 0.2 air gap).

## Tests & docs

- 6 unit tests in `src/adhesion/mod.rs`, 4 end-to-end slice tests in `tests/adhesion_slice.rs`.
- Full suite: 536 lib + all integration tests pass; `cargo fmt` + `clippy` clean on the new code.
- New `src/adhesion/README.md` (Diátaxis Explanation) + AGENTS.md pipeline-order note.

## Reviewer notes

- **Raft reuses the `Support` role** for G-code annotation (avoids touching the viewer's role table). Open question: give raft its own `Raft` role?
- **Raft layers use the global `layer_height`** by design — the G-code generator derives extrusion `E` from it, so a variable base height would mis-estimate flow. Documented as a non-goal.
- **No build-plate bounds clamping** here — that belongs to a bed-aware validation pass, not adhesion.
- Mapping Slic3r/Prusa/Orca import keys (`skirts`, `brim_type`, `raft_layers`, …) onto these fields is **out of scope** — owned by the #92 importer; the target fields now exist.

Closes #93.
