### PR TITLE
ui: unify destructive delete UX and align dialog actions

### DIFF
--- a/ui/src/app/components/profiles/fan-configs-editor.html
+++ b/ui/src/app/components/profiles/fan-configs-editor.html
@@ -6,8 +6,14 @@
           <nexus-icon name="cooling-square" />
           {{ roleLabel(fan.fan_index) }}
         </span>
-        <button nexusIconButton size="sm" aria-label="Remove fan" (click)="removeFan($index)">
-          <nexus-icon name="trash" />
+        <button
+          nexusIconButton
+          size="sm"
+          [attr.aria-label]="confirmRemoveIndex() === $index ? 'Confirm remove fan' : 'Remove fan'"
+          [class.is-confirming]="confirmRemoveIndex() === $index"
+          (click)="requestRemoveFan($index)"
+        >
+          <nexus-icon [name]="confirmRemoveIndex() === $index ? 'check' : 'trash'" />
         </button>
       </div>
 

--- a/ui/src/app/components/profiles/fan-configs-editor.scss
+++ b/ui/src/app/components/profiles/fan-configs-editor.scss
@@ -27,6 +27,18 @@
   border-bottom: 1px solid var(--color-border-light);
 }
 
+.fans__head button[nexusIconButton].is-confirming {
+  color: var(--color-danger);
+  border-color: color-mix(in oklab, var(--color-danger) 28%, var(--color-border));
+  background: color-mix(in oklab, var(--color-danger) 12%, transparent);
+
+  &:hover {
+    color: var(--color-danger);
+    border-color: color-mix(in oklab, var(--color-danger) 40%, var(--color-border));
+    background: color-mix(in oklab, var(--color-danger) 18%, transparent);
+  }
+}
+
 .fans__title {
   display: inline-flex;
   align-items: center;

--- a/ui/src/app/components/profiles/fan-configs-editor.ts
+++ b/ui/src/app/components/profiles/fan-configs-editor.ts
@@ -1,4 +1,4 @@
-import { ChangeDetectionStrategy, Component, computed, input, output } from '@angular/core';
+import { ChangeDetectionStrategy, Component, computed, input, output, signal } from '@angular/core';
 import type { FanConfig } from '../../../generated/slicer-engine-global-settings-v1';
 import { Icon } from '../../shared/icon/icon';
 import { Button } from '../../ui/button/button';
@@ -25,6 +25,8 @@ export const FAN_ROLE_PRESETS: readonly FanRolePreset[] = [
   { index: 2, label: 'Chamber', defaultName: 'fan_chamber' },
   { index: 3, label: 'Auxiliary', defaultName: 'fan_aux' },
 ];
+
+const REMOVE_CONFIRM_TIMEOUT_MS = 3000;
 
 /** A sane fan configuration for a freshly-added row of the given role index. */
 function defaultFan(index: number): FanConfig {
@@ -68,6 +70,8 @@ export class FanConfigsEditor {
   }));
 
   protected readonly rows = computed(() => this.configs() ?? []);
+  protected readonly confirmRemoveIndex = signal<number | null>(null);
+  private removeConfirmTimer: ReturnType<typeof setTimeout> | null = null;
 
   /** The `<nexus-select>` value for a role index (options are string-keyed). */
   protected roleValue(index: number): string {
@@ -85,13 +89,23 @@ export class FanConfigsEditor {
   }
 
   protected addFan(): void {
+    this.clearRemoveFanConfirm();
     const rows = this.rows();
     // First fan is the part-cooling fan; subsequent ones default to auxiliary.
     const index = rows.length === 0 ? 0 : 3;
     this.configsChange.emit([...rows, defaultFan(index)]);
   }
 
+  protected requestRemoveFan(i: number): void {
+    if (this.confirmRemoveIndex() === i) {
+      this.removeFan(i);
+      return;
+    }
+    this.armRemoveFan(i);
+  }
+
   protected removeFan(i: number): void {
+    this.clearRemoveFanConfirm();
     this.configsChange.emit(this.rows().filter((_, idx) => idx !== i));
   }
 
@@ -127,6 +141,25 @@ export class FanConfigsEditor {
 
   protected pct(fraction: number): number {
     return Math.round(clamp01(fraction) * 100);
+  }
+
+  private armRemoveFan(i: number): void {
+    this.clearRemoveFanConfirm();
+    this.confirmRemoveIndex.set(i);
+    this.removeConfirmTimer = setTimeout(() => {
+      if (this.confirmRemoveIndex() === i) {
+        this.confirmRemoveIndex.set(null);
+      }
+      this.removeConfirmTimer = null;
+    }, REMOVE_CONFIRM_TIMEOUT_MS);
+  }
+
+  private clearRemoveFanConfirm(): void {
+    if (this.removeConfirmTimer !== null) {
+      clearTimeout(this.removeConfirmTimer);
+      this.removeConfirmTimer = null;
+    }
+    this.confirmRemoveIndex.set(null);
   }
 }
 

--- a/ui/src/app/pages/settings/filaments.html
+++ b/ui/src/app/pages/settings/filaments.html
@@ -119,8 +119,13 @@
                   <nexus-icon name="copy" />
                 </button>
                 @if (filament.source !== 'builtin') {
-                  <button nexusIconButton aria-label="Delete" (click)="armDelete()">
-                    <nexus-icon name="trash" />
+                  <button
+                    nexusIconButton
+                    [attr.aria-label]="deleteArmed() ? 'Cancel delete' : 'Delete'"
+                    [class.is-danger]="deleteArmed()"
+                    (click)="toggleDelete()"
+                  >
+                    <nexus-icon [name]="deleteArmed() ? 'xmark' : 'trash'" />
                   </button>
                 }
               </div>

--- a/ui/src/app/pages/settings/filaments.ts
+++ b/ui/src/app/pages/settings/filaments.ts
@@ -23,6 +23,7 @@ import type { SchemaGroup } from '../../schema-form/models/field-def';
 import { CloudCatalog } from '../../services/catalog/cloud-catalog';
 import { ContextMenuService } from '../../services/context-menu/context-menu.service';
 import type { ContextMenuItem } from '../../services/context-menu/context-menu.model';
+import { Dialog } from '../../services/dialog';
 import { ActiveSelection } from '../../services/profiles/active-selection';
 import { matchesAllLabels, toggledLabelIds } from '../../services/profiles/label-filtering';
 import { paramNum } from '../../models/params-access';
@@ -125,6 +126,7 @@ export class FilamentsSettings {
   private readonly filterStore = inject(LabelFilterStore);
   private readonly catalog = inject(CloudCatalog);
   private readonly contextMenu = inject(ContextMenuService);
+  private readonly dialog = inject(Dialog);
   private readonly route = inject(ActivatedRoute);
 
   protected readonly sourceLabels = PROFILE_SOURCE_LABELS;
@@ -312,13 +314,18 @@ export class FilamentsSettings {
         label: 'Delete\u2026',
         icon: 'trash',
         danger: true,
-        action: () => {
-          this.select(filament.id);
-          this.armDelete();
-        },
+        action: () => this.confirmDeleteFromContextMenu(filament),
       });
     }
     void this.contextMenu.open(event, items);
+  }
+
+  protected toggleDelete(): void {
+    if (this.deleteArmed()) {
+      this.disarmDelete();
+      return;
+    }
+    this.armDelete();
   }
 
   protected armDelete(): void {
@@ -341,9 +348,31 @@ export class FilamentsSettings {
     if (!filament || !this.deleteReady()) {
       return;
     }
-    this.store.remove(filament.id);
+    this.deleteFilamentById(filament.id);
+  }
+
+  private confirmDeleteFromContextMenu(filament: FilamentProfile): void {
+    this.dialog
+      .confirm({
+        title: `Delete filament "${filament.name}"?`,
+        message: 'This filament profile will be permanently deleted.',
+        type: 'danger',
+        confirmLabel: 'Delete',
+      })
+      .subscribe((confirmed) => {
+        if (!confirmed) {
+          return;
+        }
+        this.deleteFilamentById(filament.id);
+      });
+  }
+
+  private deleteFilamentById(id: string): void {
+    this.store.remove(id);
     this.disarmDelete();
-    this.selectedId.set(this.store.items()[0]?.id ?? null);
+    if (this.selectedId() === id) {
+      this.selectedId.set(this.store.items()[0]?.id ?? null);
+    }
   }
 
   protected readonly pnum = paramNum;

--- a/ui/src/app/pages/settings/labels.html
+++ b/ui/src/app/pages/settings/labels.html
@@ -30,7 +30,7 @@
               [class.is-confirming]="confirmDeleteId() === label.id"
               (click)="requestDelete(label.id)"
             >
-              <nexus-icon name="trash" />
+              <nexus-icon [name]="confirmDeleteId() === label.id ? 'check' : 'trash'" />
             </button>
           </div>
 

--- a/ui/src/app/pages/settings/labels.scss
+++ b/ui/src/app/pages/settings/labels.scss
@@ -25,3 +25,15 @@
   color: var(--color-text-tertiary);
   font-variant-numeric: tabular-nums;
 }
+
+.profile-card__actions button[nexusIconButton].is-confirming {
+  color: var(--color-danger);
+  border-color: color-mix(in oklab, var(--color-danger) 28%, var(--color-border));
+  background: color-mix(in oklab, var(--color-danger) 12%, transparent);
+
+  &:hover {
+    color: var(--color-danger);
+    border-color: color-mix(in oklab, var(--color-danger) 40%, var(--color-border));
+    background: color-mix(in oklab, var(--color-danger) 18%, transparent);
+  }
+}

--- a/ui/src/app/pages/settings/labels.ts
+++ b/ui/src/app/pages/settings/labels.ts
@@ -5,6 +5,7 @@ import { FieldShell } from '../../components/profiles/field-shell';
 import { LabelChip } from '../../components/labels/label-chip';
 import { ContextMenuService } from '../../services/context-menu/context-menu.service';
 import type { ContextMenuItem } from '../../services/context-menu/context-menu.model';
+import { Dialog } from '../../services/dialog';
 import { FilamentsStore } from '../../services/profiles/filaments-store';
 import { LabelsStore } from '../../services/profiles/labels-store';
 import { PrintProfilesStore } from '../../services/profiles/print-profiles-store';
@@ -37,6 +38,7 @@ export class LabelsSettings {
   private readonly filaments = inject(FilamentsStore);
   private readonly profiles = inject(PrintProfilesStore);
   private readonly contextMenu = inject(ContextMenuService);
+  private readonly dialog = inject(Dialog);
 
   protected readonly editingId = signal<string | null>(null);
   protected readonly confirmDeleteId = signal<string | null>(null);
@@ -79,15 +81,10 @@ export class LabelsSettings {
       },
       { separator: true, label: '' },
       {
-        label: 'Delete',
+        label: 'Delete…',
         icon: 'trash',
         danger: true,
-        action: () => {
-          this.store.remove(label.id);
-          if (this.editingId() === label.id) {
-            this.editingId.set(null);
-          }
-        },
+        action: () => this.confirmDeleteFromMenu(label),
       },
     ];
     void this.contextMenu.open(event, items);
@@ -107,11 +104,8 @@ export class LabelsSettings {
 
   protected requestDelete(id: string): void {
     if (this.confirmDeleteId() === id) {
-      this.store.remove(id);
+      this.deleteLabel(id);
       this.confirmDeleteId.set(null);
-      if (this.editingId() === id) {
-        this.editingId.set(null);
-      }
     } else {
       this.confirmDeleteId.set(id);
       setTimeout(() => {
@@ -119,6 +113,36 @@ export class LabelsSettings {
           this.confirmDeleteId.set(null);
         }
       }, 3000);
+    }
+  }
+
+  private confirmDeleteFromMenu(label: Label): void {
+    const usage = this.usageFor(label.id);
+    const name = label.name.trim() || 'Unnamed label';
+    const usageCopy =
+      usage > 0
+        ? ` It will also be removed from ${usage} printer, filament, or profile assignment${usage === 1 ? '' : 's'}.`
+        : '';
+    this.dialog
+      .confirm({
+        title: `Delete label "${name}"?`,
+        message: `This label will be permanently deleted.${usageCopy}`,
+        type: 'danger',
+        confirmLabel: 'Delete',
+      })
+      .subscribe((confirmed) => {
+        if (!confirmed) {
+          return;
+        }
+        this.deleteLabel(label.id);
+        this.confirmDeleteId.set(null);
+      });
+  }
+
+  private deleteLabel(id: string): void {
+    this.store.remove(id);
+    if (this.editingId() === id) {
+      this.editingId.set(null);
     }
   }
 

--- a/ui/src/app/pages/settings/printers.html
+++ b/ui/src/app/pages/settings/printers.html
@@ -122,8 +122,13 @@
                   <nexus-icon name="copy" />
                 </button>
                 @if (printer.source !== 'builtin') {
-                  <button nexusIconButton aria-label="Delete" (click)="armDelete()">
-                    <nexus-icon name="trash" />
+                  <button
+                    nexusIconButton
+                    [attr.aria-label]="deleteArmed() ? 'Cancel delete' : 'Delete'"
+                    [class.is-danger]="deleteArmed()"
+                    (click)="toggleDelete()"
+                  >
+                    <nexus-icon [name]="deleteArmed() ? 'xmark' : 'trash'" />
                   </button>
                 }
               </div>

--- a/ui/src/app/pages/settings/printers.ts
+++ b/ui/src/app/pages/settings/printers.ts
@@ -34,6 +34,7 @@ import {
 import { CloudCatalog } from '../../services/catalog/cloud-catalog';
 import { ContextMenuService } from '../../services/context-menu/context-menu.service';
 import type { ContextMenuItem } from '../../services/context-menu/context-menu.model';
+import { Dialog } from '../../services/dialog';
 import { PrinterConnectionService } from '../../services/printer-connection';
 import { ActiveSelection } from '../../services/profiles/active-selection';
 import { matchesAllLabels, toggledLabelIds } from '../../services/profiles/label-filtering';
@@ -143,6 +144,7 @@ export class PrintersSettings {
   private readonly filterStore = inject(LabelFilterStore);
   private readonly catalog = inject(CloudCatalog);
   private readonly contextMenu = inject(ContextMenuService);
+  private readonly dialog = inject(Dialog);
   private readonly printerConn = inject(PrinterConnectionService);
   private readonly route = inject(ActivatedRoute);
 
@@ -360,13 +362,18 @@ export class PrintersSettings {
         label: 'Delete\u2026',
         icon: 'trash',
         danger: true,
-        action: () => {
-          this.select(printer.id);
-          this.armDelete();
-        },
+        action: () => this.confirmDeleteFromContextMenu(printer),
       });
     }
     void this.contextMenu.open(event, items);
+  }
+
+  protected toggleDelete(): void {
+    if (this.deleteArmed()) {
+      this.disarmDelete();
+      return;
+    }
+    this.armDelete();
   }
 
   protected armDelete(): void {
@@ -389,9 +396,7 @@ export class PrintersSettings {
     if (!printer || !this.deleteReady()) {
       return;
     }
-    this.store.remove(printer.id);
-    this.disarmDelete();
-    this.selectedId.set(this.store.items()[0]?.id ?? null);
+    this.deletePrinterById(printer.id);
   }
 
   protected readonly pnum = paramNum;
@@ -542,6 +547,30 @@ export class PrintersSettings {
   protected setConnectionApiKey(id: string, event: Event): void {
     const key = (event.target as HTMLInputElement).value;
     this.updateConnection(id, { api_key: key || undefined });
+  }
+
+  private confirmDeleteFromContextMenu(printer: PrinterProfile): void {
+    this.dialog
+      .confirm({
+        title: `Delete printer "${printer.name}"?`,
+        message: 'This printer profile will be permanently deleted.',
+        type: 'danger',
+        confirmLabel: 'Delete',
+      })
+      .subscribe((confirmed) => {
+        if (!confirmed) {
+          return;
+        }
+        this.deletePrinterById(printer.id);
+      });
+  }
+
+  private deletePrinterById(id: string): void {
+    this.store.remove(id);
+    this.disarmDelete();
+    if (this.selectedId() === id) {
+      this.selectedId.set(this.store.items()[0]?.id ?? null);
+    }
   }
 
   /** Merge a partial connection into a stored printer's `connection` block. */

--- a/ui/src/app/pages/settings/profiles.html
+++ b/ui/src/app/pages/settings/profiles.html
@@ -121,8 +121,13 @@
                   <nexus-icon name="copy" />
                 </button>
                 @if (profile.source !== 'builtin') {
-                  <button nexusIconButton aria-label="Delete" (click)="armDelete()">
-                    <nexus-icon name="trash" />
+                  <button
+                    nexusIconButton
+                    [attr.aria-label]="deleteArmed() ? 'Cancel delete' : 'Delete'"
+                    [class.is-danger]="deleteArmed()"
+                    (click)="toggleDelete()"
+                  >
+                    <nexus-icon [name]="deleteArmed() ? 'xmark' : 'trash'" />
                   </button>
                 }
               </div>

--- a/ui/src/app/pages/settings/profiles.ts
+++ b/ui/src/app/pages/settings/profiles.ts
@@ -16,6 +16,7 @@ import type { SchemaGroup } from '../../schema-form/models/field-def';
 import { CloudCatalog } from '../../services/catalog/cloud-catalog';
 import { ContextMenuService } from '../../services/context-menu/context-menu.service';
 import type { ContextMenuItem } from '../../services/context-menu/context-menu.model';
+import { Dialog } from '../../services/dialog';
 import { ActiveSelection } from '../../services/profiles/active-selection';
 import { matchesAllLabels, toggledLabelIds } from '../../services/profiles/label-filtering';
 import { paramNum } from '../../models/params-access';
@@ -93,6 +94,7 @@ export class ProfilesSettings {
   private readonly filterStore = inject(LabelFilterStore);
   private readonly catalog = inject(CloudCatalog);
   private readonly contextMenu = inject(ContextMenuService);
+  private readonly dialog = inject(Dialog);
   private readonly route = inject(ActivatedRoute);
 
   protected readonly sourceLabels = PROFILE_SOURCE_LABELS;
@@ -281,13 +283,18 @@ export class ProfilesSettings {
         label: 'Delete\u2026',
         icon: 'trash',
         danger: true,
-        action: () => {
-          this.select(profile.id);
-          this.armDelete();
-        },
+        action: () => this.confirmDeleteFromContextMenu(profile),
       });
     }
     void this.contextMenu.open(event, items);
+  }
+
+  protected toggleDelete(): void {
+    if (this.deleteArmed()) {
+      this.disarmDelete();
+      return;
+    }
+    this.armDelete();
   }
 
   protected armDelete(): void {
@@ -310,9 +317,31 @@ export class ProfilesSettings {
     if (!profile || !this.deleteReady()) {
       return;
     }
-    this.store.remove(profile.id);
+    this.deleteProfileById(profile.id);
+  }
+
+  private confirmDeleteFromContextMenu(profile: PrintProfile): void {
+    this.dialog
+      .confirm({
+        title: `Delete profile "${profile.name}"?`,
+        message: 'This print profile will be permanently deleted.',
+        type: 'danger',
+        confirmLabel: 'Delete',
+      })
+      .subscribe((confirmed) => {
+        if (!confirmed) {
+          return;
+        }
+        this.deleteProfileById(profile.id);
+      });
+  }
+
+  private deleteProfileById(id: string): void {
+    this.store.remove(id);
     this.disarmDelete();
-    this.selectedId.set(this.store.items()[0]?.id ?? null);
+    if (this.selectedId() === id) {
+      this.selectedId.set(this.store.items()[0]?.id ?? null);
+    }
   }
 
   protected readonly pnum = paramNum;

--- a/ui/src/app/pages/ui-components/ui-components.component.html
+++ b/ui/src/app/pages/ui-components/ui-components.component.html
@@ -350,11 +350,14 @@
         <nexus-card visualSize="small" class="demo-card">
           <h3 class="subheading">Dialogs</h3>
           <p class="hint">
-            Dialogs are rendered by the global dialog outlet attached in the root app shell.
+            Shared dialog variants used across the app (including destructive actions in Settings).
           </p>
           <div class="row wrap">
-            <button nexusButton variant="subtle" (click)="openConfirmDialog()">
-              Confirm dialog
+            <button nexusButton variant="subtle" (click)="openWarningConfirmDialog()">
+              Warning confirm
+            </button>
+            <button nexusButton variant="danger" (click)="openDangerConfirmDialog()">
+              Danger confirm
             </button>
             <button nexusButton variant="secondary" (click)="openAlertDialog()">
               Alert dialog

--- a/ui/src/app/pages/ui-components/ui-components.component.ts
+++ b/ui/src/app/pages/ui-components/ui-components.component.ts
@@ -155,7 +155,7 @@ export class UiComponentsPage implements OnDestroy {
     }, 220);
   }
 
-  openConfirmDialog(): void {
+  openWarningConfirmDialog(): void {
     this.#dialog
       .confirm({
         title: 'Discard changes?',
@@ -166,6 +166,24 @@ export class UiComponentsPage implements OnDestroy {
       .subscribe((confirmed) => {
         if (confirmed) {
           this.#notifications.success('Changes discarded');
+        }
+      });
+  }
+
+  openDangerConfirmDialog(): void {
+    this.#dialog
+      .confirm({
+        title: 'Delete printer "Voron 2.4"?',
+        message: 'This printer profile will be permanently deleted.',
+        type: 'danger',
+        confirmLabel: 'Delete',
+      })
+      .subscribe((confirmed) => {
+        if (confirmed) {
+          this.#notifications.warning(
+            'Delete confirmed',
+            'Demo only: this action does not remove anything.',
+          );
         }
       });
   }

--- a/ui/src/app/shared/dialog/dialog-outlet.html
+++ b/ui/src/app/shared/dialog/dialog-outlet.html
@@ -25,16 +25,15 @@
 
     <div class="dialog__actions">
       @if (!d.config.alertOnly) {
-        <button class="dialog__btn dialog__btn--ghost" type="button" (click)="cancel()">
+        <button nexusButton variant="ghost" size="sm" type="button" (click)="cancel()">
           {{ d.config.cancelLabel ?? 'Cancel' }}
         </button>
       }
 
       <button
-        class="dialog__btn"
-        [class.dialog__btn--primary]="(d.config.type ?? 'default') === 'default'"
-        [class.dialog__btn--warning]="d.config.type === 'warning'"
-        [class.dialog__btn--danger]="d.config.type === 'danger'"
+        nexusButton
+        [variant]="d.config.type === 'danger' ? 'danger' : 'primary'"
+        size="sm"
         type="button"
         (click)="confirm()"
       >

--- a/ui/src/app/shared/dialog/dialog-outlet.scss
+++ b/ui/src/app/shared/dialog/dialog-outlet.scss
@@ -8,17 +8,17 @@ nexus-dialog-outlet {
     display: flex;
     flex-direction: column;
     padding: 0;
-    border: 1px solid var(--color-border, #2e3640);
-    border-radius: var(--radius-lg, 8px);
+    border: 1px solid color-mix(in oklab, var(--color-border) 68%, transparent);
+    border-radius: 14px;
     background: var(--color-surface, #1e2128);
     color: inherit;
     outline: none;
-    width: min(var(--dialog-preferred-width, 440px), calc(100vw - 48px));
+    width: min(var(--dialog-preferred-width, 460px), calc(100vw - 44px));
     max-height: calc(100dvh - 48px);
     overflow: hidden;
     box-shadow:
-      0 0 0 1px color-mix(in srgb, var(--color-primary, #7c84f5) 6%, transparent),
-      var(--shadow-md, 0 8px 32px rgba(0, 0, 0, 0.4));
+      0 22px 54px color-mix(in oklab, black 46%, transparent),
+      0 2px 10px color-mix(in oklab, black 26%, transparent);
     animation: dialog-enter 240ms var(--ease-decelerate, cubic-bezier(0, 0, 0.2, 1)) both;
 
     &.dialog--leaving {
@@ -26,19 +26,15 @@ nexus-dialog-outlet {
     }
 
     &.dialog--warning {
-      box-shadow:
-        0 0 0 1px color-mix(in srgb, var(--color-warning, #f5a623) 20%, transparent),
-        var(--shadow-md, 0 8px 32px rgba(0, 0, 0, 0.4));
+      border-color: color-mix(in oklab, var(--color-warning) 35%, var(--color-border));
     }
 
     &.dialog--danger {
-      box-shadow:
-        0 0 0 1px color-mix(in srgb, var(--color-danger, #ff6b6b) 20%, transparent),
-        var(--shadow-md, 0 8px 32px rgba(0, 0, 0, 0.4));
+      border-color: color-mix(in oklab, var(--color-danger) 35%, var(--color-border));
     }
 
     &::backdrop {
-      background: rgba(0, 0, 0, 0.55);
+      background: color-mix(in oklab, black 62%, transparent);
       animation: backdrop-enter 240ms var(--ease-decelerate, cubic-bezier(0, 0, 0.2, 1)) both;
     }
 
@@ -49,141 +45,47 @@ nexus-dialog-outlet {
 
   .dialog__header {
     flex-shrink: 0;
-    padding: 14px 16px;
-    border-bottom: 1px solid var(--color-border, #2e3640);
-    background: var(--color-bg-secondary, #1a1b1e);
+    padding: 18px 22px 8px;
+    border-bottom: none;
+    background: transparent;
   }
 
   .dialog__title {
     margin: 0;
-    font-size: 14px;
-    font-weight: 600;
+    font-size: 16px;
+    font-weight: var(--font-weight-semibold);
     color: var(--color-text-primary, #f5f6f8);
-    line-height: 1.35;
+    letter-spacing: 0.01em;
+    line-height: 1.3;
   }
 
   .dialog__message {
     flex-shrink: 0;
     margin: 0;
-    padding: 16px;
-    font-size: 13px;
+    padding: 0 22px 6px;
+    font-size: var(--font-size-sm);
     color: var(--color-text-secondary, #d4d6db);
-    line-height: 1.55;
+    line-height: 1.6;
   }
 
   .dialog__actions {
     flex-shrink: 0;
     display: flex;
     justify-content: flex-end;
-    gap: var(--spacing-sm, 8px);
-    padding: 12px 16px;
-    border-top: 1px solid var(--color-border-light, #252b34);
-    background: color-mix(in srgb, var(--color-bg-secondary, #1a1b1e) 50%, transparent);
-  }
+    gap: var(--spacing-sm);
+    padding: 12px 22px 20px;
+    border-top: none;
+    background: transparent;
 
-  .dialog__btn {
-    display: inline-flex;
-    align-items: center;
-    padding: 6px 14px;
-    font-size: 13px;
-    font-weight: 500;
-    font-family: inherit;
-    line-height: 1.4;
-    border: 1px solid transparent;
-    border-radius: var(--radius-md, 6px);
-    cursor: pointer;
-    transition:
-      background var(--transition-fast, 0.15s ease),
-      border-color var(--transition-fast, 0.15s ease),
-      color var(--transition-fast, 0.15s ease);
-
-    &:focus-visible {
-      outline: 2px solid var(--color-focus-ring, #9aa2ff);
-      outline-offset: 2px;
-    }
-
-    &--ghost {
-      border-color: var(--color-border, #2e3640);
-      color: var(--color-text-secondary, #d4d6db);
-
-      &:hover {
-        background: var(--color-surface-hover, #252b34);
-        color: var(--color-text-primary, #f5f6f8);
-      }
-      &:active {
-        background: var(--color-surface-active, #2e3640);
-      }
-    }
-
-    &--primary {
-      background: var(--color-primary, #7c84f5);
-      border-color: var(--color-primary, #7c84f5);
-      color: var(--color-primary-contrast, #fff);
-
-      &:hover {
-        background: var(--color-primary-hover, #9aa2ff);
-        border-color: var(--color-primary-hover, #9aa2ff);
-      }
-      &:active {
-        filter: brightness(0.92);
-      }
-    }
-
-    &--warning {
-      background: color-mix(
-        in srgb,
-        var(--color-warning, #f5a623) 12%,
-        var(--color-surface, #1e2128)
-      );
-      border-color: color-mix(in srgb, var(--color-warning, #f5a623) 30%, transparent);
-      color: var(--color-warning, #f5a623);
-
-      &:hover {
-        background: color-mix(
-          in srgb,
-          var(--color-warning, #f5a623) 20%,
-          var(--color-surface, #1e2128)
-        );
-      }
-      &:active {
-        background: color-mix(
-          in srgb,
-          var(--color-warning, #f5a623) 25%,
-          var(--color-surface, #1e2128)
-        );
-      }
-    }
-
-    &--danger {
-      background: color-mix(
-        in srgb,
-        var(--color-danger, #ff6b6b) 12%,
-        var(--color-surface, #1e2128)
-      );
-      border-color: color-mix(in srgb, var(--color-danger, #ff6b6b) 30%, transparent);
-      color: var(--color-danger, #ff6b6b);
-
-      &:hover {
-        background: color-mix(
-          in srgb,
-          var(--color-danger, #ff6b6b) 20%,
-          var(--color-surface, #1e2128)
-        );
-      }
-      &:active {
-        background: color-mix(
-          in srgb,
-          var(--color-danger, #ff6b6b) 25%,
-          var(--color-surface, #1e2128)
-        );
-      }
+    button[nexusButton] {
+      min-width: 92px;
     }
   }
 
   .dialog__body {
     flex: 1;
     overflow-y: auto;
-    padding: 16px;
+    padding: 8px 22px 16px;
   }
 }
 
@@ -201,15 +103,15 @@ nexus-dialog-outlet {
 @keyframes dialog-enter {
   from {
     opacity: 0;
-    scale: 0.95;
-    translate: 0 6px;
+    scale: 0.97;
+    translate: 0 10px;
   }
 }
 
 @keyframes dialog-leave {
   to {
     opacity: 0;
-    scale: 0.96;
-    translate: 0 4px;
+    scale: 0.985;
+    translate: 0 6px;
   }
 }

--- a/ui/src/app/shared/dialog/dialog-outlet.ts
+++ b/ui/src/app/shared/dialog/dialog-outlet.ts
@@ -8,11 +8,12 @@ import {
   inject,
 } from '@angular/core';
 import { Dialog } from '../../services/dialog';
+import { Button } from '../../ui/button/button';
 
 @Component({
   selector: 'nexus-dialog-outlet',
   standalone: true,
-  imports: [NgComponentOutlet],
+  imports: [NgComponentOutlet, Button],
   templateUrl: './dialog-outlet.html',
   styleUrl: './dialog-outlet.scss',
   changeDetection: ChangeDetectionStrategy.OnPush,

--- a/ui/src/app/ui/button/button.scss
+++ b/ui/src/app/ui/button/button.scss
@@ -20,9 +20,7 @@
     background-color var(--duration-fast) var(--ease-standard),
     border-color var(--duration-fast) var(--ease-standard),
     color var(--duration-fast) var(--ease-standard),
-    box-shadow var(--duration-fast) var(--ease-standard),
-    font-weight var(--duration-fast) var(--ease-standard),
-    font-variation-settings var(--duration-fast) var(--ease-standard);
+    box-shadow var(--duration-fast) var(--ease-standard);
 
   &:focus-visible {
     outline: none;
@@ -46,16 +44,6 @@
   flex: none;
   color: currentColor;
   opacity: 0.92;
-}
-
-:host:hover:not(:disabled):not([aria-disabled='true']) {
-  font-weight: var(--font-weight-semibold);
-  font-variation-settings: 'wght' var(--font-weight-semibold);
-}
-
-:host:active:not(:disabled):not([aria-disabled='true']) {
-  font-weight: var(--font-weight-active);
-  font-variation-settings: 'wght' var(--font-weight-active);
 }
 
 // ── Sizes ──

--- a/ui/src/styles/components/_manage.scss
+++ b/ui/src/styles/components/_manage.scss
@@ -315,6 +315,18 @@
   gap: var(--spacing-xs);
 }
 
+.mgr__detail-actions button[nexusIconButton].is-danger {
+  color: var(--color-danger);
+  border-color: color-mix(in oklab, var(--color-danger) 28%, var(--color-border));
+  background: color-mix(in oklab, var(--color-danger) 12%, transparent);
+
+  &:hover {
+    color: var(--color-danger);
+    border-color: color-mix(in oklab, var(--color-danger) 40%, var(--color-border));
+    background: color-mix(in oklab, var(--color-danger) 18%, transparent);
+  }
+}
+
 .mgr__default-btn {
   display: inline-flex;
   align-items: center;


### PR DESCRIPTION
## Summary
- standardize destructive flows across Settings and related editors so accidental deletes are less likely
- route context-menu and right-click deletes through explicit shared danger confirmations (printers, filaments, profiles, labels)
- keep typed-name confirmation for high-impact deletes, with a clear arm and cancel state
- modernize shared dialog visuals and reuse the shared nexusButton primitive for dialog actions
- remove hover and active font-weight thickening from base nexusButton while preserving specialized emphasis behavior in settings sidebar and accordion surfaces

## Why
Right-click delete paths felt inconsistent and unexpectedly destructive compared with inline flows. This change makes destructive UX predictable by impact and keeps dialog and button presentation coherent with the shared design system.

## Validation
- pnpm exec prettier --check on all changed UI files
- pnpm run ui:build (passes; existing bundle and style budget warnings remain)
- browser validation of dialog and settings delete flows during iteration