### PR TITLE
chore(deps): bump toml 0.9->1.1 and base64 0.22->0.23

### DIFF
--- a/Cargo.toml
+++ b/Cargo.toml
@@ -18,7 +18,7 @@ schemars = "1.2.1"
 stl_io = "0.11"
 quick-xml = { version = "0.39", features = ["serialize"] }
 dirs = "6.0.0"
-toml = { version = "0.9.8", features = ["preserve_order"] }
+toml = { version = "1.1", features = ["preserve_order"] }
 chrono = { version = "0.4", features = ["serde"] }
 glam = { version = "0.33", features = ["serde"] }
 thiserror = "2.0"
@@ -48,7 +48,7 @@ actix-files = "0.6"
 actix-ws = "0.4"
 actix-multipart = "0.7.2"
 actix-cors = "0.7"
-base64 = "0.22"
+base64 = "0.23"
 futures-util = "0.3"
 reqwest = { version = "0.13", default-features = false, features = [
     "rustls",


### PR DESCRIPTION
Clears the two remaining Dependabot cargo PRs so the backlog is empty.

| PR | Update | Notes |
|----|--------|-------|
| #171 | `toml` 0.9.8 -> 1.1 | The `preserve_order` feature and the serialize/deserialize API we use are unchanged; only one `toml` version ends up in the tree. |
| #170 | `base64` 0.22 -> 0.23 | Declared dependency only — no direct use in our code (actix pulls its own 0.22 transitively), so this is a no-op for us. |

## Verification
- `cargo test` (full suite, 546+ tests incl. config/settings/profiles round-trips) passes.
- `cargo fmt --check` clean; `cargo tree` shows a single `toml` version.

Closes #171, closes #170.

Co-authored-by: Copilot <223556219+Copilot@users.noreply.github.com>