### PR TITLE
ci: separate Rust/TS SLOC + test & quality badges

### DIFF
--- a/.github/workflows/quality.yml
+++ b/.github/workflows/quality.yml
@@ -1,0 +1,41 @@
+name: Quality
+
+# The slicing quality gate, split into its own workflow so it exposes an
+# independent status badge (separate from the unit-test run in
+# test-results.yml). The job name is unchanged ("Slicing quality gate"), so the
+# branch-protection required-status-check keyed off that name still resolves.
+on:
+  push:
+    branches: [main, develop]
+  pull_request:
+    branches: [main, develop]
+
+env:
+  CARGO_TERM_COLOR: always
+
+permissions:
+  contents: read
+
+jobs:
+  quality:
+    name: Slicing quality gate
+    runs-on: ubuntu-latest
+    steps:
+      - uses: actions/checkout@v7
+      - uses: dtolnay/rust-toolchain@stable
+      - uses: Swatinem/rust-cache@v2
+      # Slices the fixture corpus with both wall generators, measures the
+      # G-code, checks invariants, and diffs against the committed baselines.
+      # QA_REPORT=1 also captures per-stage geometry into target/qa/report.html.
+      # Baselines are pinned to this job's platform+profile (ubuntu, debug), so
+      # regenerate here — not on macOS — when a deliberate change moves them:
+      #   UPDATE_QA_BASELINES=1 QA_FULL=1 cargo test --test slicing_quality -- --ignored
+      - name: Run slicing quality gate
+        run: QA_REPORT=1 cargo test --test slicing_quality -- --ignored --nocapture
+      - name: Upload quality report
+        if: always()
+        uses: actions/upload-artifact@v7
+        with:
+          name: slicing-quality-report
+          path: target/qa/
+          if-no-files-found: warn

--- a/.github/workflows/sloc.yml
+++ b/.github/workflows/sloc.yml
@@ -1,10 +1,10 @@
 name: SLOC
 
-# Keeps the README's source-lines-of-code badge current without any manual work.
-# On every push to main it recounts all git-tracked source (Rust + Angular +
-# everything else) with tokei and publishes the number as a shields.io endpoint
-# JSON on the dedicated, unprotected `badges` branch. Main is protected (all
-# changes must go through a PR), so the badge is force-pushed to `badges`
+# Keeps the README's source-lines-of-code badges current without any manual work.
+# On every push to main it recounts git-tracked source with tokei and publishes
+# per-language line counts (Rust and TypeScript, separately) as shields.io
+# endpoint JSON on the dedicated, unprotected `badges` branch. Main is protected
+# (all changes must go through a PR), so the badges are force-pushed to `badges`
 # instead - a single-commit generated branch the README reads from. Pushes made
 # with GITHUB_TOKEN don't trigger further workflow runs, so there's no loop.
 on:
@@ -33,13 +33,14 @@ jobs:
             | tar xz
           sudo install -m 0755 tokei /usr/local/bin/tokei
 
-      - name: Recount SLOC and publish badge
+      - name: Recount SLOC and publish badges
         env:
           GH_TOKEN: ${{ secrets.GITHUB_TOKEN }}
         run: |
-          code=$(tokei --output json | python3 -c "import sys,json;print(json.load(sys.stdin)['Total']['code'])")
-          formatted=$(python3 -c "print(f'{$code:,}')")
-          echo "SLOC = $formatted"
+          read rust ts <<< "$(tokei --output json | python3 -c "import sys,json;d=json.load(sys.stdin);print(d.get('Rust',{}).get('code',0), d.get('TypeScript',{}).get('code',0))")"
+          rust_f=$(python3 -c "print(f'{$rust:,}')")
+          ts_f=$(python3 -c "print(f'{$ts:,}')")
+          echo "Rust=$rust_f  TypeScript=$ts_f"
 
           # Build the whole badge branch fresh in a scratch dir so it stays a
           # single commit (no history growth) and force-push it to `badges`.
@@ -49,8 +50,8 @@ jobs:
           git config user.name 'github-actions[bot]'
           git config user.email '41898282+github-actions[bot]@users.noreply.github.com'
           git checkout -q --orphan badges
-          printf '{ "schemaVersion": 1, "label": "SLOC", "message": "%s", "color": "orange" }\n' "$formatted" \
-            > sloc.json
-          git add sloc.json
-          git commit -q -m "chore: SLOC ${formatted}"
+          printf '{ "schemaVersion": 1, "label": "Rust", "message": "%s", "color": "orange", "namedLogo": "rust", "logoColor": "white" }\n' "$rust_f" > rust.json
+          printf '{ "schemaVersion": 1, "label": "TypeScript", "message": "%s", "color": "3178c6", "namedLogo": "typescript", "logoColor": "white" }\n' "$ts_f" > typescript.json
+          git add rust.json typescript.json
+          git commit -q -m "chore: SLOC Rust ${rust_f}, TypeScript ${ts_f}"
           git push -q --force "https://x-access-token:${GH_TOKEN}@github.com/${GITHUB_REPOSITORY}.git" badges

--- a/.github/workflows/test-results.yml
+++ b/.github/workflows/test-results.yml
@@ -42,26 +42,3 @@ jobs:
           path: target/nextest/ci/junit.xml
           reporter: java-junit
           fail-on-error: true
-
-  quality:
-    name: Slicing quality gate
-    runs-on: ubuntu-latest
-    steps:
-      - uses: actions/checkout@v7
-      - uses: dtolnay/rust-toolchain@stable
-      - uses: Swatinem/rust-cache@v2
-      # Slices the fixture corpus with both wall generators, measures the
-      # G-code, checks invariants, and diffs against the committed baselines.
-      # QA_REPORT=1 also captures per-stage geometry into target/qa/report.html.
-      # Baselines are pinned to this job's platform+profile (ubuntu, debug), so
-      # regenerate here — not on macOS — when a deliberate change moves them:
-      #   UPDATE_QA_BASELINES=1 QA_FULL=1 cargo test --test slicing_quality -- --ignored
-      - name: Run slicing quality gate
-        run: QA_REPORT=1 cargo test --test slicing_quality -- --ignored --nocapture
-      - name: Upload quality report
-        if: always()
-        uses: actions/upload-artifact@v7
-        with:
-          name: slicing-quality-report
-          path: target/qa/
-          if-no-files-found: warn

--- a/README.md
+++ b/README.md
@@ -10,9 +10,12 @@ The web version runs fully in the browser, so you can slice on an iPad or any de
 
 🌐 **[Try the online slicer](https://slicer.maxscopp.de/)** → no install, no account.
 
-[![Frontend CI](https://github.com/ColdCrabby/slicer/actions/workflows/ui-ci.yml/badge.svg)](https://github.com/ColdCrabby/slicer/actions/workflows/ui-ci.yml)
-[![Security](https://github.com/ColdCrabby/slicer/actions/workflows/security.yml/badge.svg)](https://github.com/ColdCrabby/slicer/actions/workflows/security.yml)
-[![SLOC](https://img.shields.io/endpoint?url=https%3A%2F%2Fraw.githubusercontent.com%2FColdCrabby%2Fslicer%2Fbadges%2Fsloc.json)](https://github.com/ColdCrabby/slicer/actions/workflows/sloc.yml)
+[![Tests](https://img.shields.io/github/actions/workflow/status/ColdCrabby/slicer/test-results.yml?branch=main&label=tests)](https://github.com/ColdCrabby/slicer/actions/workflows/test-results.yml)
+[![Quality](https://img.shields.io/github/actions/workflow/status/ColdCrabby/slicer/quality.yml?branch=main&label=quality)](https://github.com/ColdCrabby/slicer/actions/workflows/quality.yml)
+[![Frontend CI](https://img.shields.io/github/actions/workflow/status/ColdCrabby/slicer/ui-ci.yml?branch=main&label=frontend)](https://github.com/ColdCrabby/slicer/actions/workflows/ui-ci.yml)
+[![Security](https://img.shields.io/github/actions/workflow/status/ColdCrabby/slicer/security.yml?branch=main&label=security)](https://github.com/ColdCrabby/slicer/actions/workflows/security.yml)
+[![Rust lines](https://img.shields.io/endpoint?url=https%3A%2F%2Fraw.githubusercontent.com%2FColdCrabby%2Fslicer%2Fbadges%2Frust.json)](https://github.com/ColdCrabby/slicer/actions/workflows/sloc.yml)
+[![TypeScript lines](https://img.shields.io/endpoint?url=https%3A%2F%2Fraw.githubusercontent.com%2FColdCrabby%2Fslicer%2Fbadges%2Ftypescript.json)](https://github.com/ColdCrabby/slicer/actions/workflows/sloc.yml)
 
 </div>
 


### PR DESCRIPTION
Follow-up to #189.

## SLOC: split by language
Per feedback, the badge shouldn't be one whole-repo total. The SLOC workflow now publishes **separate** counts:
- **Rust** (currently ~27.9k)
- **TypeScript** (currently ~21.6k)

as `rust.json` / `typescript.json` on the `badges` branch (both already seeded, so the badges are live).

## New status badges: tests + quality
The slicing **quality gate** lived as a job inside `test-results.yml`, so it couldn't have its own badge (a GitHub Actions badge reflects a whole workflow, not one job). Split it into its own **`quality.yml`** workflow:
- Job name is unchanged (`Slicing quality gate`), so the branch-protection required status check still resolves — no ruleset change needed.
- `test-results.yml` now runs just the unit tests.

README badge row is now consistent (shields, custom labels): **tests · quality · frontend · security · Rust lines · TypeScript lines**. (Dropped the failing/removed `build.yml` badge.)

## Notes
CI/docs only. The `quality` badge will show status after this merges and the workflow first runs on `main`.