### PR TITLE
ci: universal + signed macOS bundles, MSI-safe version, faster canary

### DIFF
--- a/.github/workflows/canary.yml
+++ b/.github/workflows/canary.yml
@@ -59,6 +59,11 @@ jobs:
             echo "> \`main\` (\`${GITHUB_SHA::7}\`) on every merge. Unstable and"
             echo "> overwritten on every push. For a stable build use a tagged release."
             echo ""
+            echo "> 🍎 **macOS:** this build is unsigned, so Gatekeeper marks the"
+            echo "> downloaded app as \"damaged\". After moving it to Applications,"
+            echo "> clear the quarantine flag once to launch it —"
+            echo "> \`xattr -cr \"/Applications/Slicer Engine Desktop.app\"\`"
+            echo ""
             git log --no-merges --format='- %s (%h)' ${range} | head -n 50
           } >> NOTES.md
           cat NOTES.md
@@ -107,15 +112,30 @@ jobs:
       - uses: dtolnay/rust-toolchain@stable
         with:
           targets: wasm32-unknown-unknown
+      - name: Add macOS universal build targets
+        if: runner.os == 'macOS'
+        run: rustup target add x86_64-apple-darwin aarch64-apple-darwin
       - uses: Swatinem/rust-cache@v2
+        with:
+          # The desktop app is a *separate* Cargo workspace; its target dir was
+          # never cached, so the whole engine recompiled from scratch every run.
+          # Cache both trees (and path-dep crates) so warm runs are minutes faster.
+          workspaces: |
+            . -> target
+            ui-desktop/src-tauri -> target
+          cache-all-crates: "true"
+          cache-on-failure: "true"
       - uses: pnpm/action-setup@v4
       - uses: actions/setup-node@v4
         with:
           node-version: 22
           cache: pnpm
 
+      # Prebuilt binary — compiling wasm-bindgen-cli from source cost minutes.
       - name: Install wasm-bindgen-cli
-        run: cargo install wasm-bindgen-cli --version 0.2.126 --locked
+        uses: taiki-e/install-action@v2
+        with:
+          tool: wasm-bindgen-cli@0.2.126
 
       - name: Install workspace dependencies
         run: pnpm install --frozen-lockfile
@@ -123,25 +143,54 @@ jobs:
       - name: Sync desktop bundle version with the canary version
         shell: bash
         run: |
-          # Tauri requires a plain semver, so strip the build-metadata suffix.
+          # Windows MSI/WiX rejects a non-numeric pre-release identifier
+          # ("canary") and caps it at 65535, so the throwaway canary string
+          # cannot be the *installer* version. Derive a numeric-only
+          # `X.Y.Z-<run>` for bundle metadata; the user-facing version still
+          # comes from SLICER_VERSION baked in at build time.
           version="${{ needs.prepare.outputs.version }}"
-          version="${version%%+*}"
-          node -e "const f='ui-desktop/src-tauri/tauri.conf.json';const c=require('./'+f);c.version=process.argv[1];require('fs').writeFileSync(f,JSON.stringify(c,null,2)+'\n');" "${version}"
+          base="${version%%-*}"
+          bundle_version="${base}-$(( ${{ github.run_number }} % 65536 ))"
+          node -e "const f='ui-desktop/src-tauri/tauri.conf.json';const c=require('./'+f);c.version=process.argv[1];require('fs').writeFileSync(f,JSON.stringify(c,null,2)+'\n');" "${bundle_version}"
 
       - name: Generate WASM bindings and schemas
         run: pnpm run hydrate
 
       - name: Build desktop bundles
-        run: pnpm --filter slicer-ui-desktop build
+        shell: bash
+        env:
+          # Ad-hoc sign by default so the .app carries a valid signature and
+          # launches (after de-quarantine) on Apple Silicon; switch to a real
+          # Developer ID + notarization automatically when these repo secrets
+          # are configured.
+          APPLE_SIGNING_IDENTITY: ${{ secrets.APPLE_SIGNING_IDENTITY || '-' }}
+          APPLE_CERTIFICATE: ${{ secrets.APPLE_CERTIFICATE }}
+          APPLE_CERTIFICATE_PASSWORD: ${{ secrets.APPLE_CERTIFICATE_PASSWORD }}
+          APPLE_ID: ${{ secrets.APPLE_ID }}
+          APPLE_PASSWORD: ${{ secrets.APPLE_PASSWORD }}
+          APPLE_TEAM_ID: ${{ secrets.APPLE_TEAM_ID }}
+        run: |
+          if [[ "$RUNNER_OS" == "macOS" ]]; then
+            # One universal binary so the DMG runs on both Intel and Apple
+            # Silicon (macos-latest runners are arm64-only otherwise).
+            pnpm --filter slicer-ui-desktop exec tauri build --target universal-apple-darwin
+          else
+            pnpm --filter slicer-ui-desktop build
+          fi
 
       - name: Upload desktop bundles to the canary release
         env:
           GH_TOKEN: ${{ github.token }}
         shell: bash
         run: |
-          # macOS ships bash 3.2 (no globstar), so enumerate with find instead
-          # of a `**` glob to stay portable across the macOS and Windows runners.
-          bundle_dir="ui-desktop/src-tauri/target/release/bundle"
+          # macOS bundles land under the universal target triple; other OSes use
+          # the default target dir. macOS ships bash 3.2 (no globstar), so
+          # enumerate with find instead of a `**` glob.
+          if [[ "$RUNNER_OS" == "macOS" ]]; then
+            bundle_dir="ui-desktop/src-tauri/target/universal-apple-darwin/release/bundle"
+          else
+            bundle_dir="ui-desktop/src-tauri/target/release/bundle"
+          fi
           assets=()
           while IFS= read -r asset; do
             assets+=("$asset")

--- a/.github/workflows/release.yml
+++ b/.github/workflows/release.yml
@@ -41,11 +41,29 @@ jobs:
           fi
 
       - name: Extract release notes from CHANGELOG.md
+        env:
+          APPLE_SIGNING_IDENTITY: ${{ secrets.APPLE_SIGNING_IDENTITY }}
         run: |
           if bash scripts/extract-changelog.sh "${{ steps.meta.outputs.version }}" > RELEASE_NOTES.md; then
             echo "Using CHANGELOG.md section for ${{ steps.meta.outputs.version }}"
           else
             echo "No CHANGELOG.md section found — falling back to auto-generated notes." | tee RELEASE_NOTES.md
+          fi
+          # Unsigned macOS bundles are quarantined on download ("damaged"); tell
+          # users how to launch them. Skipped once a real Developer ID is set.
+          if [[ -z "${APPLE_SIGNING_IDENTITY}" ]]; then
+            {
+              echo ""
+              echo "---"
+              echo ""
+              echo "### 🍎 macOS"
+              echo ""
+              echo "This build is unsigned, so macOS Gatekeeper marks the downloaded app as \"damaged\". After moving **Slicer Engine Desktop** to Applications, clear the quarantine flag once to launch it:"
+              echo ""
+              echo '```bash'
+              echo 'xattr -cr "/Applications/Slicer Engine Desktop.app"'
+              echo '```'
+            } >> RELEASE_NOTES.md
           fi
           cat RELEASE_NOTES.md
 
@@ -145,7 +163,18 @@ jobs:
       - uses: dtolnay/rust-toolchain@stable
         with:
           targets: wasm32-unknown-unknown
+      - name: Add macOS universal build targets
+        if: runner.os == 'macOS'
+        run: rustup target add x86_64-apple-darwin aarch64-apple-darwin
       - uses: Swatinem/rust-cache@v2
+        with:
+          # ui-desktop/src-tauri is a *separate* Cargo workspace; cache both
+          # target trees (and path-dep crates) so the desktop build reuses work.
+          workspaces: |
+            . -> target
+            ui-desktop/src-tauri -> target
+          cache-all-crates: "true"
+          cache-on-failure: "true"
       - uses: pnpm/action-setup@v4
       - uses: actions/setup-node@v4
         with:
@@ -159,8 +188,11 @@ jobs:
           sudo apt-get install -y libwebkit2gtk-4.1-dev libappindicator3-dev \
             librsvg2-dev patchelf libgtk-3-dev
 
+      # Prebuilt binary — compiling wasm-bindgen-cli from source cost minutes.
       - name: Install wasm-bindgen-cli
-        run: cargo install wasm-bindgen-cli --version 0.2.126 --locked
+        uses: taiki-e/install-action@v2
+        with:
+          tool: wasm-bindgen-cli@0.2.126
 
       - name: Install workspace dependencies
         run: pnpm install --frozen-lockfile
@@ -168,23 +200,50 @@ jobs:
       - name: Sync desktop bundle version with the tag
         shell: bash
         run: |
+          # Windows MSI/WiX only accepts a numeric-only pre-release identifier,
+          # so strip any `-rc.N` suffix for the *installer* version. The
+          # user-facing version still comes from SLICER_VERSION at build time.
           version="${{ needs.create-release.outputs.version }}"
-          node -e "const f='ui-desktop/src-tauri/tauri.conf.json';const c=require('./'+f);c.version=process.argv[1];require('fs').writeFileSync(f,JSON.stringify(c,null,2)+'\n');" "${version}"
+          bundle_version="${version%%-*}"
+          node -e "const f='ui-desktop/src-tauri/tauri.conf.json';const c=require('./'+f);c.version=process.argv[1];require('fs').writeFileSync(f,JSON.stringify(c,null,2)+'\n');" "${bundle_version}"
 
       - name: Generate WASM bindings and schemas
         run: pnpm run hydrate
 
       - name: Build desktop bundles
-        run: pnpm --filter slicer-ui-desktop build
+        shell: bash
+        env:
+          # Ad-hoc sign by default so the macOS .app launches (after
+          # de-quarantine); switch to real Developer ID + notarization
+          # automatically when these repo secrets are configured.
+          APPLE_SIGNING_IDENTITY: ${{ secrets.APPLE_SIGNING_IDENTITY || '-' }}
+          APPLE_CERTIFICATE: ${{ secrets.APPLE_CERTIFICATE }}
+          APPLE_CERTIFICATE_PASSWORD: ${{ secrets.APPLE_CERTIFICATE_PASSWORD }}
+          APPLE_ID: ${{ secrets.APPLE_ID }}
+          APPLE_PASSWORD: ${{ secrets.APPLE_PASSWORD }}
+          APPLE_TEAM_ID: ${{ secrets.APPLE_TEAM_ID }}
+        run: |
+          if [[ "$RUNNER_OS" == "macOS" ]]; then
+            # One universal binary so the DMG runs on both Intel and Apple
+            # Silicon (macos-latest runners are arm64-only otherwise).
+            pnpm --filter slicer-ui-desktop exec tauri build --target universal-apple-darwin
+          else
+            pnpm --filter slicer-ui-desktop build
+          fi
 
       - name: Upload desktop bundles to release
         env:
           GH_TOKEN: ${{ github.token }}
         shell: bash
         run: |
-          # macOS ships bash 3.2 (no globstar), so enumerate with find instead
-          # of a `**` glob to stay portable across every runner OS.
-          bundle_dir="ui-desktop/src-tauri/target/release/bundle"
+          # macOS bundles land under the universal target triple; other OSes use
+          # the default target dir. macOS ships bash 3.2 (no globstar), so
+          # enumerate with find instead of a `**` glob.
+          if [[ "$RUNNER_OS" == "macOS" ]]; then
+            bundle_dir="ui-desktop/src-tauri/target/universal-apple-darwin/release/bundle"
+          else
+            bundle_dir="ui-desktop/src-tauri/target/release/bundle"
+          fi
           assets=()
           while IFS= read -r asset; do
             assets+=("$asset")

--- a/RELEASING.md
+++ b/RELEASING.md
@@ -151,6 +151,40 @@ bundles.
 
 To publish a *stable*, versioned release, follow the tag-driven flow above.
 
+## macOS bundles & code signing
+
+Both desktop workflows build a **universal** macOS binary
+(`universal-apple-darwin`), so a single `.dmg` runs on Intel *and* Apple Silicon.
+
+By default the app is only **ad-hoc signed** (`APPLE_SIGNING_IDENTITY=-`). That
+is enough to launch it, but because it is not notarized, macOS attaches a
+quarantine flag to the downloaded bundle and Gatekeeper reports the app as
+**"damaged and can't be opened"**. Clearing the flag once fixes it:
+
+```bash
+xattr -cr "/Applications/Slicer Engine Desktop.app"
+```
+
+The canary and release notes already spell this out for users.
+
+### Shipping notarized builds
+
+To give users a clean double-click experience (no `xattr` dance), add these repo
+**secrets** — both workflows detect them automatically and switch from ad-hoc
+signing to real Developer ID signing + notarization:
+
+| Secret                       | What it is                                          |
+| ---------------------------- | --------------------------------------------------- |
+| `APPLE_SIGNING_IDENTITY`     | e.g. `Developer ID Application: Your Name (TEAMID)` |
+| `APPLE_CERTIFICATE`          | base64 of the exported `.p12`                       |
+| `APPLE_CERTIFICATE_PASSWORD` | password for that `.p12`                            |
+| `APPLE_ID`                   | your Apple ID email                                 |
+| `APPLE_PASSWORD`             | an app-specific password for notarization           |
+| `APPLE_TEAM_ID`              | your 10-character Apple Team ID                      |
+
+This requires a paid Apple Developer account. Until those are set, the ad-hoc +
+`xattr` path above is the supported way to run the desktop app.
+
 ## See also
 
 - [`release` skill](.github/skills/release/SKILL.md) — automates this process locally.


### PR DESCRIPTION
## Why

The rolling **canary** was half-broken and slow. From the actual run logs:

- **macOS "broken bundle / won't start"** — the DMG builds fine but is (a) **arm64-only** (macos-latest runners are Apple Silicon) so Intel Macs get nothing, and (b) **unsigned**, so a downloaded app is quarantined and Gatekeeper reports it as *"damaged and can't be opened."*
- **Windows never shipped** — the desktop job failed (~24 min in) with `optional pre-release identifier in app version must be numeric-only … for msi target`. The canary version `0.1.0-canary.<run>` has a non-numeric pre-release (`canary`) that WiX/MSI rejects, so the only asset was the arm64 DMG.
- **Slow** — `wasm-bindgen-cli` was compiled from source every run, and `ui-desktop/src-tauri` is a *separate* Cargo workspace whose `target/` was **never cached**, so the whole engine recompiled from scratch each time.

## What changed (`canary.yml` + `release.yml`)

- **macOS runs everywhere** — build a **universal** binary (`--target universal-apple-darwin`).
- **macOS launches** — ad-hoc sign by default (`APPLE_SIGNING_IDENTITY=-`), auto-upgrading to real Developer ID signing + **notarization** when `APPLE_*` repo secrets are present. Release/canary notes tell users to run `xattr -cr "/Applications/Slicer Engine Desktop.app"` for the unsigned build.
- **Windows ships again** — installer version is sanitized to a numeric-only `X.Y.Z-<run>` (also fixes `-rc.N` release tags). The user-facing version still comes from `SLICER_VERSION`, independent of bundle metadata.
- **Faster** — prebuilt `wasm-bindgen-cli` via `taiki-e/install-action`, and `rust-cache` now caches **both** workspace target trees (`cache-all-crates` + `cache-on-failure`).
- **Docs** — `RELEASING.md` gains a *macOS bundles & code signing* section.

## Notes / trade-offs

- Universal roughly doubles the macOS Rust compile, but caching the desktop workspace (never cached before) more than offsets it on warm runs.
- No Apple Developer account is required to merge this; it ships ad-hoc + `xattr`. Add the `APPLE_*` secrets later for a seamless (notarized) experience.

## Validation

- Both workflows parse as valid YAML; no editor/schema errors.
- Version derivation simulated: `0.1.0-canary.3+sha → 0.1.0-3`, `0.2.0 → 0.2.0`, `0.2.0-rc.1 → 0.2.0` (all MSI-valid).