### PR TITLE
chore(deps): bump actix-files 0.7, actix-multipart 0.8, quick-xml 0.42

### DIFF
--- a/Cargo.toml
+++ b/Cargo.toml
@@ -16,7 +16,7 @@ serde = { version = "1.0", features = ["derive"] }
 serde_json = { version = "1.0", features = ["preserve_order"] }
 schemars = "1.2.1"
 stl_io = "0.11"
-quick-xml = { version = "0.39", features = ["serialize"] }
+quick-xml = { version = "0.42", features = ["serialize"] }
 dirs = "6.0.0"
 toml = { version = "1.1", features = ["preserve_order"] }
 chrono = { version = "0.4", features = ["serde"] }
@@ -44,9 +44,9 @@ sea-orm-migration = { version = "2.0", features = [
     "runtime-tokio-rustls",
 ] }
 actix-web = "4.13"
-actix-files = "0.6"
+actix-files = "0.7"
 actix-ws = "0.4"
-actix-multipart = "0.7.2"
+actix-multipart = "0.8.1"
 actix-cors = "0.7"
 base64 = "0.23"
 futures-util = "0.3"

--- a/src/mesh/io.rs
+++ b/src/mesh/io.rs
@@ -319,19 +319,19 @@ pub fn read_3mf_from_bytes(bytes: &[u8]) -> Result<Mesh, Box<dyn std::error::Err
     loop {
         match reader.read_event_into(&mut buf)? {
             Event::Empty(ref e) | Event::Start(ref e) => match e.local_name().as_ref() {
-                b"vertex" => {
+                "vertex" => {
                     let mut x = None::<f64>;
                     let mut y = None::<f64>;
                     let mut z = None::<f64>;
                     for attr in e.attributes().flatten() {
-                        let val: f64 = std::str::from_utf8(&attr.value)
-                            .map_err(|_| "3MF vertex attribute is not valid UTF-8")?
+                        let val: f64 = attr
+                            .value
                             .parse()
                             .map_err(|_| "3MF vertex coordinate is not a valid number")?;
                         match attr.key.local_name().as_ref() {
-                            b"x" => x = Some(val),
-                            b"y" => y = Some(val),
-                            b"z" => z = Some(val),
+                            "x" => x = Some(val),
+                            "y" => y = Some(val),
+                            "z" => z = Some(val),
                             _ => {}
                         }
                     }
@@ -341,19 +341,19 @@ pub fn read_3mf_from_bytes(bytes: &[u8]) -> Result<Mesh, Box<dyn std::error::Err
                     };
                     vertices.push(Vertex::new(x, y, z));
                 }
-                b"triangle" => {
+                "triangle" => {
                     let mut v1 = None::<usize>;
                     let mut v2 = None::<usize>;
                     let mut v3 = None::<usize>;
                     for attr in e.attributes().flatten() {
-                        let val: usize = std::str::from_utf8(&attr.value)
-                            .map_err(|_| "3MF triangle attribute is not valid UTF-8")?
+                        let val: usize = attr
+                            .value
                             .parse()
                             .map_err(|_| "3MF triangle index is not a valid integer")?;
                         match attr.key.local_name().as_ref() {
-                            b"v1" => v1 = Some(val),
-                            b"v2" => v2 = Some(val),
-                            b"v3" => v3 = Some(val),
+                            "v1" => v1 = Some(val),
+                            "v2" => v2 = Some(val),
+                            "v3" => v3 = Some(val),
                             _ => {}
                         }
                     }

--- a/src/server/mod.rs
+++ b/src/server/mod.rs
@@ -195,8 +195,7 @@ async fn run_server(
                     .default_handler(web::to(move || {
                         let path = format!("{}/index.html", fallback_dir);
                         async move {
-                            actix_files::NamedFile::open_async(path)
-                                .await
+                            actix_files::NamedFile::open(path)
                                 .map_err(actix_web::error::ErrorNotFound)
                         }
                     })),


### PR DESCRIPTION
Clears the remaining Dependabot cargo PRs, adapting to their breaking changes.

| PR | Update | Change required |
|----|--------|-----------------|
| #172 | `actix-files` 0.6 -> 0.7 | `NamedFile::open_async` was removed; the SPA fallback handler now uses the sync `NamedFile::open`. |
| #173 | `quick-xml` 0.39 -> 0.42 | `Reader::from_str` is now str-based — element local names and attribute values come back as `&str` / `Cow<str>` instead of bytes. The 3MF parser matches string literals and parses `attr.value` directly (dropping the now-unnecessary UTF-8 decode). |
| #174 | `actix-multipart` 0.7.2 -> 0.8.1 | No source changes required. |

All three stay on actix-web 4.x (verified their dep ranges).

## Verification
- `cargo test` (full suite, incl. the 3MF read round-trip tests) passes.
- `cargo fmt --check` + `cargo clippy` clean.

Closes #172, closes #173, closes #174.

Co-authored-by: Copilot <223556219+Copilot@users.noreply.github.com>