### PR TITLE
fix(ci): keep canary bundles downloadable and fix macOS launch

### DIFF
--- a/.github/workflows/canary.yml
+++ b/.github/workflows/canary.yml
@@ -59,9 +59,12 @@ jobs:
             echo "> \`main\` (\`${GITHUB_SHA::7}\`) on every merge. Unstable and"
             echo "> overwritten on every push. For a stable build use a tagged release."
             echo ""
-            echo "> 🍎 **macOS:** this build is unsigned, so Gatekeeper marks the"
-            echo "> downloaded app as \"damaged\". After moving it to Applications,"
-            echo "> clear the quarantine flag once to launch it —"
+            echo "> 🍎 **macOS:** this build is unsigned (no paid Apple"
+            echo "> Developer ID), so Gatekeeper marks the downloaded app as"
+            echo "> \"damaged\" — **right-click → Open will not clear this**. Drag"
+            echo "> **Slicer Engine Desktop** to Applications, then run this once"
+            echo "> in Terminal to strip the quarantine flag and launch it:"
+            echo ">"
             echo "> \`xattr -cr \"/Applications/Slicer Engine Desktop.app\"\`"
             echo ""
             git log --no-merges --format='- %s (%h)' ${range} | head -n 50
@@ -74,16 +77,17 @@ jobs:
         run: |
           title="Canary (${{ steps.meta.outputs.version }})"
           if gh release view "${CANARY_TAG}" >/dev/null 2>&1; then
-            # Move the rolling tag to this commit, refresh notes, and clear the
-            # stale bundles so only the current build's assets remain.
+            # Move the rolling tag to this commit and refresh the notes only.
+            # Deliberately do NOT wipe the existing assets here: the upload step
+            # re-uploads each bundle under a stable, version-less name with
+            # --clobber, overwriting it in place once the new build is ready.
+            # A slow or failed build therefore leaves the previous working
+            # bundles downloadable instead of emptying the release mid-build.
             gh release edit "${CANARY_TAG}" \
               --target "${GITHUB_SHA}" \
               --title "${title}" \
               --notes-file NOTES.md \
               --prerelease
-            for asset in $(gh release view "${CANARY_TAG}" --json assets -q '.assets[].name'); do
-              gh release delete-asset "${CANARY_TAG}" "${asset}" --yes || true
-            done
           else
             gh release create "${CANARY_TAG}" \
               --target "${GITHUB_SHA}" \
@@ -194,6 +198,20 @@ jobs:
             pnpm --filter slicer-ui-desktop build
           fi
 
+      - name: Verify the macOS bundle is validly ad-hoc signed
+        if: runner.os == 'macOS'
+        shell: bash
+        run: |
+          # Ad-hoc signing (not notarization) is what lets Apple Silicon run the
+          # app at all after the user clears quarantine. If Tauri's signing were
+          # incomplete the app would still be "damaged" even after `xattr -cr`,
+          # so fail loudly here rather than shipping an unlaunchable bundle.
+          # Note: `spctl` is intentionally NOT used — it always rejects an
+          # un-notarized app and would give a false failure.
+          app="ui-desktop/src-tauri/target/universal-apple-darwin/release/bundle/macos/Slicer Engine Desktop.app"
+          codesign --verify --deep --strict --verbose=2 "$app"
+          codesign -dvv "$app" 2>&1 | sed -n '1,8p'
+
       - name: Upload desktop bundles to the canary release
         env:
           GH_TOKEN: ${{ github.token }}
@@ -207,9 +225,28 @@ jobs:
           else
             bundle_dir="ui-desktop/src-tauri/target/release/bundle"
           fi
+          # Copy each bundle to a *stable*, version-less name before uploading.
+          # Tauri embeds the run-specific version in the filename, which would
+          # (a) accumulate stale assets on the rolling release and (b) break the
+          # download URL every build. Stable names let --clobber overwrite the
+          # previous build's asset in place (so `prepare` no longer needs to
+          # wipe assets) and keep a permanent link, e.g.
+          #   .../releases/download/canary/Slicer-Engine-Desktop-macOS.dmg
+          staging="$(mktemp -d)"
+          stable_name() {
+            case "$1" in
+              *.dmg)        echo "Slicer-Engine-Desktop-macOS.dmg" ;;
+              *.app.tar.gz) echo "Slicer-Engine-Desktop-macOS.app.tar.gz" ;;
+              *.msi)        echo "Slicer-Engine-Desktop-Windows-x64.msi" ;;
+              *.exe)        echo "Slicer-Engine-Desktop-Windows-x64-setup.exe" ;;
+              *)            basename "$1" ;;
+            esac
+          }
           assets=()
-          while IFS= read -r asset; do
-            assets+=("$asset")
+          while IFS= read -r src; do
+            dest="${staging}/$(stable_name "$src")"
+            cp "$src" "$dest"
+            assets+=("$dest")
           done < <(find "$bundle_dir" -type f \( \
             -name '*.dmg' -o -name '*.app.tar.gz' -o -name '*.msi' -o -name '*.exe' \
           \))

--- a/.github/workflows/release.yml
+++ b/.github/workflows/release.yml
@@ -58,7 +58,7 @@ jobs:
               echo ""
               echo "### 🍎 macOS"
               echo ""
-              echo "This build is unsigned, so macOS Gatekeeper marks the downloaded app as \"damaged\". After moving **Slicer Engine Desktop** to Applications, clear the quarantine flag once to launch it:"
+              echo "This build is unsigned (no paid Apple Developer ID), so macOS Gatekeeper marks the downloaded app as \"damaged\" — **right-click → Open will not clear this**. After moving **Slicer Engine Desktop** to Applications, run this once in Terminal to strip the quarantine flag and launch it:"
               echo ""
               echo '```bash'
               echo 'xattr -cr "/Applications/Slicer Engine Desktop.app"'


### PR DESCRIPTION
## Why

Two problems with the rolling **canary** release:

1. **The canary was empty/broken for most of every build.** The `prepare` job
   deleted *every* asset up front, then kicked off the multi-minute Tauri build.
   So from the moment a push landed until the build finished uploading, the
   release had **no downloadable bundles** — and if a build failed, it stayed
   empty. Assets carried a run-versioned filename, which is *why* the destructive
   wipe existed (clobber couldn't overwrite them).
2. **The macOS app wouldn't launch.** Bundles are ad-hoc signed (required so
   Apple Silicon runs them at all) but not notarized, so a quarantined download
   shows *"is damaged and can't be opened."* Crucially, **right-click → Open does
   not clear this** — only a paid Developer ID would — so users trying the
   "unknown source" route hit a dead end. The `xattr` fix was buried.

## What changed

**`canary.yml`**
- `prepare` no longer wipes assets. Bundles upload under **stable, version-less
  names** (`Slicer-Engine-Desktop-macOS.dmg`, `-Windows-x64.msi`,
  `-Windows-x64-setup.exe`) so `--clobber` overwrites each in place **only once
  the new build is ready**. A slow or failed build now leaves the previous
  working bundles downloadable instead of emptying the release. Download URLs are
  permanent too (e.g. `.../releases/download/canary/Slicer-Engine-Desktop-macOS.dmg`).
- New CI step runs `codesign --verify --deep --strict` on the `.app`, so an
  incomplete ad-hoc signing **fails the build** instead of shipping an app that
  stays "damaged" even after de-quarantine. (`spctl` is intentionally not used —
  it always rejects an un-notarized app.)
- Release notes now state plainly that right-click → Open won't work and lead
  with the one no-license fix: `xattr -cr "/Applications/Slicer Engine Desktop.app"`.

**`release.yml`**
- Same clarified macOS note for tagged releases.

## Notes

- The canary stays a **single rolling pre-release** (each push supersedes the
  last), just made non-destructive. If we'd rather keep every canary as its own
  entry in the Releases tab, that's a separate design change.
- No functional/runtime code touched — CI workflows only.
