### PR TITLE
ui: fix dialog mount and iPad modal sizing

### DIFF
--- a/ui/src/app/shared/dialog/dialog-outlet.scss
+++ b/ui/src/app/shared/dialog/dialog-outlet.scss
@@ -5,7 +5,7 @@ nexus-dialog-outlet {
   display: contents;
 
   dialog {
-    display: flex;
+    display: none;
     flex-direction: column;
     padding: 0;
     border: 1px solid color-mix(in oklab, var(--color-border) 68%, transparent);
@@ -14,12 +14,19 @@ nexus-dialog-outlet {
     color: inherit;
     outline: none;
     width: min(var(--dialog-preferred-width, 460px), calc(100vw - 44px));
-    max-height: calc(100dvh - 48px);
+    max-height: calc(
+      100vh - env(safe-area-inset-top, 0px) - env(safe-area-inset-bottom, 0px) - 48px
+    );
     overflow: hidden;
+    margin: auto;
     box-shadow:
       0 22px 54px color-mix(in oklab, black 46%, transparent),
       0 2px 10px color-mix(in oklab, black 26%, transparent);
     animation: dialog-enter 240ms var(--ease-decelerate, cubic-bezier(0, 0, 0.2, 1)) both;
+
+    &[open] {
+      display: flex;
+    }
 
     &.dialog--leaving {
       animation: dialog-leave 200ms var(--ease-accelerate, cubic-bezier(0.4, 0, 1, 1)) forwards;
@@ -84,8 +91,17 @@ nexus-dialog-outlet {
 
   .dialog__body {
     flex: 1;
+    min-height: 0;
     overflow-y: auto;
     padding: 8px 22px 16px;
+  }
+}
+
+@supports (height: 100svh) {
+  nexus-dialog-outlet dialog {
+    max-height: calc(
+      100svh - env(safe-area-inset-top, 0px) - env(safe-area-inset-bottom, 0px) - 48px
+    );
   }
 }
 

--- a/ui/src/app/ui/modal-shell/modal-shell.scss
+++ b/ui/src/app/ui/modal-shell/modal-shell.scss
@@ -5,6 +5,10 @@
   display: grid;
   place-items: center;
   padding: var(--spacing-xl);
+  padding-top: calc(var(--spacing-xl) + env(safe-area-inset-top, 0px));
+  padding-right: calc(var(--spacing-xl) + env(safe-area-inset-right, 0px));
+  padding-bottom: calc(var(--spacing-xl) + env(safe-area-inset-bottom, 0px));
+  padding-left: calc(var(--spacing-xl) + env(safe-area-inset-left, 0px));
 }
 
 .modal__scrim {
@@ -18,12 +22,24 @@
   display: flex;
   flex-direction: column;
   width: min(560px, 100%);
-  max-height: min(720px, 88vh);
+  max-height: min(
+    720px,
+    calc(100vh - env(safe-area-inset-top, 0px) - env(safe-area-inset-bottom, 0px) - 64px)
+  );
   background: var(--color-surface);
   border: 1px solid var(--color-border);
   border-radius: var(--radius-lg);
   box-shadow: var(--shadow-lg);
   overflow: hidden;
+}
+
+@supports (height: 100svh) {
+  .modal {
+    max-height: min(
+      720px,
+      calc(100svh - env(safe-area-inset-top, 0px) - env(safe-area-inset-bottom, 0px) - 64px)
+    );
+  }
 }
 
 .modal__header {


### PR DESCRIPTION
## Summary
- hide the shared `<dialog>` unless it is actually `[open]` so closed dialogs cannot render as a stray floating 1px line
- make the shared dialog body flex-safe (`min-height: 0`) so long dialog content can scroll instead of collapsing
- switch shared dialog and modal-shell height constraints to viewport + safe-area aware `vh/svh` rules for more stable iPad sizing

## Why
On iPad, the speed/performance dialog could render with an unusably small visible body, and occasionally a dangling line remained after dialogs closed. These changes harden dialog mounting/visibility and use safer viewport sizing behavior across iPad/browser chrome states.

## Validation
- pre-commit hook passed (`prettier` on changed files)
- manually reviewed all in-app dialog containers touched by these styles:
  - shared dialog outlet (`nexus-dialog-outlet`)
  - settings catalog modal shell (`nexus-modal-shell`)
