### PR TITLE
fix(ui): make workplate naming coherent across actions

### DIFF
--- a/ui/src/app/components/list-history/list-history.ts
+++ b/ui/src/app/components/list-history/list-history.ts
@@ -21,13 +21,9 @@ export class ListHistory {
   readonly #workplateNames = inject(WorkplateNames);
   readonly #contextMenu = inject(ContextMenuService);
 
-  /** Custom workplate name if the user set one, otherwise the source filename. */
+  /** Custom workplate name, or a default derived from the first uploaded model. */
   displayName(session: RuntimeHistorySession): string {
-    return (
-      this.#workplateNames.nameFor(session.request_uuid) ??
-      session.original_filename ??
-      'unknown.stl'
-    );
+    return this.#workplateNames.displayNameFor(session.request_uuid, session.original_filename);
   }
 
   navigate(session: RuntimeHistorySession): void {

--- a/ui/src/app/components/workplate-name/workplate-name.ts
+++ b/ui/src/app/components/workplate-name/workplate-name.ts
@@ -41,8 +41,11 @@ export class WorkplateName {
   readonly savedName = computed(() => this.store.nameFor(this.requestUuid()) ?? '');
 
   /** Fallback shown as placeholder when the plate has no custom name yet. */
-  readonly placeholder = computed(
-    () => this.slicerFile.selectedFile()?.name ?? 'Untitled workplate',
+  readonly placeholder = computed(() =>
+    this.store.displayNameFor(
+      this.requestUuid(),
+      this.slicerFile.sourceFilename() ?? this.slicerFile.selectedFile()?.name,
+    ),
   );
 
   rename(event: Event): void {

--- a/ui/src/app/nexus/slice-control/slice-control.ts
+++ b/ui/src/app/nexus/slice-control/slice-control.ts
@@ -235,16 +235,8 @@ export class SliceControl {
     if (!printer || !uuid) return;
     this.printerConn.sendToPrinter(printer, uuid, {
       start: action === 'print',
-      filename: this.gcodeFilename(),
+      filename: this.slicer.currentGcodeFilename(),
     });
-  }
-
-  /** A printer-friendly `<model>.gcode` name, falling back to the engine default. */
-  private gcodeFilename(): string | undefined {
-    const name = this.slicer.selectedFile()?.name;
-    if (!name) return undefined;
-    const base = name.replace(/\.[^./\\]+$/, '').trim();
-    return base ? `${base}.gcode` : undefined;
   }
 
   protected toggleMenu(): void {

--- a/ui/src/app/pages/slice-viewer/slice-viewer.ts
+++ b/ui/src/app/pages/slice-viewer/slice-viewer.ts
@@ -80,9 +80,8 @@ export class SliceViewer {
 
       let meta: RequestMeta;
       if (stateUpload && stateUpload.ruuid === requestUuid) {
-        // Adopt the upload result; we don't have filenames in the upload
-        // response itself, so fetch the meta in the background only if we
-        // need the original filename later.
+        // Adopt the upload result immediately, then hydrate it with canonical
+        // request metadata (file IDs + original filename) from the backend.
         this.#slicerFile.adopt({
           ruuid: stateUpload.ruuid,
           status: 'upload_complete',
@@ -90,6 +89,7 @@ export class SliceViewer {
           ofids: stateUpload.ofids.map((id) => ({ file_uuid: id, original_filename: 'model' })),
         });
         meta = await this.#slicerFile.getRequestMeta(requestUuid);
+        this.#slicerFile.adopt(meta);
       } else {
         meta = await this.#slicerFile.getRequestMeta(requestUuid);
         this.#slicerFile.adopt(meta);

--- a/ui/src/app/services/slicer-file.ts
+++ b/ui/src/app/services/slicer-file.ts
@@ -31,6 +31,8 @@ export class SlicerFile {
   readonly #http = inject(HttpClient);
 
   readonly selectedFile = signal<File | null>(null);
+  /** Source model filename for the active workplate (used for title/download fallbacks). */
+  readonly sourceFilename = signal<string | null>(null);
   /** Workplate UUID — the `ruuid` from the upload response. */
   readonly requestUuid = signal<string | null>(null);
   /** File UUIDs (`ofids`) that belong to {@link requestUuid}. */
@@ -45,6 +47,7 @@ export class SlicerFile {
 
   selectFile(file: File): void {
     this.selectedFile.set(file);
+    this.sourceFilename.set(file.name);
     this.requestUuid.set(null);
     this.fileIds.set([]);
     this.uploadProgress.set(0);
@@ -107,6 +110,7 @@ export class SlicerFile {
 
   reset(): void {
     this.selectedFile.set(null);
+    this.sourceFilename.set(null);
     this.requestUuid.set(null);
     this.fileIds.set([]);
     this.uploadProgress.set(0);
@@ -139,6 +143,8 @@ export class SlicerFile {
   adopt(meta: RequestMeta): void {
     this.requestUuid.set(meta.ruuid);
     this.fileIds.set(meta.ofids.map((f) => f.file_uuid));
+    const firstFilename = meta.ofids[0]?.original_filename?.trim();
+    this.sourceFilename.set(firstFilename || null);
   }
 
   /** Mark the selected file as belonging to a local-only workplate. */
@@ -147,6 +153,10 @@ export class SlicerFile {
     this.fileIds.set([]);
     this.uploadProgress.set(0);
     this.uploadError.set(null);
+    if (!this.sourceFilename()) {
+      const selected = this.selectedFile()?.name?.trim();
+      this.sourceFilename.set(selected || null);
+    }
   }
 
   /**
@@ -180,6 +190,7 @@ export class SlicerFile {
                   type: 'application/octet-stream',
                 });
                 this.selectedFile.set(file);
+                this.sourceFilename.set(filename);
                 this.requestUuid.set(requestUuid);
                 this.fileIds.set([fileUuid]);
                 this.uploadProgress.set(100);

--- a/ui/src/app/services/slicer.ts
+++ b/ui/src/app/services/slicer.ts
@@ -18,6 +18,7 @@ import { SceneEngine } from './scene-engine';
 import { AppVersion } from './app-version';
 import { ConnectionStatus, SlicerConnection } from './slicer-connection';
 import { SlicerFile, UploadResponse } from './slicer-file';
+import { WorkplateNames } from './workplate-names';
 
 /** Human-readable label for each pipeline phase. */
 export const PHASE_LABELS: Record<string, string> = {
@@ -98,6 +99,7 @@ export class Slicer {
   private readonly sceneEngine = inject(SceneEngine);
   private readonly activeSelection = inject(ActiveSelection);
   private readonly appVersion = inject(AppVersion);
+  private readonly workplateNames = inject(WorkplateNames);
   private readonly runtimeMode = this.resolveRuntimeMode();
   private readonly runtime = createRuntime({
     mode: this.runtimeMode,
@@ -358,7 +360,14 @@ export class Slicer {
     if (!url) {
       return;
     }
-    void this.downloadFromUrl(url, this.selectedFile()?.name ?? undefined);
+    void this.downloadFromUrl(url, this.currentGcodeFilename());
+  }
+
+  currentGcodeFilename(): string {
+    return this.workplateNames.gcodeFilenameFor(
+      this.currentRequestUuid(),
+      this.slicerFile.sourceFilename() ?? this.selectedFile()?.name,
+    );
   }
 
   selectFile(file: File): void {
@@ -587,10 +596,15 @@ export class Slicer {
   }
 
   async downloadHistorySession(session: RuntimeHistorySession): Promise<void> {
+    const filename = this.workplateNames.gcodeFilenameFor(
+      session.request_uuid,
+      session.original_filename,
+    );
+
     if (!session.download_url) {
       const preview = await this.orchestrator.getPreviewSource(session.request_uuid);
       if (preview.kind === 'download-url') {
-        await this.downloadFromUrl(preview.url, session.original_filename ?? undefined);
+        await this.downloadFromUrl(preview.url, filename);
         return;
       }
       if (preview.kind === 'gcode-inline') {
@@ -599,7 +613,7 @@ export class Slicer {
             type: 'text/plain;charset=utf-8',
           }),
         );
-        await this.downloadFromUrl(url, session.original_filename ?? undefined);
+        await this.downloadFromUrl(url, filename);
         URL.revokeObjectURL(url);
         return;
       }
@@ -610,14 +624,10 @@ export class Slicer {
       return;
     }
 
-    await this.downloadFromUrl(session.download_url, session.original_filename ?? undefined);
+    await this.downloadFromUrl(session.download_url, filename);
   }
 
-  private async downloadFromUrl(url: string, originalFilename?: string): Promise<void> {
-    const filename =
-      (originalFilename as string | null | undefined)?.replace(/\.(stl|obj|3mf)$/i, '.gcode') ??
-      'output.gcode';
-
+  private async downloadFromUrl(url: string, filename: string): Promise<void> {
     if (this.runtimeMode === 'native') {
       // Tauri's webview does not reliably honour `<a download>` against a
       // custom `asset://` URL (it's meant for `<img>`/`<video>` src, not

--- a/ui/src/app/services/workplate-names.ts
+++ b/ui/src/app/services/workplate-names.ts
@@ -2,6 +2,10 @@ import { Injectable, inject, signal } from '@angular/core';
 import { BrowserStorage } from './browser-storage';
 
 const STORAGE_KEY = 'workplate.names';
+const DEFAULT_WORKPLATE_NAME = 'Untitled workplate';
+const DEFAULT_GCODE_FILENAME = 'output.gcode';
+const INVALID_FILENAME_CHARS = /[<>:"/\\|?*\u0000-\u001F]/g;
+const GCODE_EXTENSION = /\.(gcode|gco|g)$/i;
 
 /**
  * Remembers the user-chosen display name for each workplate, keyed by its
@@ -29,6 +33,55 @@ export class WorkplateNames {
     return this._names()[uuid] ?? null;
   }
 
+  /**
+   * The human-facing workplate title:
+   * custom rename → uploaded model stem → fallback.
+   */
+  displayNameFor(
+    uuid: string | null | undefined,
+    sourceFilename: string | null | undefined,
+  ): string {
+    return (
+      this.nameFor(uuid) ?? this.defaultNameFromFilename(sourceFilename) ?? DEFAULT_WORKPLATE_NAME
+    );
+  }
+
+  /** Derive the default plate name from an uploaded model filename. */
+  defaultNameFromFilename(filename: string | null | undefined): string | null {
+    if (!filename) {
+      return null;
+    }
+
+    const basename = filename.trim().split(/[\\/]/).pop()?.trim();
+    if (!basename) {
+      return null;
+    }
+
+    const stem = basename.replace(/\.[^./\\]+$/, '').trim();
+    return stem || null;
+  }
+
+  /**
+   * Canonical `<workplate>.gcode` filename used for downloads and printer sends.
+   */
+  gcodeFilenameFor(
+    uuid: string | null | undefined,
+    sourceFilename: string | null | undefined,
+  ): string {
+    const baseName = this.nameFor(uuid) ?? this.defaultNameFromFilename(sourceFilename);
+    if (!baseName) {
+      return DEFAULT_GCODE_FILENAME;
+    }
+
+    const safeBase = this.#sanitizeFilenameBase(baseName);
+    if (!safeBase) {
+      return DEFAULT_GCODE_FILENAME;
+    }
+
+    const withoutGcodeExt = safeBase.replace(GCODE_EXTENSION, '').trim();
+    return withoutGcodeExt ? `${withoutGcodeExt}.gcode` : DEFAULT_GCODE_FILENAME;
+  }
+
   /** Store (or, when blank, clear) the custom name for a workplate. */
   setName(uuid: string, name: string): void {
     const trimmed = name.trim();
@@ -42,5 +95,13 @@ export class WorkplateNames {
       return next;
     });
     this.storage.writeJson(STORAGE_KEY, this._names(), 'local');
+  }
+
+  #sanitizeFilenameBase(name: string): string {
+    return name
+      .replace(INVALID_FILENAME_CHARS, ' ')
+      .replace(/\s+/g, ' ')
+      .replace(/\.+$/, '')
+      .trim();
   }
 }


### PR DESCRIPTION
## Summary
- centralize workplate naming logic in `WorkplateNames` for both display titles and generated `.gcode` filenames
- derive default workplate names from the first model filename **without** extension
- apply the same naming source across titlebar placeholder, history list labels, G-code downloads, and send-to-printer filenames
- persist and hydrate `sourceFilename` in `SlicerFile` so fallback naming survives route restores/reloads

## Why
The workplate rename feature existed but was inconsistently consumed, and fallback names exposed source file extensions in UI labels. This change makes naming behavior predictable and coherent across user-facing actions.

## Validation
- `pnpm install`
- `pnpm run hydrate`
- `pnpm --filter slicer-ui build`