### PR TITLE
viewer: add global filament-color toggle for model meshes

### DIFF
--- a/ui/src/app/components/viewer/viewer.ts
+++ b/ui/src/app/components/viewer/viewer.ts
@@ -18,6 +18,7 @@ import { AppTheme } from '../../services/app-theme';
 import { GcodePreview, ROLE_LABELS, scalarChannelFor } from '../../services/gcode-preview';
 import { ObjectTracker } from '../../services/object-tracker';
 import { PrintArea } from '../../services/print-area';
+import { ActiveSelection } from '../../services/profiles/active-selection';
 import { SceneCommand } from '../../services/scene-command/scene-command';
 import { SceneEngine } from '../../services/scene-engine';
 import { ViewerControl } from '../../services/viewer-control';
@@ -90,6 +91,7 @@ export class Viewer {
   private readonly sceneEngine = inject(SceneEngine);
   private readonly sceneCommand = inject(SceneCommand);
   private readonly gcodePreview = inject(GcodePreview);
+  private readonly activeSelection = inject(ActiveSelection);
   private readonly appTheme = inject(AppTheme);
   private readonly destroyRef = inject(DestroyRef);
 
@@ -271,7 +273,11 @@ export class Viewer {
     effect(() => {
       const isDark = this.appTheme.isDarkMode();
       this.scene?.setTheme(isDark);
-      const color = modelColor(isDark);
+      const color = resolveModelColor(
+        isDark,
+        this.viewerControl.useFilamentColor(),
+        this.activeSelection.filament()?.color,
+      );
       for (const mesh of this.wasmMeshes.values()) {
         (mesh.material as MeshPhongMaterial).color.setHex(color);
       }
@@ -758,7 +764,7 @@ export class Viewer {
       geometry.computeBoundingBox();
       geometry.computeBoundingSphere();
       const material = new MeshPhongMaterial({
-        color: modelColor(this.appTheme.isDarkMode()),
+        color: this.currentModelColor(),
         flatShading: true,
         shininess: 16,
       });
@@ -826,7 +832,7 @@ export class Viewer {
     geometry.computeBoundingBox();
     geometry.computeBoundingSphere();
     const material = new MeshPhongMaterial({
-      color: modelColor(this.appTheme.isDarkMode()),
+      color: this.currentModelColor(),
       flatShading: true,
       shininess: 16,
     });
@@ -909,6 +915,14 @@ export class Viewer {
       this.currentAbort = null;
     }
   }
+
+  private currentModelColor(): number {
+    return resolveModelColor(
+      this.appTheme.isDarkMode(),
+      this.viewerControl.useFilamentColor(),
+      this.activeSelection.filament()?.color,
+    );
+  }
 }
 
 function messageOf(error: unknown): string {
@@ -966,4 +980,31 @@ function parseWasmId(stringId: string): bigint | null {
   } catch {
     return null;
   }
+}
+
+function resolveModelColor(
+  isDark: boolean,
+  useFilamentColor: boolean,
+  filamentColor: string | null | undefined,
+): number {
+  if (!useFilamentColor) {
+    return modelColor(isDark);
+  }
+  const parsed = parseHexColor(filamentColor);
+  return parsed ?? modelColor(isDark);
+}
+
+function parseHexColor(raw: string | null | undefined): number | null {
+  if (!raw) {
+    return null;
+  }
+  const trimmed = raw.trim();
+  const match = /^#([0-9a-f]{3}|[0-9a-f]{6})$/i.exec(trimmed);
+  if (!match) {
+    return null;
+  }
+  const hex = match[1];
+  const normalized =
+    hex.length === 3 ? `${hex[0]}${hex[0]}${hex[1]}${hex[1]}${hex[2]}${hex[2]}` : hex.toLowerCase();
+  return Number.parseInt(normalized, 16);
 }

--- a/ui/src/app/pages/settings/general.html
+++ b/ui/src/app/pages/settings/general.html
@@ -199,5 +199,35 @@
         </button>
       </div>
     </div>
+
+    <div class="settings-field">
+      <span class="settings-field-label">
+        <span class="settings-field-title">Use filament color for models</span>
+        <span class="settings-field-desc">
+          Color model meshes with the active filament profile color instead of the neutral viewer
+          tone.
+        </span>
+      </span>
+      <div class="segmented" role="group" aria-label="Use filament color for models">
+        <button
+          type="button"
+          class="segmented-btn"
+          [class.is-active]="useFilamentColor()"
+          [attr.aria-pressed]="useFilamentColor()"
+          (click)="setUseFilamentColor(true)"
+        >
+          On
+        </button>
+        <button
+          type="button"
+          class="segmented-btn"
+          [class.is-active]="!useFilamentColor()"
+          [attr.aria-pressed]="!useFilamentColor()"
+          (click)="setUseFilamentColor(false)"
+        >
+          Off
+        </button>
+      </div>
+    </div>
   </div>
 </div>

--- a/ui/src/app/pages/settings/general.ts
+++ b/ui/src/app/pages/settings/general.ts
@@ -27,6 +27,7 @@ export class GeneralSettings implements OnInit {
   protected readonly fieldOfView = this.viewer.fieldOfView;
   protected readonly antialiasing = this.viewer.antialiasing;
   protected readonly renderQuality = this.viewer.renderQuality;
+  protected readonly useFilamentColor = this.viewer.useFilamentColor;
 
   protected readonly minFov = MIN_FIELD_OF_VIEW;
   protected readonly maxFov = MAX_FIELD_OF_VIEW;
@@ -71,5 +72,9 @@ export class GeneralSettings implements OnInit {
 
   setRenderQuality(quality: RenderQuality): void {
     this.viewer.setRenderQuality(quality);
+  }
+
+  setUseFilamentColor(value: boolean): void {
+    this.viewer.setUseFilamentColor(value);
   }
 }

--- a/ui/src/app/services/viewer-control.ts
+++ b/ui/src/app/services/viewer-control.ts
@@ -75,6 +75,7 @@ const STATS_VISIBLE_KEY = 'nexus.viewer.statsVisible';
 const FIELD_OF_VIEW_KEY = 'nexus.viewer.fieldOfView';
 const ANTIALIASING_KEY = 'nexus.viewer.antialiasing';
 const RENDER_QUALITY_KEY = 'nexus.viewer.renderQuality';
+const USE_FILAMENT_COLOR_KEY = 'nexus.viewer.useFilamentColor';
 
 /**
  * Shared state between the 3D-view toolbar and the viewer component.
@@ -129,6 +130,14 @@ export class ViewerControl {
    * live via the renderer's pixel ratio.
    */
   readonly renderQuality = signal<RenderQuality>(this.readRenderQuality());
+
+  /**
+   * Whether model meshes use the active filament profile color instead of the
+   * neutral theme-based graphite tone.
+   *
+   * Default is `false` to preserve the existing scene appearance.
+   */
+  readonly useFilamentColor = signal(this.readUseFilamentColor());
 
   /**
    * Currently selected object-manipulation mode. Drives the gizmo shown
@@ -243,6 +252,12 @@ export class ViewerControl {
     this.storage.write(RENDER_QUALITY_KEY, quality);
   }
 
+  /** Update model-color source preference and persist it. */
+  setUseFilamentColor(value: boolean): void {
+    this.useFilamentColor.set(value);
+    this.storage.write(USE_FILAMENT_COLOR_KEY, String(value));
+  }
+
   private readTwoFingerGesture(): TwoFingerGesture {
     return this.storage.get(TWO_FINGER_GESTURE_KEY)() === 'pan' ? 'pan' : 'orbit';
   }
@@ -274,6 +289,10 @@ export class ViewerControl {
   private readRenderQuality(): RenderQuality {
     const raw = this.storage.get(RENDER_QUALITY_KEY)();
     return raw === 'performance' || raw === 'quality' ? raw : 'balanced';
+  }
+
+  private readUseFilamentColor(): boolean {
+    return this.storage.get(USE_FILAMENT_COLOR_KEY)() === 'true';
   }
 
   /**


### PR DESCRIPTION
## Summary
- add a new persisted global viewer preference (nexus.viewer.useFilamentColor) to control whether model meshes use filament color
- expose the preference in General settings as an On/Off segmented toggle
- update the 3D viewer so model mesh materials resolve from either the neutral theme model color (default) or the active filament profile color
- apply the selected color source both to newly loaded meshes and to already-rendered meshes when theme, filament, or toggle changes

## Why
Users can now preview objects using the active filament color in the main scene while preserving the existing neutral default behavior.

## Validation
- pnpm --filter slicer-ui build
