### PR TITLE
Fix Klipper default START_PRINT temps for Klippain macros

### DIFF
--- a/src/gcode/dialects/klipper.rs
+++ b/src/gcode/dialects/klipper.rs
@@ -81,14 +81,17 @@ impl GcodeDialect for KlipperDialect {
 
     /// Default Klipper start script: delegates to the `START_PRINT` macro.
     ///
-    /// Print temperatures are forwarded as macro arguments so the user's
-    /// Klipper `START_PRINT` macro can use them for pre-heat, bed levelling,
-    /// purge routines, etc.  This follows the OrcaSlicer / SuperSlicer
-    /// convention for Klipper start G-code.
+    /// Print temperatures are forwarded using both common parameter naming
+    /// conventions:
+    /// - Orca/SuperSlicer style: `BED_TEMP` / `EXTRUDER_TEMP`
+    /// - Klippain style: `BED` / `EXTRUDER`
+    ///
+    /// Emitting both keeps the default robust across macro packs while still
+    /// preserving user-configurable custom start G-code overrides.
     fn start_script(&self, params: &SlicingParams) -> Vec<String> {
         vec![format!(
-            "START_PRINT BED_TEMP={:.0} EXTRUDER_TEMP={:.0}",
-            params.bed_temp, params.nozzle_temp
+            "START_PRINT BED_TEMP={:.0} EXTRUDER_TEMP={:.0} BED={:.0} EXTRUDER={:.0}",
+            params.bed_temp, params.nozzle_temp, params.bed_temp, params.nozzle_temp
         )]
     }
 

--- a/src/gcode/generator.rs
+++ b/src/gcode/generator.rs
@@ -1822,6 +1822,14 @@ mod tests {
             gcode.contains("EXTRUDER_TEMP=210"),
             "Klipper START_PRINT missing EXTRUDER_TEMP: {gcode}"
         );
+        assert!(
+            gcode.contains("BED=60"),
+            "Klipper START_PRINT missing Klippain BED alias: {gcode}"
+        );
+        assert!(
+            gcode.contains("EXTRUDER=210"),
+            "Klipper START_PRINT missing Klippain EXTRUDER alias: {gcode}"
+        );
     }
 
     #[test]


### PR DESCRIPTION
## Summary
Fixes a Klipper temperature handoff bug where default-generated START_PRINT passed only BED_TEMP / EXTRUDER_TEMP, which Klippain-style macros may ignore.

## Root cause
The default Klipper dialect start line emitted:
START_PRINT BED_TEMP=<...> EXTRUDER_TEMP=<...>

Klippain commonly reads BED and EXTRUDER params instead. When those are missing, macros fall back to internal defaults (often EXTRUDER=240), causing the wrong preheat temp despite slicer profile settings.

## Fix
Default Klipper start script now emits both naming conventions:
START_PRINT BED_TEMP=<...> EXTRUDER_TEMP=<...> BED=<...> EXTRUDER=<...>

This preserves existing Orca/SuperSlicer compatibility while making defaults Klippain-compatible.

## Validation
- Ran targeted tests:
  - cargo test gcode::generator::tests::test_generator_klipper_ -- --nocapture
- Added assertions that generated Klipper start macro contains both BED and EXTRUDER aliases.
