### PR TITLE
fix(ui): printer connection test and file download in Tauri

### DIFF
--- a/ui-desktop/src-tauri/capabilities/default.json
+++ b/ui-desktop/src-tauri/capabilities/default.json
@@ -17,6 +17,7 @@
     "core:window:allow-is-maximized",
     "core:window:allow-close",
     "dialog:allow-open",
+    "dialog:allow-save",
     "fs:allow-read-file",
     "fs:allow-write-file",
     "fs:allow-mkdir",

--- a/ui/src/app/services/printer-connection.ts
+++ b/ui/src/app/services/printer-connection.ts
@@ -2,6 +2,7 @@ import { Injectable, computed, inject, signal } from '@angular/core';
 import { environment } from '../../environments/environment';
 import type { ClientMessage } from '../../generated/slicer-engine-ws-client-message-v1';
 import type { ServerMessage } from '../../generated/slicer-engine-ws-server-message-v1';
+import { isTauriHost } from '../runtime/domain/runtime-mode.util';
 import type {
   BedShape,
   PrinterConnection,
@@ -163,14 +164,20 @@ export class PrinterConnectionService {
 
     this.setStatus(printer.id, { state: 'checking', label: 'Checking…' });
 
-    // In cloud mode the server always performs the probe (no CORS). If the
-    // WebSocket isn't up yet, stay in `checking` — a reconnect-driven re-probe
-    // (see the home dashboard effect) will pick it up rather than falling back
-    // to a CORS-prone browser request.
-    if (environment.runtimeMode === 'cloud') {
-      if (this.ws.isConnected()) {
-        this.sendWs({ type: 'CheckPrinter', printer_id: printer.id, connection });
-      }
+    // Prefer the server-side probe (no CORS), exactly like {@link
+    // detectPrinter} and {@link sendToPrinter}. `canUseServer()` (not the raw
+    // `cloud` environment constant) correctly detects Tauri at runtime: the
+    // desktop build also ships the `cloud` environment but its WebSocket never
+    // connects, so checking the constant alone used to leave native `check()`
+    // silently doing nothing instead of falling back to a browser probe.
+    if (this.canUseServer()) {
+      this.sendWs({ type: 'CheckPrinter', printer_id: printer.id, connection });
+      return;
+    }
+    if (environment.runtimeMode === 'cloud' && !isTauriHost()) {
+      // WebSocket isn't up yet — stay in `checking`; a reconnect-driven
+      // re-probe (see the home dashboard effect) will pick it up rather than
+      // falling back to a CORS-prone browser request.
       return;
     }
 
@@ -516,7 +523,7 @@ export class PrinterConnectionService {
 
   /** True when the cloud WebSocket is connected and usable for RPC. */
   private canUseServer(): boolean {
-    return environment.runtimeMode === 'cloud' && this.ws.isConnected();
+    return environment.runtimeMode === 'cloud' && !isTauriHost() && this.ws.isConnected();
   }
 
   private sendWs(msg: ClientMessage): void {

--- a/ui/src/app/services/slicer.ts
+++ b/ui/src/app/services/slicer.ts
@@ -1,3 +1,5 @@
+import { save } from '@tauri-apps/plugin-dialog';
+import { writeFile } from '@tauri-apps/plugin-fs';
 import { Injectable, computed, inject, signal } from '@angular/core';
 import { environment } from '../../environments/environment';
 import { SlicingParams } from '../../generated/slicer-engine-ws-client-message-v1';
@@ -356,12 +358,7 @@ export class Slicer {
     if (!url) {
       return;
     }
-    const filename =
-      this.selectedFile()?.name.replace(/\.(stl|obj|3mf)$/i, '.gcode') ?? 'output.gcode';
-    const link = document.createElement('a');
-    link.href = url;
-    link.download = filename;
-    link.click();
+    void this.downloadFromUrl(url, this.selectedFile()?.name ?? undefined);
   }
 
   selectFile(file: File): void {
@@ -593,7 +590,7 @@ export class Slicer {
     if (!session.download_url) {
       const preview = await this.orchestrator.getPreviewSource(session.request_uuid);
       if (preview.kind === 'download-url') {
-        this.downloadFromUrl(preview.url, session.original_filename ?? undefined);
+        await this.downloadFromUrl(preview.url, session.original_filename ?? undefined);
         return;
       }
       if (preview.kind === 'gcode-inline') {
@@ -602,7 +599,7 @@ export class Slicer {
             type: 'text/plain;charset=utf-8',
           }),
         );
-        this.downloadFromUrl(url, session.original_filename ?? undefined);
+        await this.downloadFromUrl(url, session.original_filename ?? undefined);
         URL.revokeObjectURL(url);
         return;
       }
@@ -613,13 +610,40 @@ export class Slicer {
       return;
     }
 
-    this.downloadFromUrl(session.download_url, session.original_filename ?? undefined);
+    await this.downloadFromUrl(session.download_url, session.original_filename ?? undefined);
   }
 
-  private downloadFromUrl(url: string, originalFilename?: string): void {
+  private async downloadFromUrl(url: string, originalFilename?: string): Promise<void> {
     const filename =
       (originalFilename as string | null | undefined)?.replace(/\.(stl|obj|3mf)$/i, '.gcode') ??
       'output.gcode';
+
+    if (this.runtimeMode === 'native') {
+      // Tauri's webview does not reliably honour `<a download>` against a
+      // custom `asset://` URL (it's meant for `<img>`/`<video>` src, not
+      // forcing a save) — depending on OS/WebView the link just navigates or
+      // is silently ignored instead of prompting a save. Use the native
+      // "Save As" dialog + filesystem write instead: fetch the bytes (works
+      // for both `asset://` URLs and blob URLs) and write them to the
+      // user-chosen path.
+      try {
+        const destination = await save({
+          defaultPath: filename,
+          filters: [{ name: 'G-code', extensions: ['gcode', 'gco', 'g'] }],
+        });
+        if (!destination) {
+          return; // user cancelled the dialog
+        }
+        const bytes = new Uint8Array(await (await fetch(url)).arrayBuffer());
+        await writeFile(destination, bytes);
+        this.notifications.success('Saved', `G-code saved to ${destination}`);
+      } catch (error) {
+        const message = error instanceof Error ? error.message : String(error);
+        this.notifications.error('Save failed', message);
+      }
+      return;
+    }
+
     const link = document.createElement('a');
     link.href = url;
     link.download = filename;


### PR DESCRIPTION
## Fixes

Resolves two critical bugs in the desktop Tauri build affecting printer connectivity and file downloads:

### Bug 1: Printer "Test connection" doesn't work
In Settings → Printers and the printer setup wizard, clicking "Test connection" silently does nothing in the Tauri desktop build.

**Root cause**: The desktop build ships the `cloud` environment file and only becomes native by detecting Tauri at runtime. The `check()` method in `PrinterConnectionService` gated on the raw `environment.runtimeMode === 'cloud'` build-time constant, which is always `'cloud'` even in Tauri. This made the check take the WebSocket branch, where the connection never succeeds (because `SlicerConnection` correctly disables WS in Tauri), resulting in a silent no-op instead of falling back to the working direct browser probe.

**Fix**: Use the Tauri-aware `canUseServer()` method instead of the raw environment constant. Updated `canUseServer()` to check `isTauriHost()` to correctly exclude Tauri from the cloud transport path, allowing Tauri to fall through to `probeFromBrowser()`/`detectFromBrowser()` as intended.

### Bug 2: File download broken in Tauri
Clicking the "Download" button for G-code in the Tauri desktop app produces no result.

**Root cause**: The implementation uses `<a download>` clicks against Tauri's custom `asset://` protocol URLs. This pattern is unreliable across OS/WebView combinations — the protocol is meant for `<img>`/`<video>` src, not forcing native saves. Depending on platform, the link either just navigates to the file or is silently ignored.

**Fix**: Implement a native flow for Tauri using `@tauri-apps/plugin-dialog`'s `save()` to open a native Save-As dialog, then fetch the G-code bytes and write them to the chosen path via `@tauri-apps/plugin-fs`'s `writeFile()`. Added the missing `dialog:allow-save` permission to the Tauri capabilities manifest. The browser download path remains unchanged for cloud/web builds.

## Changes
- **ui/src/app/services/printer-connection.ts**: Import `isTauriHost`, fix `check()` and `canUseServer()` to use Tauri-aware runtime detection
- **ui/src/app/services/slicer.ts**: Import `save`/`writeFile`, implement native download flow for Tauri runtime
- **ui-desktop/src-tauri/capabilities/default.json**: Add `dialog:allow-save` permission

## Verification
- ✅ TypeScript compiles (`tsc --noEmit`)
- ✅ No new type errors introduced
- ✅ Rust printer tests pass (`cargo test --lib printer`)
- ✅ Code formatting clean (`prettier`)
