### PR TITLE
fix(gcode): resolve first-layer temp handoff and Orca placeholder compatibility

### DIFF
--- a/src/gcode/generator.rs
+++ b/src/gcode/generator.rs
@@ -216,6 +216,9 @@ pub(crate) fn render_marker(
 /// `{chamber_temp}`, `{filament_type}`, plus `{layer_height}` and
 /// `{first_layer_height}`.
 ///
+/// For migration convenience, common Orca-style bracket placeholders are also
+/// accepted as aliases (for example `[nozzle_temperature_initial_layer]`).
+///
 /// The `_first_layer` temperatures fall back to the general value when set to
 /// `0` (the "use base value" sentinel), matching the slicer's own resolution.
 /// Longer keys are replaced before their prefixes (e.g. `{nozzle_temp_first_layer}`
@@ -245,6 +248,25 @@ pub(crate) fn render_script_placeholders(line: &str, params: &SlicingParams) -> 
         .replace("{filament_type}", &params.filament_type)
         .replace("{first_layer_height}", &format!("{:.3}", first_height))
         .replace("{layer_height}", &format!("{:.3}", params.layer_height))
+        // Orca-style aliases
+        .replace(
+            "[nozzle_temperature_initial_layer]",
+            &format!("{:.0}", first_nozzle),
+        )
+        .replace(
+            "[bed_temperature_initial_layer_single]",
+            &format!("{:.0}", first_bed),
+        )
+        .replace(
+            "[nozzle_temperature]",
+            &format!("{:.0}", params.nozzle_temp),
+        )
+        .replace("[bed_temperature]", &format!("{:.0}", params.bed_temp))
+        .replace(
+            "[chamber_temperature]",
+            &format!("{:.0}", params.chamber_temp),
+        )
+        .replace("[filament_type]", &params.filament_type)
 }
 
 // ── GcodeGenerator ─────────────────────────────────────────────────────────────
@@ -643,6 +665,25 @@ impl GcodeGenerator {
         // command when the target changes (persists across layers).
         let mut last_accel: Option<f64> = None;
 
+        // If a custom start script heats for first layer (e.g.
+        // `{nozzle_temp_first_layer}` / `{bed_temp_first_layer}`), restore the
+        // normal temperatures when layer 2 starts unless a custom layer script
+        // chooses to override that behavior afterward.
+        let first_nozzle = if params.nozzle_temp_first_layer > 0.0 {
+            params.nozzle_temp_first_layer
+        } else {
+            params.nozzle_temp
+        };
+        let first_bed = if params.bed_temp_first_layer > 0.0 {
+            params.bed_temp_first_layer
+        } else {
+            params.bed_temp
+        };
+        let restore_nozzle_after_first_layer = params.nozzle_temp_first_layer > 0.0
+            && (first_nozzle - params.nozzle_temp).abs() > 1e-9;
+        let restore_bed_after_first_layer =
+            params.bed_temp_first_layer > 0.0 && (first_bed - params.bed_temp).abs() > 1e-9;
+
         for (layer_index, layer) in layers.iter().enumerate() {
             let z_str = format!("{:.3}", layer.z);
             let height_str = format!("{:.3}", params.layer_height);
@@ -715,6 +756,21 @@ impl GcodeGenerator {
                     "{}\n",
                     self.dialect.move_z(layer.z, params.travel_speed_mm_min)
                 ));
+            }
+
+            if layer_index == 1 {
+                if restore_nozzle_after_first_layer {
+                    out.push_str(&format!(
+                        "{} ; restore normal nozzle temperature\n",
+                        self.dialect.set_nozzle_temp(params.nozzle_temp, false)
+                    ));
+                }
+                if restore_bed_after_first_layer {
+                    out.push_str(&format!(
+                        "{} ; restore normal bed temperature\n",
+                        self.dialect.set_bed_temp(params.bed_temp, false)
+                    ));
+                }
             }
 
             // ── Custom layer-change G-code (Klipper macros, timelapse, …) ─────
@@ -2654,6 +2710,61 @@ CHAMBER={chamber_temp} MATERIAL={filament_type}"
         assert!(
             gcode.contains("EXTRUDER=255 BED=105 CHAMBER=50 MATERIAL=ABS"),
             "Klippain start line not fully substituted: {gcode}"
+        );
+    }
+
+    #[test]
+    fn test_start_script_substitutes_orca_bracket_placeholders() {
+        let params = SlicingParams {
+            nozzle_temp: 210.0,
+            bed_temp: 60.0,
+            nozzle_temp_first_layer: 215.0,
+            bed_temp_first_layer: 65.0,
+            chamber_temp: 45.0,
+            filament_type: "PLA".to_string(),
+            ..SlicingParams::default()
+        };
+        let gen = GcodeGenerator::new(GcodeFlavor::Klipper).with_start_script(vec![
+            "START_PRINT EXTRUDER=[nozzle_temperature_initial_layer] BED=[bed_temperature_initial_layer_single] CHAMBER=[chamber_temperature] MATERIAL=[filament_type]"
+                .to_string(),
+        ]);
+        let gcode = gen.generate(&[], &params);
+        assert!(
+            gcode.contains("START_PRINT EXTRUDER=215 BED=65 CHAMBER=45 MATERIAL=PLA"),
+            "Orca-style bracket placeholders were not substituted: {gcode}"
+        );
+    }
+
+    #[test]
+    fn test_restores_normal_temperatures_on_second_layer_when_first_layer_overridden() {
+        let params = SlicingParams {
+            nozzle_temp: 210.0,
+            bed_temp: 60.0,
+            nozzle_temp_first_layer: 215.0,
+            bed_temp_first_layer: 65.0,
+            ..SlicingParams::default()
+        };
+        let gen = GcodeGenerator::new(GcodeFlavor::Klipper)
+            .with_start_script(vec![
+                "START_PRINT EXTRUDER={nozzle_temp_first_layer} BED={bed_temp_first_layer}"
+                    .to_string(),
+            ])
+            .with_lifecycle_markers(false);
+
+        let layers = vec![SliceLayer::new(0.2), SliceLayer::new(0.4)];
+        let gcode = gen.generate(&layers, &params);
+
+        assert!(
+            gcode.contains("START_PRINT EXTRUDER=215 BED=65"),
+            "first-layer start temperatures missing: {gcode}"
+        );
+        assert!(
+            gcode.contains("M104 S210 ; restore normal nozzle temperature"),
+            "normal nozzle temperature was not restored on layer 2: {gcode}"
+        );
+        assert!(
+            gcode.contains("M140 S60 ; restore normal bed temperature"),
+            "normal bed temperature was not restored on layer 2: {gcode}"
         );
     }
 

--- a/src/gcode_viewer/parser.rs
+++ b/src/gcode_viewer/parser.rs
@@ -4,6 +4,15 @@ use super::types::{FanSample, InternalLayer, Role};
 /// paths without having to hide other roles.
 const SEAM_DOT_DIAMETER_FROM_LAYER_HEIGHT_SCALE: f32 = 4.0;
 const MIN_SEAM_DOT_RADIUS_MM: f32 = 0.3;
+/// Parameter keys used by common start-macro conventions to pass nozzle temp.
+const NOZZLE_TEMP_KEYS: &[&str] = &[
+    "EXTRUDER_TEMP=",
+    "EXTRUDER=",
+    "NOZZLE_TEMP=",
+    "NOZZLE=",
+    "HOTEND_TEMP=",
+    "HOTEND=",
+];
 
 fn seam_dot_radius(layer_height_mm: f32) -> f32 {
     let diameter = layer_height_mm.max(0.0) * SEAM_DOT_DIAMETER_FROM_LAYER_HEIGHT_SCALE;
@@ -247,6 +256,25 @@ pub(super) fn parse_gcode_bytes(bytes: &[u8]) -> Vec<InternalLayer> {
                     }
                 }
             }
+            "SET_HEATER_TEMPERATURE" => {
+                // Klipper direct heater command:
+                // `SET_HEATER_TEMPERATURE HEATER=extruder TARGET=210`.
+                let mut heater = None;
+                let mut target = None;
+                for param in parts {
+                    if let Some(v) = strip_prefix_ci(param, "heater=") {
+                        heater = Some(v);
+                    } else if let Some(v) = strip_prefix_ci(param, "target=") {
+                        target = parse_leading_f32(v);
+                    }
+                }
+                if heater.is_some_and(|h| h.eq_ignore_ascii_case("extruder")) {
+                    if let Some(v) = target {
+                        sticky.nozzle_temp = Some(v);
+                        sticky.seed(&mut current);
+                    }
+                }
+            }
             "M106" => {
                 // Marlin part-cooling: `M106 P<n> S<0-255>` (P defaults to 0).
                 let mut fan_index: u32 = 0;
@@ -298,7 +326,15 @@ pub(super) fn parse_gcode_bytes(bytes: &[u8]) -> Vec<InternalLayer> {
                     sticky.seed(&mut current);
                 }
             }
-            _ => {} // G28, G4, M140, etc. — ignore
+            _ => {
+                // Custom start macros often pass temperatures as named args
+                // (e.g. `START_PRINT EXTRUDER_TEMP=...`). Capture those so
+                // temperature-based color modes work for Klipper-style starts.
+                if let Some(v) = parse_nozzle_temp_from_params(parts) {
+                    sticky.nozzle_temp = Some(v);
+                    sticky.seed(&mut current);
+                }
+            } // G28, G4, M140, etc. — ignore
         }
     }
 
@@ -313,6 +349,25 @@ fn strip_prefix_ci<'a>(value: &'a str, prefix: &str) -> Option<&'a str> {
     } else {
         None
     }
+}
+
+/// Parse nozzle temperature from key/value-style macro args.
+///
+/// Supports common conventions such as:
+/// - `START_PRINT EXTRUDER_TEMP=210`
+/// - `START_PRINT EXTRUDER=210`
+/// - `PRINT_START HOTEND=210`
+fn parse_nozzle_temp_from_params<'a>(params: impl Iterator<Item = &'a str>) -> Option<f32> {
+    for param in params {
+        for key in NOZZLE_TEMP_KEYS {
+            if let Some(raw) = strip_prefix_ci(param, key) {
+                if let Some(temp) = parse_leading_f32(raw) {
+                    return Some(temp);
+                }
+            }
+        }
+    }
+    None
 }
 
 /// Handle a `;` comment line, mutating parser state as needed.
@@ -721,6 +776,54 @@ G1 X10 Y0 Z0.2 E1.0
         let layers = parse_gcode_bytes(gcode);
         let layer = first_printed_layer(&layers);
         assert_eq!(layer.meta.nozzle_temp, Some(210.0));
+    }
+
+    /// Klipper-style start macros pass nozzle temp as named arguments.
+    #[test]
+    fn nozzle_temperature_is_captured_from_start_print_macro() {
+        let gcode = b"
+START_PRINT BED_TEMP=60 EXTRUDER_TEMP=215 BED=60 EXTRUDER=215
+;LAYER_CHANGE
+;Z:0.200
+;TYPE:Outer wall
+G1 X0 Y0 Z0.2 E0 F1800
+G1 X10 Y0 Z0.2 E1.0
+";
+        let layers = parse_gcode_bytes(gcode);
+        let layer = first_printed_layer(&layers);
+        assert_eq!(layer.meta.nozzle_temp, Some(215.0));
+    }
+
+    /// Generic macros with common aliases (`HOTEND`, `NOZZLE`) are supported too.
+    #[test]
+    fn nozzle_temperature_is_captured_from_generic_macro_aliases() {
+        let gcode = b"
+PRINT_START HOTEND=225
+;LAYER_CHANGE
+;Z:0.200
+;TYPE:Outer wall
+G1 X0 Y0 Z0.2 E0 F1800
+G1 X10 Y0 Z0.2 E1.0
+";
+        let layers = parse_gcode_bytes(gcode);
+        let layer = first_printed_layer(&layers);
+        assert_eq!(layer.meta.nozzle_temp, Some(225.0));
+    }
+
+    /// Direct Klipper heater commands are also mapped to nozzle temperature.
+    #[test]
+    fn nozzle_temperature_is_captured_from_set_heater_temperature() {
+        let gcode = b"
+SET_HEATER_TEMPERATURE HEATER=extruder TARGET=235
+;LAYER_CHANGE
+;Z:0.200
+;TYPE:Outer wall
+G1 X0 Y0 Z0.2 E0 F1800
+G1 X10 Y0 Z0.2 E1.0
+";
+        let layers = parse_gcode_bytes(gcode);
+        let layer = first_printed_layer(&layers);
+        assert_eq!(layer.meta.nozzle_temp, Some(235.0));
     }
 
     /// Active tool index is captured from `T<n>` commands.

--- a/src/gcode_viewer/types.rs
+++ b/src/gcode_viewer/types.rs
@@ -166,7 +166,9 @@ pub(super) struct InternalLayer {
 /// per-layer color channels (fan / temperature / tool / layer time).
 #[derive(Debug, Clone, Default)]
 pub(super) struct LayerMeta {
-    /// Nozzle target temperature in °C, if a `M104`/`M109` was seen.
+    /// Nozzle target temperature in °C, captured from temperature commands
+    /// (`M104`/`M109`, `SET_HEATER_TEMPERATURE`) and common start-macro
+    /// key/value args (`EXTRUDER_TEMP=`, `EXTRUDER=`, `HOTEND=`...).
     pub(super) nozzle_temp: Option<f32>,
     /// Active tool/extruder index (`T0` by default).
     pub(super) tool: u32,


### PR DESCRIPTION
## Summary
- parse viewer temperature metadata from Klipper macro-style commands (`START_PRINT EXTRUDER_TEMP=...`, `EXTRUDER=...`, `HOTEND=...`) and `SET_HEATER_TEMPERATURE HEATER=extruder TARGET=...`
- add Orca-style bracket placeholder aliases for custom scripts (e.g. `[nozzle_temperature_initial_layer]`, `[bed_temperature_initial_layer_single]`)
- emit an automatic non-blocking layer-2 temperature handoff back to normal nozzle/bed targets when first-layer overrides are used

## Why
- fixes missing `Color by -> Temperature` mode when files rely on macro temperature args instead of `M104/M109`
- fixes first-layer-only temperatures staying constant throughout print
- prevents unresolved Orca placeholders from falling back to unexpected printer-side macro defaults

## Validation
- `cargo test --lib`
- `cargo test --lib gcode::generator::tests`
- targeted parser + generator regression tests for new macro and placeholder paths
