### PR TITLE
ci: fix SLOC badge to publish to unprotected branch

### DIFF
--- a/.github/badges/sloc.json
+++ b/.github/badges/sloc.json
@@ -1,1 +1,0 @@
-{ "schemaVersion": 1, "label": "SLOC", "message": "75,399", "color": "orange" }

--- a/.github/workflows/sloc.yml
+++ b/.github/workflows/sloc.yml
@@ -2,17 +2,17 @@ name: SLOC
 
 # Keeps the README's source-lines-of-code badge current without any manual work.
 # On every push to main it recounts all git-tracked source (Rust + Angular +
-# everything else) with tokei and rewrites .github/badges/sloc.json, which the
-# README renders through a shields.io endpoint badge. The badge commit carries
-# [skip ci] so it never re-triggers this (or any other) workflow.
+# everything else) with tokei and publishes the number as a shields.io endpoint
+# JSON on the dedicated, unprotected `badges` branch. Main is protected (all
+# changes must go through a PR), so the badge is force-pushed to `badges`
+# instead - a single-commit generated branch the README reads from. Pushes made
+# with GITHUB_TOKEN don't trigger further workflow runs, so there's no loop.
 on:
   push:
     branches: [main]
-    paths-ignore:
-      - ".github/badges/sloc.json"
   workflow_dispatch:
 
-# Needs write access to commit the refreshed badge JSON back to main.
+# Needs write access to force-push the refreshed badge JSON to the badges branch.
 permissions:
   contents: write
 
@@ -33,23 +33,24 @@ jobs:
             | tar xz
           sudo install -m 0755 tokei /usr/local/bin/tokei
 
-      - name: Recount SLOC and refresh badge
+      - name: Recount SLOC and publish badge
+        env:
+          GH_TOKEN: ${{ secrets.GITHUB_TOKEN }}
         run: |
           code=$(tokei --output json | python3 -c "import sys,json;print(json.load(sys.stdin)['Total']['code'])")
           formatted=$(python3 -c "print(f'{$code:,}')")
-          mkdir -p .github/badges
-          printf '{ "schemaVersion": 1, "label": "SLOC", "message": "%s", "color": "orange" }\n' "$formatted" \
-            > .github/badges/sloc.json
           echo "SLOC = $formatted"
 
-      - name: Commit if changed
-        run: |
+          # Build the whole badge branch fresh in a scratch dir so it stays a
+          # single commit (no history growth) and force-push it to `badges`.
+          work=$(mktemp -d)
+          cd "$work"
+          git init -q
           git config user.name 'github-actions[bot]'
           git config user.email '41898282+github-actions[bot]@users.noreply.github.com'
-          git add .github/badges/sloc.json
-          if git diff --staged --quiet; then
-            echo "SLOC badge already up to date."
-          else
-            git commit -m "chore: update SLOC badge [skip ci]"
-            git push
-          fi
+          git checkout -q --orphan badges
+          printf '{ "schemaVersion": 1, "label": "SLOC", "message": "%s", "color": "orange" }\n' "$formatted" \
+            > sloc.json
+          git add sloc.json
+          git commit -q -m "chore: SLOC ${formatted}"
+          git push -q --force "https://x-access-token:${GH_TOKEN}@github.com/${GITHUB_REPOSITORY}.git" badges

--- a/README.md
+++ b/README.md
@@ -12,7 +12,7 @@ The web version runs fully in the browser, so you can slice on an iPad or any de
 
 [![Frontend CI](https://github.com/ColdCrabby/slicer/actions/workflows/ui-ci.yml/badge.svg)](https://github.com/ColdCrabby/slicer/actions/workflows/ui-ci.yml)
 [![Security](https://github.com/ColdCrabby/slicer/actions/workflows/security.yml/badge.svg)](https://github.com/ColdCrabby/slicer/actions/workflows/security.yml)
-[![SLOC](https://img.shields.io/endpoint?url=https%3A%2F%2Fraw.githubusercontent.com%2FColdCrabby%2Fslicer%2Fmain%2F.github%2Fbadges%2Fsloc.json)](https://github.com/ColdCrabby/slicer/actions/workflows/sloc.yml)
+[![SLOC](https://img.shields.io/endpoint?url=https%3A%2F%2Fraw.githubusercontent.com%2FColdCrabby%2Fslicer%2Fbadges%2Fsloc.json)](https://github.com/ColdCrabby/slicer/actions/workflows/sloc.yml)
 
 </div>
 


### PR DESCRIPTION
## Problem
The `SLOC` workflow tried to push the refreshed badge JSON straight to `main`, but `main` is protected by a ruleset (*"Changes must be made through a pull request"* + required status checks). The push was rejected (`GH013`), so the workflow failed on merge.

## Fix
Publish the badge to a dedicated, **unprotected** `badges` branch instead of `main`:

- The workflow now force-pushes a single-commit `badges` branch containing just `sloc.json` (a shields.io endpoint payload). The ruleset only targets the default branch, so `GITHUB_TOKEN` can push here freely. Force-push keeps it to one commit (no history growth), and `GITHUB_TOKEN` pushes don't re-trigger workflows (no loop).
- README badge now reads from `…/slicer/badges/sloc.json`.
- Removed the now-unused `.github/badges/sloc.json` seed from `main`.

The `badges` branch is already seeded (`SLOC: 75,399`), so the badge is live now; each push to `main` refreshes it.

## Notes
CI/docs only.