### PR TITLE
fix(printer): use the OS network line in desktop mode (no CORS)

### DIFF
--- a/AGENTS.md
+++ b/AGENTS.md
@@ -276,14 +276,30 @@ user-facing version number.
 
 [src/printer/](src/printer/) is the **native-only** (`cfg(not(target_arch = "wasm32"))`)
 outbound transport to real printers. Today it implements **Moonraker/Klipper**
-(`check_status`, `send_gcode`) over `reqwest`.
+(`check_status`, `detect_printer`, `send_gcode`) over `reqwest`. It is reached by
+**both** native runtimes over the OS network line — never the browser:
 
-- **Prefer slicer → printer, not browser → printer.** Probes and uploads run
-  server-side (WS `CheckPrinter` / `SendToPrinter` → `PrinterStatus` /
-  `PrinterSendResult`) precisely so they are **not subject to CORS** — Moonraker
+- **Cloud** `serve` WebSocket: `CheckPrinter` / `DetectPrinter` / `SendToPrinter`.
+- **Desktop** Tauri commands: `printer_check` / `printer_detect` / `printer_send`
+  ([ui-desktop/src-tauri/src/commands.rs](ui-desktop/src-tauri/src/commands.rs)),
+  which call the same `crate::printer` functions in-process. Their result types
+  (`PrinterStatusReport`, `PrinterDetection`, `SendOutcome`) are `Serialize`d to
+  the **same field shape** as the WS `PrinterStatus` / `PrinterDetected` /
+  `PrinterSendResult` payloads (minus the envelope), so the UI reuses one set of
+  `fromServer*` mappers for both transports.
+
+- **Prefer slicer → printer, not browser → printer.** Probes and uploads run in
+  the native process precisely so they are **not subject to CORS** — Moonraker
   ships no permissive `Access-Control-*` headers, so a direct browser `fetch`
-  fails for most users. The wasm/`web` build has no native transport and falls
-  back to a browser `fetch`; the UI ([printer-connection.ts](ui/src/app/services/printer-connection.ts))
+  fails for most users. Only the pure wasm/`web` build has no native transport
+  and falls back to a browser `fetch`; the UI
+  ([printer-connection.ts](ui/src/app/services/printer-connection.ts)) picks the
+  transport at runtime — cloud WS when connected, Tauri commands when
+  `isTauriHost()`, browser `fetch` only in `web`. **Do not gate on
+  `environment.runtimeMode` alone**: the desktop build ships the `cloud`
+  environment and only becomes native by detecting Tauri at runtime, so a
+  build-time constant would send the desktop app down the CORS-prone browser
+  path (the bug this contract exists to prevent). The web fallback still
   distinguishes *unreachable* from *reachable-but-CORS-blocked* (via a `no-cors`
   follow-up probe) and surfaces a distinct `cors` status instead of a misleading
   green/offline dot.

--- a/src/printer/mod.rs
+++ b/src/printer/mod.rs
@@ -20,13 +20,19 @@
 use std::path::Path;
 use std::time::Duration;
 
+use serde::Serialize;
+
 use crate::profiles::printer::{BedShape, PrinterConnection, PrinterConnectionKind};
 
 /// How long to wait for a printer to answer before declaring it offline.
 const REQUEST_TIMEOUT: Duration = Duration::from_secs(5);
 
 /// A point-in-time snapshot of a printer's reachability and job state.
-#[derive(Debug, Clone, Default)]
+///
+/// Serializes to the same field shape as the WS `PrinterStatus` payload (minus
+/// the `printer_id` envelope) so the native Tauri `printer_check` command and
+/// the cloud WebSocket probe hand the UI an identical object.
+#[derive(Debug, Clone, Default, Serialize)]
 pub struct PrinterStatusReport {
     /// The host answered a status query.
     pub online: bool,
@@ -51,7 +57,7 @@ impl PrinterStatusReport {
 }
 
 /// Outcome of an upload/print request.
-#[derive(Debug, Clone)]
+#[derive(Debug, Clone, Serialize)]
 pub struct SendOutcome {
     /// Human-readable summary for the UI.
     pub message: String,
@@ -65,7 +71,11 @@ pub struct SendOutcome {
 /// gracefully. A `reachable: false` result still carries a `message` explaining
 /// why. When `kind` is identified but hardware fields are absent (OctoPrint /
 /// PrusaLink), the wizard can still pre-select the transport and host.
-#[derive(Debug, Clone, Default)]
+///
+/// Serializes to the same field shape as the WS `PrinterDetected` payload
+/// (minus the `host` envelope) so the native Tauri `printer_detect` command and
+/// the cloud WebSocket probe hand the UI an identical object.
+#[derive(Debug, Clone, Default, Serialize)]
 pub struct PrinterDetection {
     /// The host answered at least one probe.
     pub reachable: bool,

--- a/ui-desktop/src-tauri/src/commands.rs
+++ b/ui-desktop/src-tauri/src/commands.rs
@@ -1,7 +1,8 @@
-use serde_json::Value;
+use serde_json::{json, Value};
 use tauri::State;
 
 use crate::bridge::runtime_bridge::AppState;
+use slicer_engine::profiles::PrinterConnection;
 
 #[tauri::command]
 pub fn runtime_init(state: State<'_, AppState>) -> Result<Value, String> {
@@ -71,4 +72,64 @@ pub fn profiles_save_category(kind: String, items: Value) -> Result<Value, Strin
         .replace_category(parsed, items)
         .map_err(|e| e.to_string())?;
     serde_json::to_value(library).map_err(|e| e.to_string())
+}
+
+// ── Printer transport ─────────────────────────────────────────────────────────
+//
+// The desktop runtime talks to printers **from this native process** using the
+// OS network stack (`slicer_engine::printer`, backed by `reqwest`), exactly
+// like the cloud `serve` WebSocket. This is what keeps printer probes/uploads
+// **off the browser `fetch` path**, which Moonraker (Klipper) blocks via CORS —
+// so the desktop app reports honest online/offline status instead of a
+// misleading "blocked (CORS)".
+
+/// Probe a printer connection and return its live status (same JSON shape as the
+/// cloud WS `PrinterStatus` payload, minus the `printer_id` envelope).
+#[tauri::command]
+pub async fn printer_check(connection: PrinterConnection) -> Result<Value, String> {
+    let report = slicer_engine::printer::check_status(&connection).await;
+    serde_json::to_value(report).map_err(|e| e.to_string())
+}
+
+/// Probe a single host to identify a printer and prefill the setup wizard (same
+/// JSON shape as the cloud WS `PrinterDetected` payload, minus the `host`).
+#[tauri::command]
+pub async fn printer_detect(host: String) -> Result<Value, String> {
+    let detection = slicer_engine::printer::detect_printer(&host).await;
+    serde_json::to_value(detection).map_err(|e| e.to_string())
+}
+
+/// Upload the most recently sliced G-code to a printer, optionally starting the
+/// print. The desktop runtime is single-active-slice, so the authoritative
+/// source is `AppState::last_gcode_path`.
+#[tauri::command]
+pub async fn printer_send(
+    state: State<'_, AppState>,
+    connection: PrinterConnection,
+    filename: Option<String>,
+    start: bool,
+) -> Result<Value, String> {
+    let gcode_path = state
+        .last_gcode_path
+        .lock()
+        .map_err(|e| e.to_string())?
+        .clone()
+        .ok_or_else(|| "No sliced G-code found for this scene — slice it first".to_string())?;
+
+    let path = std::path::PathBuf::from(&gcode_path);
+    let name = filename.unwrap_or_else(|| {
+        path.file_name()
+            .and_then(|n| n.to_str())
+            .unwrap_or("print.gcode")
+            .to_string()
+    });
+
+    match slicer_engine::printer::send_gcode(&connection, &path, &name, start).await {
+        Ok(outcome) => Ok(json!({
+            "ok": true,
+            "message": outcome.message,
+            "started": outcome.started,
+        })),
+        Err(e) => Ok(json!({ "ok": false, "message": e, "started": false })),
+    }
 }

--- a/ui-desktop/src-tauri/src/main.rs
+++ b/ui-desktop/src-tauri/src/main.rs
@@ -38,6 +38,9 @@ fn main() {
             commands::get_system_accent,
             commands::profiles_load,
             commands::profiles_save_category,
+            commands::printer_check,
+            commands::printer_detect,
+            commands::printer_send,
         ])
         .run(tauri::generate_context!())
         .expect("failed to run desktop runtime");

--- a/ui/src/app/services/printer-connection.ts
+++ b/ui/src/app/services/printer-connection.ts
@@ -100,15 +100,17 @@ const DETECT_TIMEOUT_MS = 15_000;
 /**
  * Tracks live printer connectivity and drives "send to printer".
  *
- * **Transport preference (matches the engine's SSOT):** when the cloud
- * WebSocket is available, probes and uploads are performed **server-side**
- * (`CheckPrinter` / `SendToPrinter`). This is preferred because the request
- * originates from the slicer process, not the browser, so it is **not subject
- * to CORS** — Moonraker ships no permissive CORS headers, so a direct browser
- * request fails for most users.
+ * **Transport preference (matches the engine's SSOT):** always talk to the
+ * printer over the OS network line, never the browser, whenever one is
+ * available. When the cloud WebSocket is up, probes/uploads run **server-side**
+ * (`CheckPrinter` / `SendToPrinter`); in the desktop app they run **in the
+ * native process** via Tauri commands (`printer_check` / `printer_detect` /
+ * `printer_send`). Both are preferred because the request originates from the
+ * slicer, not the browser, so it is **not subject to CORS** — Moonraker ships
+ * no permissive CORS headers, so a direct browser request fails for most users.
  *
- * When no WebSocket is available (the wasm/`web` build), the service falls back
- * to a direct browser `fetch`. That path is expected to hit CORS for many
+ * Only the pure wasm/`web` build has no OS network line; there the service falls
+ * back to a direct browser `fetch`. That path is expected to hit CORS for many
  * hosts; rather than reporting a misleading "offline", it distinguishes a
  * genuinely unreachable host from a reachable-but-CORS-blocked one (via a
  * follow-up `no-cors` probe) and surfaces an actionable `cors` state.
@@ -169,19 +171,26 @@ export class PrinterConnectionService {
     // `cloud` environment constant) correctly detects Tauri at runtime: the
     // desktop build also ships the `cloud` environment but its WebSocket never
     // connects, so checking the constant alone used to leave native `check()`
-    // silently doing nothing instead of falling back to a browser probe.
+    // silently doing nothing instead of using the native transport.
     if (this.canUseServer()) {
       this.sendWs({ type: 'CheckPrinter', printer_id: printer.id, connection });
       return;
     }
-    if (environment.runtimeMode === 'cloud' && !isTauriHost()) {
+    // Native desktop (Tauri): probe from the engine process over the OS network
+    // stack (no browser CORS), mirroring the cloud WebSocket probe.
+    if (isTauriHost()) {
+      void this.probeViaNative(printer.id, connection);
+      return;
+    }
+    if (environment.runtimeMode === 'cloud') {
       // WebSocket isn't up yet — stay in `checking`; a reconnect-driven
       // re-probe (see the home dashboard effect) will pick it up rather than
       // falling back to a CORS-prone browser request.
       return;
     }
 
-    // Non-cloud (wasm/web, native): probe directly from the browser.
+    // Pure web (wasm) build: no OS network line available, so probe directly
+    // from the browser and honestly surface CORS when it blocks us.
     void this.probeFromBrowser(printer.id, connection);
   }
 
@@ -207,7 +216,20 @@ export class PrinterConnectionService {
     if (this.canUseServer()) {
       return this.detectViaServer(trimmed);
     }
-    return this.detectFromBrowser(trimmed);
+    if (isTauriHost()) {
+      return this.detectViaNative(trimmed);
+    }
+    if (environment.runtimeMode === 'web') {
+      return this.detectFromBrowser(trimmed);
+    }
+    // Cloud build whose WebSocket isn't connected yet — don't fall back to a
+    // CORS-prone browser probe that would misreport a reachable printer.
+    return Promise.resolve({
+      host: trimmed,
+      reachable: false,
+      kind: 'none',
+      message: 'Not connected to the slicer yet — try again in a moment.',
+    });
   }
 
   /**
@@ -241,10 +263,17 @@ export class PrinterConnectionService {
       return;
     }
 
-    // Browser fallback: this reads the sliced G-code from the server's download
-    // endpoint and pushes it to the printer directly. Only viable when a
-    // download URL exists and the printer permits CORS — otherwise it fails the
-    // same way a browser probe does.
+    // Native desktop (Tauri): upload from the engine process over the OS network
+    // stack (no browser CORS), mirroring the cloud WebSocket upload.
+    if (isTauriHost()) {
+      this.beginSendProgress(printer, requestUuid);
+      void this.sendViaNative(printer, requestUuid, connection, options);
+      return;
+    }
+
+    // Browser fallback (pure web build): pushing to the printer directly is
+    // blocked the same way a browser probe is (CORS). Use the desktop app or the
+    // local/cloud server instead.
     this.notifications.error(
       'Direct send unavailable',
       'Sending to a printer from the browser is blocked by CORS. Use the desktop app or the local server to send prints.',
@@ -526,6 +555,78 @@ export class PrinterConnectionService {
     return environment.runtimeMode === 'cloud' && !isTauriHost() && this.ws.isConnected();
   }
 
+  // ── native (Tauri) transport ──────────────────────────────────────────────
+  //
+  // The desktop app probes/uploads from the engine process over the OS network
+  // stack (`slicer_engine::printer`, via `reqwest`) — the same code path as the
+  // cloud WebSocket — so it is **not** subject to browser CORS. Each command
+  // returns the same field shape as the corresponding WS server message (minus
+  // its envelope), so the existing `fromServer*` mappers are reused verbatim.
+
+  /** Invoke a Tauri command; resolves `null` if the bridge is unavailable. */
+  private async invokeNative<T>(command: string, args: Record<string, unknown>): Promise<T | null> {
+    try {
+      const { invoke } = await import('@tauri-apps/api/core');
+      return await invoke<T>(command, args);
+    } catch {
+      return null;
+    }
+  }
+
+  /** Native equivalent of {@link probeFromBrowser} — no CORS. */
+  private async probeViaNative(printerId: string, connection: PrinterConnection): Promise<void> {
+    const report = await this.invokeNative<NativeStatusReport>('printer_check', { connection });
+    if (!report) {
+      this.setStatus(printerId, {
+        state: 'error',
+        label: 'Error',
+        message: 'Could not reach the desktop runtime to check the printer.',
+        checkedAt: Date.now(),
+      });
+      return;
+    }
+    this.setStatus(
+      printerId,
+      this.fromServerStatus({ type: 'PrinterStatus', printer_id: printerId, ...report }),
+    );
+  }
+
+  /** Native equivalent of {@link detectFromBrowser} — no CORS. */
+  private async detectViaNative(host: string): Promise<PrinterDetectionResult> {
+    const detection = await this.invokeNative<NativeDetection>('printer_detect', { host });
+    if (!detection) {
+      return {
+        host,
+        reachable: false,
+        kind: 'none',
+        message: 'Could not reach the desktop runtime to probe the printer.',
+      };
+    }
+    return this.fromServerDetection({ type: 'PrinterDetected', host, ...detection });
+  }
+
+  /** Native equivalent of the server-side upload — no CORS. */
+  private async sendViaNative(
+    printer: PrinterProfile,
+    requestUuid: string,
+    connection: PrinterConnection,
+    options: { filename?: string; start?: boolean },
+  ): Promise<void> {
+    const result = await this.invokeNative<NativeSendResult>('printer_send', {
+      connection,
+      filename: options.filename ?? null,
+      start: options.start ?? false,
+    });
+    this.finishSend({
+      type: 'PrinterSendResult',
+      printer_id: printer.id,
+      request_uuid: requestUuid,
+      ok: result?.ok ?? false,
+      message: result?.message ?? 'Could not reach the desktop runtime to send the print.',
+      started: result?.started ?? false,
+    });
+  }
+
   private sendWs(msg: ClientMessage): void {
     this.ws.send(msg);
   }
@@ -627,6 +728,39 @@ interface MoonrakerQueryResponse {
       display_status?: { progress?: number };
     };
   };
+}
+
+/** JSON from the native `printer_check` command (WS `PrinterStatus` minus envelope). */
+interface NativeStatusReport {
+  online: boolean;
+  state?: string | null;
+  print_state?: string | null;
+  progress?: number | null;
+  message?: string | null;
+}
+
+/** JSON from the native `printer_detect` command (WS `PrinterDetected` minus envelope). */
+interface NativeDetection {
+  reachable: boolean;
+  kind: PrinterConnectionKind;
+  message?: string | null;
+  name?: string | null;
+  model?: string | null;
+  vendor?: string | null;
+  firmware?: string | null;
+  bed_shape?: BedShape | null;
+  bed_width?: number | null;
+  bed_depth?: number | null;
+  bed_height?: number | null;
+  origin_at_center?: boolean | null;
+  nozzle_diameter_mm?: number | null;
+}
+
+/** JSON from the native `printer_send` command (WS `PrinterSendResult` minus envelope). */
+interface NativeSendResult {
+  ok: boolean;
+  message: string;
+  started: boolean;
 }
 
 interface MoonrakerInfoResponse {


### PR DESCRIPTION
## Problem

Printer connectivity falsely reported **"Blocked (CORS)"** where it shouldn't — in the desktop (Tauri) app the status dot and connection test failed even for perfectly reachable printers.

[#157](https://github.com/max-scopp/slicer-engine/pull/157) made native `check()` / `detectPrinter()` / `sendToPrinter()` fall through to a direct browser `fetch`. But Moonraker/Klipper ships no permissive `Access-Control-*` headers, so that request is blocked by the browser — *even though the printer is perfectly reachable over the OS network stack the slicer already runs on.* The whole point of the engine's SSOT contract is to talk to printers from the native process, not the browser.

## Fix

Route the desktop app through the native process, exactly like the cloud `serve` WebSocket already does:

- **New Tauri commands** `printer_check` / `printer_detect` / `printer_send` ([`ui-desktop/src-tauri/src/commands.rs`](ui-desktop/src-tauri/src/commands.rs)) that call the same `crate::printer` functions in-process — `reqwest` over the OS network line, **not subject to CORS**.
- **`Serialize` derived** on `PrinterStatusReport`, `PrinterDetection`, and `SendOutcome` so the commands emit the same field shape as the WS `PrinterStatus` / `PrinterDetected` / `PrinterSendResult` payloads. The UI reuses its existing `fromServer*` mappers for both transports.
- **Runtime transport selection** in [`printer-connection.ts`](ui/src/app/services/printer-connection.ts): cloud WS when connected → Tauri commands when `isTauriHost()` → browser `fetch` only in the pure `web` build (where the honest *unreachable-vs-CORS* distinction still applies). Gating on `environment.runtimeMode` alone is explicitly avoided — the desktop build ships the `cloud` environment and only becomes native by detecting Tauri at runtime.

## Verification

Reproduced in **cloud mode via the browser** against a headerless mock Moonraker:

- Direct browser `fetch` → **CORS-blocked** (`TypeError: Failed to fetch`), `no-cors` follow-up returns opaque (host reachable) — i.e. exactly the false-CORS condition.
- Server-side probe over WS → printer reports **Online**.

The native commands wrap the same engine functions, confirmed returning the expected JSON against the mock:

```
check_status: {"online":true,"state":"ready","print_state":"standby","progress":0.0,...}
detect:       {"reachable":true,"kind":"moonraker","name":"mock-klipper","bed_width":220.0,...}
```

- `cargo test --lib printer` — 8/8 pass
- Engine lib + Tauri desktop crate build clean (`cargo clippy` no warnings on the desktop crate)
- UI typechecks and production-builds