### PR TITLE
viewer: pen-priority palm rejection for iPad stylus use

### DIFF
--- a/pnpm-lock.yaml
+++ b/pnpm-lock.yaml
@@ -129,6 +129,9 @@ importers:
       vitest:
         specifier: ^4.1.11
         version: 4.1.11(@types/node@25.6.0)(jsdom@28.1.0)(vite@8.1.5(@types/node@25.6.0)(esbuild@0.28.2)(sass@1.101.0))
+      zone.js:
+        specifier: ~0.16.0
+        version: 0.16.1
 
   ui-desktop:
     devDependencies:
@@ -6875,7 +6878,7 @@ snapshots:
       '@babel/parser': 7.29.2
       '@istanbuljs/schema': 0.1.6
       istanbul-lib-coverage: 3.2.2
-      semver: 7.7.4
+      semver: 7.8.5
     transitivePeerDependencies:
       - supports-color
     optional: true

--- a/ui/package.json
+++ b/ui/package.json
@@ -49,6 +49,7 @@
     "json-schema-to-typescript": "^15.0.4",
     "prettier": "^3.9.6",
     "typescript": "~6.0.3",
-    "vitest": "^4.1.11"
+    "vitest": "^4.1.11",
+    "zone.js": "~0.16.0"
   }
 }

--- a/ui/src/app/components/viewer/README.md
+++ b/ui/src/app/components/viewer/README.md
@@ -201,6 +201,34 @@ raycaster, gizmo), the viewer applies a clear priority order:
 4. **Normal mode** — the selection raycaster runs; OrbitControls handles any
    gesture that misses a selectable object.
 
+### Viewport-cube auto-ortho
+
+Clicking a viewport-cube face/edge/corner snaps the camera to that view **and
+flattens the projection to orthographic** — the CAD convention that a snapped
+view is dimension-true. The temporary ortho is held until the user **pans or
+zooms** the main viewport, at which point the projection reverts to whatever the
+toolbar preset was (normally perspective). **Rotating** the view or interacting
+with the cube again keeps ortho.
+
+| Action                                    | Auto-ortho       |
+| ----------------------------------------- | ---------------- |
+| Cube face/edge/corner snap                | engage (→ ortho) |
+| Rotate (1-finger / left-drag / swipe)     | keep             |
+| Cube drag-orbit / roll / re-snap          | keep             |
+| **Pan** (2-finger / right-drag / ⌥-swipe) | **revert**       |
+| **Zoom** (pinch / wheel / autoscroll)     | **revert**       |
+| Toolbar view toggle / home reset          | cancel (manual)  |
+
+This lives entirely in [`SceneCamera`](scene/camera.ts) as a projection override
+(`autoOrtho`) — it deliberately does **not** touch the toolbar `view` signal, so
+there is no signal-ordering race between the snap animation and a view toggle.
+Engaging animates to the snapped direction at ~1° FOV with an apparent-size-
+preserving distance; reverting is an **instant** apparent-size-preserving FOV
+swap (`notifyUserPanOrZoom`) so it never fights the live pan/zoom gesture that
+triggered it. The pan/zoom trigger is emitted only from the genuine pan/zoom
+input sites in [`SceneControls`](scene/controls.ts) (`setRevertGestureSink`) —
+rotate and cube-driven moves never emit it.
+
 ### Pen-priority palm rejection ("wrist detection")
 
 On an iPad the hand resting on the glass while drawing with an Apple Pencil
@@ -238,11 +266,11 @@ below-right placement is ideal with a mouse but lands the readout **directly
 under the palm** of a right-handed pen user. `preferredHoverPlacement`
 ([hover-placement.ts](hover-placement.ts), unit-tested) picks the side per input:
 
-| Pointer | Placement                                                     |
-| ------- | ------------------------------------------------------------- |
-| mouse   | `right-start` — the familiar below-right desktop behaviour.   |
-| touch   | `top` — the finger and hand occlude below, so float above.    |
-| pen     | opposite the tilt (hand) direction; `top` when near-upright.  |
+| Pointer | Placement                                                    |
+| ------- | ------------------------------------------------------------ |
+| mouse   | `right-start` — the familiar below-right desktop behaviour.  |
+| touch   | `top` — the finger and hand occlude below, so float above.   |
+| pen     | opposite the tilt (hand) direction; `top` when near-upright. |
 
 The elegant part is the pen case: `PointerEvent.tiltX`/`tiltY` point from the tip
 toward the barrel — i.e. toward the hand — so the tooltip floats to the _opposite_
@@ -279,14 +307,14 @@ viewer/
 
 ### ViewerScene sub-module responsibilities
 
-| File                 | Class            | Owns                                                                                        |
-| -------------------- | ---------------- | ------------------------------------------------------------------------------------------- |
-| `scene/camera.ts`    | `SceneCamera`    | `PerspectiveCamera` pose, view animations, `fitToContent`                                   |
-| `scene/controls.ts`  | `SceneControls`  | `OrbitControls` config, orbit inertia, touch gestures, autoscroll zoom                      |
-| `scene/grid.ts`      | `SceneGrid`      | Bed grid `LineSegments`, adaptive spacing, CSS theme integration                            |
-| `scene/pointer-arbiter.ts` | `PointerArbiter` | Pen-priority palm rejection — capture-phase touch veto while a stylus is in use          |
-| `scene/selection.ts` | `SceneSelection` | Selectable `Map`, emissive highlight, pointer event plumbing, face-pick overlay             |
-| `scene/index.ts`     | `ViewerScene`    | Three.js primitives (`Scene`, `WebGLRenderer`, `OrbitControls`), `contentRoot`, render loop |
+| File                       | Class            | Owns                                                                                        |
+| -------------------------- | ---------------- | ------------------------------------------------------------------------------------------- |
+| `scene/camera.ts`          | `SceneCamera`    | `PerspectiveCamera` pose, view animations, `fitToContent`                                   |
+| `scene/controls.ts`        | `SceneControls`  | `OrbitControls` config, orbit inertia, touch gestures, autoscroll zoom                      |
+| `scene/grid.ts`            | `SceneGrid`      | Bed grid `LineSegments`, adaptive spacing, CSS theme integration                            |
+| `scene/pointer-arbiter.ts` | `PointerArbiter` | Pen-priority palm rejection — capture-phase touch veto while a stylus is in use             |
+| `scene/selection.ts`       | `SceneSelection` | Selectable `Map`, emissive highlight, pointer event plumbing, face-pick overlay             |
+| `scene/index.ts`           | `ViewerScene`    | Three.js primitives (`Scene`, `WebGLRenderer`, `OrbitControls`), `contentRoot`, render loop |
 
 ### G-code layer architecture
 

--- a/ui/src/app/components/viewer/README.md
+++ b/ui/src/app/components/viewer/README.md
@@ -184,6 +184,13 @@ array to the viewer.
 When multiple input consumers are active at the same time (orbit, selection
 raycaster, gizmo), the viewer applies a clear priority order:
 
+0. **Palm rejection (stylus in use)** — [`PointerArbiter`](scene/pointer-arbiter.ts)
+   listens in the _capture_ phase on the canvas host (an ancestor of the WebGL
+   canvas), so it runs before every other consumer. While an Apple Pencil /
+   stylus is down, hovering, or was active within the grace window, it swallows
+   `pointerType === 'touch'` events — the hand and wrist resting on the glass —
+   so the palm never orbits, pinches, or selects. Genuine finger gestures are
+   untouched whenever no pen is involved.
 1. **Gizmo dragging in progress** — gizmo owns the pointer; OrbitControls
    and the selection raycaster are both suppressed.
 2. **Gizmo hovering** (cursor over a handle, not yet dragging) — the selection
@@ -193,6 +200,35 @@ raycaster, gizmo), the viewer applies a clear priority order:
    dedicated to face picking.
 4. **Normal mode** — the selection raycaster runs; OrbitControls handles any
    gesture that misses a selectable object.
+
+### Pen-priority palm rejection ("wrist detection")
+
+On an iPad the hand resting on the glass while drawing with an Apple Pencil
+fires `touch` pointer events for the palm and wrist. Unfiltered, they drive the
+camera — OrbitControls' single-touch rotate spins the view and two palm
+contacts read as a pinch — so the model lurches while the user works with the
+pencil. [`PointerArbiter`](scene/pointer-arbiter.ts) vetoes those contacts.
+
+```mermaid
+flowchart TD
+    E[pointer event on host<br/>capture phase] --> P{pointerType?}
+    P -->|pen| T[track pen: penActive + penEverUsed<br/>pass through]
+    P -->|touch| C{palm?}
+    P -->|mouse| A[pass through]
+    C -->|pen active, in grace,<br/>or palm-sized after pen use| S[stopImmediatePropagation<br/>swallow]
+    C -->|otherwise| A
+    T --> D[OrbitControls / selection / gizmo]
+    A --> D
+```
+
+A touch is judged palm at its `pointerdown` (`isPalmTouch`, unit-tested) when a
+pen is active — down, hovering, or lifted within `PEN_GRACE_MS` — or, once a pen
+has been seen this session, when its contact patch is palm-sized
+(`PALM_CONTACT_MIN_PX`), which catches the palm that lands just before the tip on
+iPads without pencil hover. Pure-touch users are never affected: the contact-size
+path is gated behind "a pen has been seen", and the pen-active path only fires
+while a pen is in use. The user can turn the whole behaviour off from
+**Settings → General → Controls → Palm rejection** (persisted; default on).
 
 ---
 
@@ -208,6 +244,7 @@ viewer/
 │   ├── camera.ts              SceneCamera — animations, view presets, fit-to-content, near/far
 │   ├── controls.ts            SceneControls — orbit inertia, multi-touch (pinch/pan/roll), autoscroll zoom
 │   ├── grid.ts                SceneGrid — adaptive build-plate grid with cross-fade and fade-on-graze
+│   ├── pointer-arbiter.ts     PointerArbiter — pen-priority palm rejection (capture-phase touch veto)
 │   ├── selection.ts           SceneSelection — selectable registry, emissive highlight, raycasting, face-pick
 │   ├── types.ts               Shared public types (SceneSelectionHandlers, SceneGizmoHandlers, ViewerView, …)
 │   └── utils.ts               disposeObject — recursive Three.js geometry/material cleanup
@@ -224,6 +261,7 @@ viewer/
 | `scene/camera.ts`    | `SceneCamera`    | `PerspectiveCamera` pose, view animations, `fitToContent`                                   |
 | `scene/controls.ts`  | `SceneControls`  | `OrbitControls` config, orbit inertia, touch gestures, autoscroll zoom                      |
 | `scene/grid.ts`      | `SceneGrid`      | Bed grid `LineSegments`, adaptive spacing, CSS theme integration                            |
+| `scene/pointer-arbiter.ts` | `PointerArbiter` | Pen-priority palm rejection — capture-phase touch veto while a stylus is in use          |
 | `scene/selection.ts` | `SceneSelection` | Selectable `Map`, emissive highlight, pointer event plumbing, face-pick overlay             |
 | `scene/index.ts`     | `ViewerScene`    | Three.js primitives (`Scene`, `WebGLRenderer`, `OrbitControls`), `contentRoot`, render loop |
 
@@ -266,6 +304,7 @@ flowchart LR
 - [scene/camera.ts](scene/camera.ts) — `SceneCamera`
 - [scene/controls.ts](scene/controls.ts) — `SceneControls`
 - [scene/grid.ts](scene/grid.ts) — `SceneGrid`
+- [scene/pointer-arbiter.ts](scene/pointer-arbiter.ts) — `PointerArbiter`, `isPalmTouch`, `PEN_GRACE_MS`, `PALM_CONTACT_MIN_PX`
 - [scene/selection.ts](scene/selection.ts) — `SceneSelection`
 - [gizmo.ts](gizmo.ts) — `GizmoManager`, `GizmoDelta`, `FacePickResult`, `raycastFace`, `computeSelectionCentroid`
 - [gcode-orchestrator.ts](gcode-orchestrator.ts) — `GcodeOrchestrator`

--- a/ui/src/app/components/viewer/README.md
+++ b/ui/src/app/components/viewer/README.md
@@ -230,6 +230,28 @@ path is gated behind "a pen has been seen", and the pen-active path only fires
 while a pen is in use. The user can turn the whole behaviour off from
 **Settings → General → Controls → Palm rejection** (persisted; default on).
 
+### Hand-aware inspector tooltip placement
+
+The G-code inspector tooltip (extrusion width/height/speed on hover in the
+scalar views) is anchored to a virtual element at the pointer. A fixed
+below-right placement is ideal with a mouse but lands the readout **directly
+under the palm** of a right-handed pen user. `preferredHoverPlacement`
+([hover-placement.ts](hover-placement.ts), unit-tested) picks the side per input:
+
+| Pointer | Placement                                                     |
+| ------- | ------------------------------------------------------------- |
+| mouse   | `right-start` — the familiar below-right desktop behaviour.   |
+| touch   | `top` — the finger and hand occlude below, so float above.    |
+| pen     | opposite the tilt (hand) direction; `top` when near-upright.  |
+
+The elegant part is the pen case: `PointerEvent.tiltX`/`tiltY` point from the tip
+toward the barrel — i.e. toward the hand — so the tooltip floats to the _opposite_
+side. Because tilt reveals which way the pen leans, this adapts to left- vs.
+right-handed users with **no setting to configure**. Floating UI's flip/shift
+still keep it on-screen, so this only chooses the _preferred_ side. The
+`viewer.ts` effect re-anchors when the preferred side changes (input swap or a
+tilt that crosses an axis).
+
 ---
 
 ## Anatomy
@@ -239,6 +261,7 @@ The viewer is split into focused files so each concern stays under ~300 lines.
 ```
 viewer/
 ├── viewer.ts                  Angular component — effects wiring, WASM ↔ Three bridge
+├── hover-placement.ts         preferredHoverPlacement — hand-aware inspector-tooltip side (pen tilt)
 ├── scene/                     ViewerScene and all Three.js sub-systems
 │   ├── index.ts               ViewerScene — owns renderer, render loop, delegates to sub-modules
 │   ├── camera.ts              SceneCamera — animations, view presets, fit-to-content, near/far
@@ -307,6 +330,7 @@ flowchart LR
 - [scene/pointer-arbiter.ts](scene/pointer-arbiter.ts) — `PointerArbiter`, `isPalmTouch`, `PEN_GRACE_MS`, `PALM_CONTACT_MIN_PX`
 - [scene/selection.ts](scene/selection.ts) — `SceneSelection`
 - [gizmo.ts](gizmo.ts) — `GizmoManager`, `GizmoDelta`, `FacePickResult`, `raycastFace`, `computeSelectionCentroid`
+- [hover-placement.ts](hover-placement.ts) — `preferredHoverPlacement`, `HoverPointerInfo`
 - [gcode-orchestrator.ts](gcode-orchestrator.ts) — `GcodeOrchestrator`
 - [gcode-layer-renderer.ts](gcode-layer-renderer.ts) — layer builder and visibility helpers
 - [viewer.ts](viewer.ts) — Angular component wiring

--- a/ui/src/app/components/viewer/gcode-hover.ts
+++ b/ui/src/app/components/viewer/gcode-hover.ts
@@ -7,6 +7,12 @@ export interface GcodeHoverHit {
   instanceId: number;
   clientX: number;
   clientY: number;
+  /** Originating pointer type (`'mouse' | 'pen' | 'touch'`) — drives tooltip placement. */
+  pointerType: string;
+  /** Pen tilt toward +X in degrees (−90…90); 0 for mouse/touch. */
+  tiltX: number;
+  /** Pen tilt toward +Y in degrees (−90…90); 0 for mouse/touch. */
+  tiltY: number;
 }
 
 /**
@@ -95,6 +101,9 @@ export class GcodeHoverProbe {
       instanceId: hit.instanceId,
       clientX: event.clientX,
       clientY: event.clientY,
+      pointerType: event.pointerType,
+      tiltX: event.tiltX ?? 0,
+      tiltY: event.tiltY ?? 0,
     });
   };
 }

--- a/ui/src/app/components/viewer/hover-placement.spec.ts
+++ b/ui/src/app/components/viewer/hover-placement.spec.ts
@@ -1,0 +1,53 @@
+import { describe, expect, it } from 'vitest';
+import { preferredHoverPlacement } from './hover-placement';
+
+describe('preferredHoverPlacement', () => {
+  it('keeps the below-right placement for a mouse', () => {
+    expect(preferredHoverPlacement({ pointerType: 'mouse' })).toBe('right-start');
+  });
+
+  it('floats above the contact for touch', () => {
+    expect(preferredHoverPlacement({ pointerType: 'touch' })).toBe('top');
+  });
+
+  it('floats above the tip for a near-upright pen (no usable tilt)', () => {
+    expect(preferredHoverPlacement({ pointerType: 'pen', tiltX: 0, tiltY: 0 })).toBe('top');
+    expect(preferredHoverPlacement({ pointerType: 'pen', tiltX: 2, tiltY: -3 })).toBe('top');
+  });
+
+  it('places opposite the hand for a right-handed pen (leaning down-right)', () => {
+    // Hand down-right → tooltip should go left and extend upward (`left-end`).
+    const p = preferredHoverPlacement({ pointerType: 'pen', tiltX: 40, tiltY: 20 });
+    expect(p).toBe('left-end');
+  });
+
+  it('places opposite the hand for a left-handed pen (leaning down-left)', () => {
+    // Hand down-left → tooltip should go right and extend upward (`right-end`).
+    const p = preferredHoverPlacement({ pointerType: 'pen', tiltX: -40, tiltY: 20 });
+    expect(p).toBe('right-end');
+  });
+
+  it('uses a vertical side when tilt is dominantly vertical', () => {
+    // Hand mostly below, slightly right → float above, biased left (`top-end`).
+    expect(preferredHoverPlacement({ pointerType: 'pen', tiltX: 10, tiltY: 60 })).toBe('top-end');
+    // Hand mostly above, slightly left → float below, biased right (`bottom-start`).
+    expect(preferredHoverPlacement({ pointerType: 'pen', tiltX: -10, tiltY: -60 })).toBe(
+      'bottom-start',
+    );
+  });
+
+  it('biases horizontal placement vertically away from the hand', () => {
+    // Hand up-right (tiltY < 0) → tooltip left and extends downward (`left-start`).
+    expect(preferredHoverPlacement({ pointerType: 'pen', tiltX: 40, tiltY: -20 })).toBe(
+      'left-start',
+    );
+  });
+
+  it('treats missing tilt as zero (upright) rather than throwing', () => {
+    expect(preferredHoverPlacement({ pointerType: 'pen' })).toBe('top');
+  });
+
+  it('falls back to the mouse placement for an unknown pointer type', () => {
+    expect(preferredHoverPlacement({ pointerType: 'unknown' })).toBe('right-start');
+  });
+});

--- a/ui/src/app/components/viewer/hover-placement.ts
+++ b/ui/src/app/components/viewer/hover-placement.ts
@@ -1,0 +1,84 @@
+import type { FloatingPlacement } from '../../shared/floating';
+
+/**
+ * The minimal pointer facts the placement decision needs. Kept DOM-free so the
+ * decision is a pure function and unit-testable without a `PointerEvent`.
+ */
+export interface HoverPointerInfo {
+  /** `'mouse' | 'pen' | 'touch'` (or any future pointer type). */
+  pointerType: string;
+  /**
+   * Pen tilt toward +X (right), in degrees, −90…90. Positive means the top of
+   * the barrel leans right — i.e. the hand is to the right. Absent/0 for
+   * mouse and touch, and for a perfectly upright pen.
+   */
+  tiltX?: number;
+  /** Pen tilt toward +Y (down), in degrees, −90…90. Positive → hand is below. */
+  tiltY?: number;
+}
+
+/**
+ * Below which absolute tilt (deg) a pen is treated as effectively upright, so
+ * we stop trusting the tilt direction and fall back to "float above the tip".
+ */
+const TILT_DEADZONE_DEG = 5;
+
+/**
+ * Choose where the G-code inspector tooltip should sit relative to the pointer
+ * so the user's hand never covers it.
+ *
+ * The problem: a fixed below-right placement (great with a mouse) lands the
+ * tooltip directly under the palm of a right-handed pen user. The signal that
+ * fixes it for free is **pen tilt** — the barrel, and therefore the hand,
+ * extends from the tip in the tilt direction, so we place the tooltip on the
+ * _opposite_ side. Because tilt reveals which way the pen leans, this adapts to
+ * left- vs. right-handed users automatically, with no setting to configure.
+ *
+ * | Pointer | Placement                                                        |
+ * | ------- | ---------------------------------------------------------------- |
+ * | mouse   | `right-start` — the familiar below-right desktop behaviour.      |
+ * | touch   | `top` — the finger and hand occlude below, so float above.       |
+ * | pen     | opposite the tilt (hand) direction; `top` when nearly upright.    |
+ *
+ * Floating UI's flip/shift still keep the result on-screen near the edges, so
+ * this only chooses the _preferred_ side.
+ */
+export function preferredHoverPlacement(info: HoverPointerInfo): FloatingPlacement {
+  if (info.pointerType === 'pen') {
+    return penPlacement(info.tiltX ?? 0, info.tiltY ?? 0);
+  }
+  if (info.pointerType === 'touch') {
+    // Finger contact: the fingertip and the hand behind it cover the area below
+    // and around the point, so float the readout above it.
+    return 'top';
+  }
+  // Mouse / unknown: keep the desktop-friendly below-and-right placement.
+  return 'right-start';
+}
+
+function penPlacement(tiltX: number, tiltY: number): FloatingPlacement {
+  // Nearly-upright pen (or a device that reports no tilt): we can't tell which
+  // way the hand extends, so play it safe and float above the tip.
+  if (Math.abs(tiltX) < TILT_DEADZONE_DEG && Math.abs(tiltY) < TILT_DEADZONE_DEG) {
+    return 'top';
+  }
+
+  // Occlusion (hand) direction ≈ (tiltX, tiltY); we want the opposite.
+  const awayX = -tiltX;
+  const awayY = -tiltY;
+
+  if (Math.abs(awayX) >= Math.abs(awayY)) {
+    // Dominantly horizontal: put the tooltip left/right of the tip, and bias its
+    // vertical growth away from the hand — if the hand is below (tiltY > 0) the
+    // box should extend upward (`-end`), otherwise downward (`-start`).
+    const side = awayX >= 0 ? 'right' : 'left';
+    const align = tiltY > 0 ? 'end' : 'start';
+    return `${side}-${align}` as FloatingPlacement;
+  }
+
+  // Dominantly vertical: put it above/below, biasing horizontal growth away from
+  // the hand — hand to the right (tiltX > 0) → box extends left (`-end`).
+  const side = awayY >= 0 ? 'bottom' : 'top';
+  const align = tiltX > 0 ? 'end' : 'start';
+  return `${side}-${align}` as FloatingPlacement;
+}

--- a/ui/src/app/components/viewer/scene/camera.ts
+++ b/ui/src/app/components/viewer/scene/camera.ts
@@ -46,6 +46,15 @@ export class SceneCamera {
   private printArea: PrintAreaConfig;
   /** User-configurable perspective FOV (degrees); the ortho preset ignores it. */
   private perspectiveFov = PERSPECTIVE_FOV;
+  /**
+   * True while the projection has been *temporarily* forced to orthographic by
+   * a viewport-cube snap (see {@link animateToDirection}). Distinct from the
+   * user's `currentView`: the cube engages this without touching the toolbar
+   * preset, and a free pan/zoom in the main viewport reverts it
+   * ({@link notifyUserPanOrZoom}) back to `currentView`. Rotating or further
+   * cube interaction keep it engaged.
+   */
+  private autoOrtho = false;
 
   constructor(
     private readonly camera: PerspectiveCamera,
@@ -83,7 +92,10 @@ export class SceneCamera {
    */
   setPerspectiveFov(fov: number): void {
     this.perspectiveFov = fov;
-    if (this.currentView !== 'perspective' || this.animation) {
+    // While auto-ortho holds the projection at ~1°, only remember the new FOV;
+    // it is applied when the projection reverts. Applying it live here would
+    // fight the forced ortho.
+    if (this.currentView !== 'perspective' || this.animation || this.autoOrtho) {
       return;
     }
     const target = this.controls.target;
@@ -115,6 +127,8 @@ export class SceneCamera {
   }
 
   setView(view: ViewerView): void {
+    // A manual toolbar view change takes over from any temporary cube ortho.
+    this.autoOrtho = false;
     if (view === this.currentView && !this.animation) {
       return;
     }
@@ -123,6 +137,7 @@ export class SceneCamera {
   }
 
   resetView(): void {
+    this.autoOrtho = false;
     this.currentView = 'perspective';
     const pose = this.initialPoseForBed();
     this.animateToPose({
@@ -133,7 +148,18 @@ export class SceneCamera {
     });
   }
 
-  animateToDirection(direction: Vector3, up: Vector3): void {
+  /**
+   * Snap the camera to look along `direction` (target → camera) with `up`.
+   * Driven by the viewport-cube gizmo.
+   *
+   * When `forceOrtho` is set (every cube snap does), the projection is also
+   * driven to orthographic and {@link autoOrtho} is engaged, matching the CAD
+   * convention that clicking a cube face gives a flat, dimension-true view. The
+   * user's toolbar `currentView` is deliberately left untouched so a later free
+   * pan/zoom can revert to it ({@link notifyUserPanOrZoom}); rotating or further
+   * cube snaps keep ortho.
+   */
+  animateToDirection(direction: Vector3, up: Vector3, forceOrtho = false): void {
     const target = this.controls.target.clone();
     const distance = Math.max(this.camera.position.distanceTo(target), 1);
     // Express every snapped view in the scene's stable world Z-up frame so that
@@ -160,12 +186,64 @@ export class SceneCamera {
       ).normalize();
       resolvedUp = INITIAL_CAMERA_UP.clone();
     }
-    this.animateToPose({
-      position: target.clone().addScaledVector(dir, distance),
-      target,
-      up: resolvedUp,
-      fov: this.camera.fov,
+
+    // Default: keep the current projection and orbit distance (pure re-orient).
+    let toFov = this.camera.fov;
+    let toDistance = distance;
+    if (forceOrtho) {
+      this.autoOrtho = true;
+      toFov = ORTHO_FOV;
+      // Grow the distance so the flattened (~1° FOV) view frames the same
+      // apparent size — advanceAnimation interpolates in apparent-size space,
+      // so this keeps the snap from appearing to zoom.
+      const fromTan = Math.tan(((this.camera.fov / 2) * Math.PI) / 180);
+      const toTan = Math.tan(((ORTHO_FOV / 2) * Math.PI) / 180);
+      toDistance = toTan > 1e-6 ? distance * (fromTan / toTan) : distance;
+    }
+    this.startAnimation({
+      toDir: dir,
+      toFov,
+      toTarget: target,
+      toUp: resolvedUp,
+      toDistance,
     });
+  }
+
+  /**
+   * Called when the user pans or zooms the *main viewport* (not a rotate, not a
+   * cube gesture). If a cube snap had forced the projection to orthographic,
+   * this reverts it to the user's `currentView`. The swap is instantaneous and
+   * apparent-size-preserving (no distance/target lock), so it never fights the
+   * in-flight pan/zoom gesture that triggered it; only the perspective
+   * distortion (re)appears. A no-op when auto-ortho is not engaged.
+   */
+  notifyUserPanOrZoom(): void {
+    if (!this.autoOrtho) {
+      return;
+    }
+    this.autoOrtho = false;
+    // Cancel any in-flight snap animation so it can't fight the swap, and hand
+    // control straight back to the user's live gesture.
+    this.animation = null;
+    this.controls.enabled = true;
+    const targetFov = this.currentView === 'ortho' ? ORTHO_FOV : this.perspectiveFov;
+    if (Math.abs(this.camera.fov - targetFov) < 1e-3) {
+      return;
+    }
+    const target = this.controls.target;
+    const offset = this.camera.position.clone().sub(target);
+    const distance = Math.max(offset.length(), 1);
+    const dir = offset.divideScalar(distance);
+    // Preserve apparent size: distance × tan(fov/2) is held constant so content
+    // does not jump size when the projection changes.
+    const apparent = distance * Math.tan(((this.camera.fov / 2) * Math.PI) / 180);
+    const newDistance = apparent / Math.tan(((targetFov / 2) * Math.PI) / 180);
+    this.camera.fov = targetFov;
+    this.camera.position.copy(target).addScaledVector(dir, newDistance);
+    this.updateNearFar(newDistance, Math.max(newDistance * 0.5, 1));
+    this.camera.lookAt(target);
+    this.camera.updateProjectionMatrix();
+    this.controls.update();
   }
 
   orbitBy(azimuth: number, polar: number): void {

--- a/ui/src/app/components/viewer/scene/controls.ts
+++ b/ui/src/app/components/viewer/scene/controls.ts
@@ -15,6 +15,8 @@ import type { OrbitControls } from 'three/examples/jsm/controls/OrbitControls.js
 const TOUCH_DISABLED = -1 as unknown as TOUCH;
 const TWO_FINGER_DOLLY_DEAD_ZONE_PX = 1.5;
 const TWO_FINGER_ROLL_DEAD_ZONE_RAD = 0.01;
+/** Right-drag travel (px) before it counts as a pan for the auto-ortho revert. */
+const RIGHT_PAN_REVERT_THRESHOLD_PX = 3;
 
 /**
  * Safari/WebKit-proprietary gesture event (not in the standard DOM lib types).
@@ -111,6 +113,20 @@ export class SceneControls {
   private twoFingerGesture: 'orbit' | 'pan' = 'orbit';
 
   /**
+   * Fired whenever the user *pans or zooms* the main viewport (never on a
+   * rotate). Used by the viewport-cube auto-ortho behaviour to revert the
+   * temporary orthographic projection back to the user's chosen view. Rotate
+   * and cube-driven camera moves deliberately do not fire it. See
+   * {@link SceneCamera.notifyUserPanOrZoom}.
+   */
+  private revertGestureSink: (() => void) | null = null;
+
+  /** Handlers for the right-drag (pan) revert detector, retained for cleanup. */
+  private rightPanPointerDownHandler: ((event: PointerEvent) => void) | null = null;
+  private rightPanPointerMoveHandler: ((event: PointerEvent) => void) | null = null;
+  private rightPanPointerUpHandler: ((event: PointerEvent) => void) | null = null;
+
+  /**
    * @param cancelDragCallback  Called when a two-finger gesture begins so
    *   any in-flight single-finger selection drag can be abandoned cleanly.
    */
@@ -132,6 +148,7 @@ export class SceneControls {
     this.installAutoscrollZoom();
     this.installAlwaysOnWheelZoom();
     this.installWebKitGestureZoom();
+    this.installRightPanRevertDetection();
     // Orbit is the fixed cursor mode: left-drag rotates, right-drag pans.
     // Middle mouse is reserved for autoscroll zoom; disable OrbitControls' drag-dolly.
     const MIDDLE = null as unknown as MOUSE;
@@ -146,6 +163,19 @@ export class SceneControls {
   /** Set the macOS bare-two-finger-swipe action (orbit or pan). */
   setTwoFingerGesture(gesture: 'orbit' | 'pan'): void {
     this.twoFingerGesture = gesture;
+  }
+
+  /**
+   * Register a callback fired whenever the user pans or zooms the main viewport
+   * (never on a rotate or a cube gesture). Drives the viewport-cube auto-ortho
+   * revert. Pass `null` to clear.
+   */
+  setRevertGestureSink(sink: (() => void) | null): void {
+    this.revertGestureSink = sink;
+  }
+
+  private emitRevertGesture(): void {
+    this.revertGestureSink?.();
   }
 
   applyOrbitInertia(dt: number): void {
@@ -280,7 +310,77 @@ export class SceneControls {
     this.uninstallAutoscrollZoom();
     this.uninstallRendererPointerListeners();
     this.uninstallWebKitGestureZoom();
+    this.uninstallRightPanRevertDetection();
     this.renderer.domElement.removeEventListener('wheel', this.wheelHandler, { capture: true });
+  }
+
+  // -------------------------------------------------------------------------
+  // Right-drag (pan) revert detection
+  // -------------------------------------------------------------------------
+
+  /**
+   * OrbitControls maps the right mouse button to PAN. Panning is handled
+   * internally by OrbitControls (not by our custom helpers), so to notify the
+   * auto-ortho revert we watch the right-button drag ourselves. We only observe
+   * — we never call `preventDefault`/`stopPropagation` — so OrbitControls still
+   * performs the pan. A small travel threshold avoids reverting on a bare
+   * right-click that never moves.
+   */
+  private installRightPanRevertDetection(): void {
+    const el = this.renderer.domElement;
+    let pointerId: number | null = null;
+    let startX = 0;
+    let startY = 0;
+    let emitted = false;
+
+    this.rightPanPointerDownHandler = (event: PointerEvent): void => {
+      if (event.button !== 2) {
+        return;
+      }
+      pointerId = event.pointerId;
+      startX = event.clientX;
+      startY = event.clientY;
+      emitted = false;
+    };
+    this.rightPanPointerMoveHandler = (event: PointerEvent): void => {
+      if (event.pointerId !== pointerId || emitted) {
+        return;
+      }
+      if (
+        Math.hypot(event.clientX - startX, event.clientY - startY) > RIGHT_PAN_REVERT_THRESHOLD_PX
+      ) {
+        emitted = true;
+        this.emitRevertGesture();
+      }
+    };
+    this.rightPanPointerUpHandler = (event: PointerEvent): void => {
+      if (event.pointerId === pointerId) {
+        pointerId = null;
+        emitted = false;
+      }
+    };
+
+    el.addEventListener('pointerdown', this.rightPanPointerDownHandler);
+    el.addEventListener('pointermove', this.rightPanPointerMoveHandler);
+    el.addEventListener('pointerup', this.rightPanPointerUpHandler);
+    el.addEventListener('pointercancel', this.rightPanPointerUpHandler);
+  }
+
+  private uninstallRightPanRevertDetection(): void {
+    const el = this.renderer.domElement;
+    if (this.rightPanPointerDownHandler) {
+      el.removeEventListener('pointerdown', this.rightPanPointerDownHandler);
+      this.rightPanPointerDownHandler = null;
+    }
+    if (this.rightPanPointerMoveHandler) {
+      el.removeEventListener('pointermove', this.rightPanPointerMoveHandler);
+      this.rightPanPointerMoveHandler = null;
+    }
+    if (this.rightPanPointerUpHandler) {
+      el.removeEventListener('pointerup', this.rightPanPointerUpHandler);
+      el.removeEventListener('pointercancel', this.rightPanPointerUpHandler);
+      this.rightPanPointerUpHandler = null;
+    }
   }
 
   // -------------------------------------------------------------------------
@@ -312,6 +412,7 @@ export class SceneControls {
     }
     event.preventDefault();
     event.stopImmediatePropagation();
+    this.emitRevertGesture();
 
     const zoomSpeed = this.controls.zoomSpeed;
     let normalised: number;
@@ -790,6 +891,7 @@ export class SceneControls {
    * `factor < 1` zooms in, `factor > 1` zooms out.
    */
   private applyTouchDolly(factor: number, cx: number, cy: number): void {
+    this.emitRevertGesture();
     const { camera } = this;
     const target = this.controls.target;
     camera.updateMatrixWorld(true);
@@ -822,6 +924,7 @@ export class SceneControls {
 
   /** Translate camera + target by a screen-space pixel delta. */
   private applyTouchPan(dxPx: number, dyPx: number): void {
+    this.emitRevertGesture();
     const { camera } = this;
     const target = this.controls.target;
     camera.updateMatrix();
@@ -881,6 +984,7 @@ export class SceneControls {
     }
     event.preventDefault();
     event.stopPropagation();
+    this.emitRevertGesture();
     const el = this.renderer.domElement;
     el.setPointerCapture(event.pointerId);
     el.style.cursor = 'ns-resize';

--- a/ui/src/app/components/viewer/scene/controls.ts
+++ b/ui/src/app/components/viewer/scene/controls.ts
@@ -618,6 +618,11 @@ export class SceneControls {
   /**
    * Combined pinch-dolly + centroid-pan + twist-roll for two-finger touch.
    * Bypasses OrbitControls entirely while two or more fingers are down.
+   *
+   * Palm/wrist contacts never reach here while a stylus is in use: the
+   * {@link PointerArbiter} installed on the canvas host swallows them in the
+   * capture phase, upstream of these listeners. So a resting hand can't be
+   * mistaken for the second finger of a pinch. See `scene/pointer-arbiter.ts`.
    */
   private installCustomTwoFingerControls(): void {
     const el = this.renderer.domElement;

--- a/ui/src/app/components/viewer/scene/index.ts
+++ b/ui/src/app/components/viewer/scene/index.ts
@@ -22,6 +22,7 @@ import { GizmoManager } from '../gizmo';
 import { INITIAL_CAMERA_UP, INITIAL_PERSPECTIVE_FOV, SceneCamera } from './camera';
 import { SceneControls } from './controls';
 import { SceneGrid } from './grid';
+import { PointerArbiter } from './pointer-arbiter';
 import { SceneSelection } from './selection';
 import type { SceneGizmoHandlers, SceneSelectionHandlers, ViewerView } from './types';
 import { disposeObject } from './utils';
@@ -106,6 +107,7 @@ export class ViewerScene {
   private readonly _controls: SceneControls;
   private readonly _grid: SceneGrid;
   private readonly _selection: SceneSelection;
+  private readonly _pointerArbiter: PointerArbiter;
   private readonly gizmo: GizmoManager;
   private readonly axesGizmo: Group;
   private readonly hemiLight: HemisphereLight;
@@ -177,6 +179,13 @@ export class ViewerScene {
     this.renderer.setSize(clientWidth, clientHeight);
     this.renderer.domElement.style.touchAction = 'none';
     host.appendChild(this.renderer.domElement);
+
+    // Palm rejection is installed on `host` (an ancestor of the canvas) in the
+    // capture phase so it runs before OrbitControls, selection, and the
+    // two-finger touch handlers — it can veto a palm/wrist contact before any
+    // of them start a camera gesture. Created before those consumers so its
+    // capture listeners are the first thing every pointer event meets.
+    this._pointerArbiter = new PointerArbiter(host);
 
     this.controls = new OrbitControls(this.camera, this.renderer.domElement);
     this.controls.enableDamping = false;
@@ -484,6 +493,16 @@ export class ViewerScene {
     this._controls.setTwoFingerGesture(gesture);
   }
 
+  /**
+   * Enable or disable pen-priority palm rejection ("wrist detection"). When
+   * enabled (default) touch contacts from the hand resting on the glass are
+   * swallowed while an Apple Pencil / stylus is in use, so the palm never
+   * orbits or pinches the camera. See {@link PointerArbiter}.
+   */
+  setPalmRejectionEnabled(enabled: boolean): void {
+    this._pointerArbiter.setEnabled(enabled);
+  }
+
   /** Set the perspective field-of-view (degrees); applied live when perspective. */
   setFieldOfView(fov: number): void {
     this._camera.setPerspectiveFov(fov);
@@ -507,6 +526,7 @@ export class ViewerScene {
     this._controls.dispose();
     this._grid.dispose();
     this._selection.dispose();
+    this._pointerArbiter.dispose();
     this.gizmo.dispose();
     this.clearContent();
     this.controls.dispose();

--- a/ui/src/app/components/viewer/scene/index.ts
+++ b/ui/src/app/components/viewer/scene/index.ts
@@ -206,6 +206,9 @@ export class ViewerScene {
     this._controls = new SceneControls(this.camera, this.controls, this.renderer, () =>
       this._selection.cancelActiveDrag(),
     );
+    // Free pan/zoom in the main viewport reverts the viewport-cube's temporary
+    // orthographic snap; rotate and cube gestures never fire this.
+    this._controls.setRevertGestureSink(() => this._camera.notifyUserPanOrZoom());
     this._grid = new SceneGrid(this.scene, this.camera, this.controls, this.renderer, printArea);
 
     // Wire gizmo callbacks.
@@ -472,8 +475,8 @@ export class ViewerScene {
     return dataUrl;
   }
 
-  animateToDirection(direction: Vector3, up: Vector3): void {
-    this._camera.animateToDirection(direction, up);
+  animateToDirection(direction: Vector3, up: Vector3, forceOrtho = false): void {
+    this._camera.animateToDirection(direction, up, forceOrtho);
   }
 
   orbitBy(azimuth: number, polar: number): void {

--- a/ui/src/app/components/viewer/scene/pointer-arbiter.spec.ts
+++ b/ui/src/app/components/viewer/scene/pointer-arbiter.spec.ts
@@ -1,0 +1,161 @@
+import { afterEach, beforeEach, describe, expect, it } from 'vitest';
+import { isPalmTouch, PALM_CONTACT_MIN_PX, PEN_GRACE_MS, PointerArbiter } from './pointer-arbiter';
+
+describe('isPalmTouch', () => {
+  const base = {
+    enabled: true,
+    penActive: false,
+    penEverUsed: false,
+    contactMaxPx: 10,
+    palmContactMinPx: PALM_CONTACT_MIN_PX,
+  };
+
+  it('never rejects when disabled', () => {
+    expect(isPalmTouch({ ...base, enabled: false, penActive: true })).toBe(false);
+    expect(isPalmTouch({ ...base, enabled: false, penEverUsed: true, contactMaxPx: 200 })).toBe(
+      false,
+    );
+  });
+
+  it('rejects any touch while a pen is active', () => {
+    expect(isPalmTouch({ ...base, penActive: true })).toBe(true);
+  });
+
+  it('allows normal touches when no pen has ever been used', () => {
+    expect(isPalmTouch({ ...base, penActive: false, penEverUsed: false })).toBe(false);
+    // Even a large contact is allowed for pure-touch users.
+    expect(isPalmTouch({ ...base, penEverUsed: false, contactMaxPx: 200 })).toBe(false);
+  });
+
+  it('rejects palm-sized contacts once a pen has been seen this session', () => {
+    expect(isPalmTouch({ ...base, penEverUsed: true, contactMaxPx: PALM_CONTACT_MIN_PX })).toBe(
+      true,
+    );
+    expect(isPalmTouch({ ...base, penEverUsed: true, contactMaxPx: PALM_CONTACT_MIN_PX - 1 })).toBe(
+      false,
+    );
+  });
+});
+
+/**
+ * Builds a plain Event carrying the PointerEvent fields the arbiter reads. A
+ * full PointerEvent constructor is not available in every test environment, and
+ * the arbiter only touches `pointerType`, `pointerId`, `width`, `height`, and
+ * the standard propagation methods — all present on a base Event.
+ */
+function pointerEvent(type: string, props: Partial<PointerEvent>): Event {
+  const event = new Event(type, { bubbles: true, cancelable: true });
+  Object.assign(event, { pointerId: 1, width: 10, height: 10, ...props });
+  return event as Event;
+}
+
+describe('PointerArbiter', () => {
+  let host: HTMLElement;
+  let canvas: HTMLElement;
+  let arbiter: PointerArbiter;
+  let clock: { t: number };
+  let originalMaxTouchPoints: PropertyDescriptor | undefined;
+
+  /** Dispatch on the canvas; returns true if a downstream canvas listener saw it. */
+  function dispatch(type: string, props: Partial<PointerEvent>): boolean {
+    let reached = false;
+    const spy = (): void => {
+      reached = true;
+    };
+    canvas.addEventListener(type, spy);
+    canvas.dispatchEvent(pointerEvent(type, props));
+    canvas.removeEventListener(type, spy);
+    return reached;
+  }
+
+  beforeEach(() => {
+    originalMaxTouchPoints = Object.getOwnPropertyDescriptor(navigator, 'maxTouchPoints');
+    Object.defineProperty(navigator, 'maxTouchPoints', { value: 5, configurable: true });
+
+    host = document.createElement('div');
+    canvas = document.createElement('canvas');
+    host.appendChild(canvas);
+    document.body.appendChild(host);
+
+    clock = { t: 1_000 };
+    arbiter = new PointerArbiter(host, () => clock.t);
+  });
+
+  afterEach(() => {
+    arbiter.dispose();
+    host.remove();
+    if (originalMaxTouchPoints) {
+      Object.defineProperty(navigator, 'maxTouchPoints', originalMaxTouchPoints);
+    }
+  });
+
+  it('lets normal finger touches through when no pen is in use', () => {
+    expect(dispatch('pointerdown', { pointerType: 'touch', pointerId: 1 })).toBe(true);
+  });
+
+  it('swallows a palm touch while a pen is down', () => {
+    dispatch('pointerdown', { pointerType: 'pen', pointerId: 9 });
+    expect(arbiter.isPenActive()).toBe(true);
+    expect(dispatch('pointerdown', { pointerType: 'touch', pointerId: 1 })).toBe(false);
+  });
+
+  it('keeps swallowing the whole life of a committed palm pointer', () => {
+    dispatch('pointerdown', { pointerType: 'pen', pointerId: 9 });
+    expect(dispatch('pointerdown', { pointerType: 'touch', pointerId: 1 })).toBe(false);
+    // Even after the pen lifts and grace elapses, the already-committed palm
+    // pointer's own move/up stream stays swallowed so it can't start a gesture.
+    dispatch('pointerup', { pointerType: 'pen', pointerId: 9 });
+    clock.t += PEN_GRACE_MS + 100;
+    expect(dispatch('pointermove', { pointerType: 'touch', pointerId: 1 })).toBe(false);
+    expect(dispatch('pointerup', { pointerType: 'touch', pointerId: 1 })).toBe(false);
+  });
+
+  it('rejects touch within the grace window after the pen lifts', () => {
+    dispatch('pointerdown', { pointerType: 'pen', pointerId: 9 });
+    dispatch('pointerup', { pointerType: 'pen', pointerId: 9 });
+    clock.t += PEN_GRACE_MS - 50;
+    expect(arbiter.isPenActive()).toBe(true);
+    expect(dispatch('pointerdown', { pointerType: 'touch', pointerId: 2 })).toBe(false);
+  });
+
+  it('allows touch again once the grace window elapses', () => {
+    dispatch('pointerdown', { pointerType: 'pen', pointerId: 9 });
+    dispatch('pointerout', { pointerType: 'pen', pointerId: 9 });
+    clock.t += PEN_GRACE_MS + 50;
+    expect(arbiter.isPenActive()).toBe(false);
+    expect(dispatch('pointerdown', { pointerType: 'touch', pointerId: 2 })).toBe(true);
+  });
+
+  it('rejects a palm-sized contact after the pen lifts (hover-less iPad case)', () => {
+    // Pen used once, then fully gone (past grace).
+    dispatch('pointerdown', { pointerType: 'pen', pointerId: 9 });
+    dispatch('pointerout', { pointerType: 'pen', pointerId: 9 });
+    clock.t += PEN_GRACE_MS + 500;
+    expect(arbiter.isPenActive()).toBe(false);
+    // A fingertip-sized contact passes…
+    expect(
+      dispatch('pointerdown', { pointerType: 'touch', pointerId: 2, width: 20, height: 20 }),
+    ).toBe(true);
+    // …but a palm-sized one is rejected.
+    expect(
+      dispatch('pointerdown', {
+        pointerType: 'touch',
+        pointerId: 3,
+        width: PALM_CONTACT_MIN_PX + 20,
+        height: PALM_CONTACT_MIN_PX + 20,
+      }),
+    ).toBe(false);
+  });
+
+  it('passes everything through when disabled', () => {
+    arbiter.setEnabled(false);
+    dispatch('pointerdown', { pointerType: 'pen', pointerId: 9 });
+    expect(dispatch('pointerdown', { pointerType: 'touch', pointerId: 1 })).toBe(true);
+  });
+
+  it('stops arbitrating after dispose', () => {
+    dispatch('pointerdown', { pointerType: 'pen', pointerId: 9 });
+    arbiter.dispose();
+    expect(dispatch('pointerdown', { pointerType: 'touch', pointerId: 1 })).toBe(true);
+  });
+});

--- a/ui/src/app/components/viewer/scene/pointer-arbiter.ts
+++ b/ui/src/app/components/viewer/scene/pointer-arbiter.ts
@@ -1,0 +1,235 @@
+/**
+ * Pen-priority palm rejection ("wrist detection") for the 3D viewport.
+ *
+ * On an iPad — or any screen that mixes a stylus with finger touch — the hand
+ * resting on the glass while drawing with an Apple Pencil fires
+ * `pointerType === 'touch'` events for the palm and wrist. Left unfiltered,
+ * those stray contacts drive the camera: OrbitControls' single-touch rotate
+ * spins the view, and two palm contacts read as a pinch/pan/roll gesture, so
+ * the model lurches while the user is simply trying to work with the pencil.
+ * That is the "clunky, weird pen support" this arbiter fixes.
+ *
+ * It watches every pointer event on the viewport **before** any camera,
+ * selection, or gizmo handler by listening in the *capture* phase on the
+ * canvas's `host` element (an ancestor of the WebGL canvas). Capture on an
+ * ancestor is guaranteed by the DOM to run ahead of every listener on the
+ * canvas itself — including OrbitControls' — so a palm contact can be swallowed
+ * with {@link Event.stopImmediatePropagation} before anything downstream sees
+ * it. Because the palm's `pointerdown` never reaches OrbitControls, no camera
+ * motion is ever started and there is no half-finished gesture state to unwind.
+ *
+ * A touch is classified as palm at its `pointerdown` (see {@link isPalmTouch})
+ * when either:
+ *
+ *   - a pen is currently down or hovering, or was lifted within the grace
+ *     window ({@link PEN_GRACE_MS}). Hover-capable Pencils (M2 iPad Pro +
+ *     Pencil Pro) fire hover events before the tip lands, so this pre-arms
+ *     rejection and the palm is rejected seamlessly; or
+ *   - the pen has been used at least once this session **and** the contact
+ *     patch is palm-sized ({@link PALM_CONTACT_MIN_PX}). This catches the palm
+ *     that lands a moment before the tip on iPads without pencil hover.
+ *
+ * Pure-touch users are never affected: the contact-size path is gated behind
+ * "a pen has been seen this session", and the pen-active path only fires while
+ * a pen is actually in use. Genuine two-finger orbit/pinch/pan therefore keeps
+ * working exactly as before whenever no pen is involved.
+ */
+
+/**
+ * How long after a pen lifts off the glass touch input stays suppressed.
+ * Covers the beat between finishing a pencil stroke and lifting the palm —
+ * and a quick tip re-plant — without stranding two-finger gestures for long.
+ */
+export const PEN_GRACE_MS = 600;
+
+/**
+ * Contact patch size (max of `PointerEvent.width`/`height`, CSS px) at or above
+ * which a touch is treated as a palm/wrist rather than a fingertip. iPad Safari
+ * reports genuine contact geometry: fingertips land around 15–35 px, while a
+ * resting palm edge is markedly larger. Only consulted once a pen has been seen
+ * this session, so ordinary fat-finger touches on pen-less devices are safe.
+ */
+export const PALM_CONTACT_MIN_PX = 45;
+
+/**
+ * The minimal, side-effect-free inputs needed to decide whether a touch is a
+ * palm. Extracted so the decision is unit-testable without a DOM.
+ */
+export interface PalmRejectionState {
+  /** Master switch — when `false` every touch is allowed through. */
+  enabled: boolean;
+  /** A pen is down, hovering, or was active within {@link PEN_GRACE_MS}. */
+  penActive: boolean;
+  /** A pen has produced at least one event this session. */
+  penEverUsed: boolean;
+  /** `max(width, height)` of this touch's contact patch, in CSS px. */
+  contactMaxPx: number;
+  /** Threshold above which {@link contactMaxPx} counts as a palm. */
+  palmContactMinPx: number;
+}
+
+/**
+ * Pure predicate at the heart of palm rejection. Returns `true` when a touch
+ * pointer should be swallowed as a palm/wrist contact. See the module comment
+ * for the rationale behind each branch.
+ */
+export function isPalmTouch(state: PalmRejectionState): boolean {
+  if (!state.enabled) {
+    return false;
+  }
+  // A pen is in play — every concurrent touch is the supporting hand.
+  if (state.penActive) {
+    return true;
+  }
+  // No pen right now, but the user has a pen and this contact is palm-sized:
+  // the hand that landed a beat before the tip on a hover-less iPad.
+  if (state.penEverUsed && state.contactMaxPx >= state.palmContactMinPx) {
+    return true;
+  }
+  return false;
+}
+
+/**
+ * Installs pen-priority palm rejection on a viewport host element and tracks
+ * pen presence over time. One instance per {@link ViewerScene}.
+ */
+export class PointerArbiter {
+  private enabled = true;
+  private penEverUsed = false;
+  /** A pen is currently down or hovering (distinct from the grace window). */
+  private penContact = false;
+  /** `performance.now()` of the most recent pen event, for the grace window. */
+  private lastPenActivityMs = Number.NEGATIVE_INFINITY;
+  /** Touch pointer ids currently classified as palm — swallowed for their life. */
+  private readonly palmPointerIds = new Set<number>();
+
+  private readonly listenerOptions: AddEventListenerOptions = { capture: true };
+
+  /**
+   * @param host  The viewport host element (ancestor of the WebGL canvas).
+   * @param now   Monotonic clock in ms; injectable for deterministic tests.
+   *              Defaults to `performance.now()` (falling back to `Date.now()`).
+   */
+  constructor(
+    private readonly host: HTMLElement,
+    private readonly now: () => number = () =>
+      typeof performance !== 'undefined' ? performance.now() : Date.now(),
+  ) {
+    // Pen-less desktops never emit touch/pen events, so skip the per-move
+    // capture listeners entirely there. iPads, Surface tablets, and 2-in-1s
+    // all report a positive touch-point count.
+    const touchCapable = typeof navigator !== 'undefined' && (navigator.maxTouchPoints ?? 0) > 0;
+    if (!touchCapable) {
+      return;
+    }
+    host.addEventListener('pointerdown', this.onPointerDown, this.listenerOptions);
+    host.addEventListener('pointermove', this.onPointerMove, this.listenerOptions);
+    host.addEventListener('pointerup', this.onPointerUp, this.listenerOptions);
+    host.addEventListener('pointercancel', this.onPointerUp, this.listenerOptions);
+    host.addEventListener('pointerout', this.onPointerOut, this.listenerOptions);
+  }
+
+  /** Enable or disable palm rejection (a user preference). Default on. */
+  setEnabled(enabled: boolean): void {
+    this.enabled = enabled;
+    if (!enabled) {
+      this.palmPointerIds.clear();
+    }
+  }
+
+  dispose(): void {
+    this.host.removeEventListener('pointerdown', this.onPointerDown, this.listenerOptions);
+    this.host.removeEventListener('pointermove', this.onPointerMove, this.listenerOptions);
+    this.host.removeEventListener('pointerup', this.onPointerUp, this.listenerOptions);
+    this.host.removeEventListener('pointercancel', this.onPointerUp, this.listenerOptions);
+    this.host.removeEventListener('pointerout', this.onPointerOut, this.listenerOptions);
+    this.palmPointerIds.clear();
+  }
+
+  /**
+   * True while a pen is down, hovering, or was active within the grace window.
+   * Exposed for diagnostics and potential UI affordances.
+   */
+  isPenActive(): boolean {
+    if (this.penContact) {
+      return true;
+    }
+    return this.now() - this.lastPenActivityMs < PEN_GRACE_MS;
+  }
+
+  private notePenActivity(): void {
+    this.penEverUsed = true;
+    this.penContact = true;
+    this.lastPenActivityMs = this.now();
+  }
+
+  private swallow(event: PointerEvent): void {
+    event.stopImmediatePropagation();
+    event.stopPropagation();
+    if (event.cancelable) {
+      event.preventDefault();
+    }
+  }
+
+  private classify(event: PointerEvent): boolean {
+    return isPalmTouch({
+      enabled: this.enabled,
+      penActive: this.isPenActive(),
+      penEverUsed: this.penEverUsed,
+      contactMaxPx: Math.max(event.width ?? 0, event.height ?? 0),
+      palmContactMinPx: PALM_CONTACT_MIN_PX,
+    });
+  }
+
+  private readonly onPointerDown = (event: PointerEvent): void => {
+    if (event.pointerType === 'pen') {
+      this.notePenActivity();
+      return;
+    }
+    if (event.pointerType !== 'touch') {
+      return;
+    }
+    if (this.classify(event)) {
+      this.palmPointerIds.add(event.pointerId);
+      this.swallow(event);
+    }
+  };
+
+  private readonly onPointerMove = (event: PointerEvent): void => {
+    if (event.pointerType === 'pen') {
+      this.notePenActivity();
+      return;
+    }
+    if (event.pointerType !== 'touch') {
+      return;
+    }
+    // A touch already committed to "palm" stays swallowed for its whole life so
+    // its move stream can never leak into a gesture handler.
+    if (this.palmPointerIds.has(event.pointerId)) {
+      this.swallow(event);
+    }
+  };
+
+  private readonly onPointerUp = (event: PointerEvent): void => {
+    if (event.pointerType === 'pen') {
+      this.penContact = false;
+      this.lastPenActivityMs = this.now();
+      return;
+    }
+    if (event.pointerType !== 'touch') {
+      return;
+    }
+    if (this.palmPointerIds.delete(event.pointerId)) {
+      this.swallow(event);
+    }
+  };
+
+  private readonly onPointerOut = (event: PointerEvent): void => {
+    // Pen left hover range (or the surface). Drop the "in contact" flag so the
+    // grace window starts counting down; touch resumes once it elapses.
+    if (event.pointerType === 'pen') {
+      this.penContact = false;
+      this.lastPenActivityMs = this.now();
+    }
+  };
+}

--- a/ui/src/app/components/viewer/scene/selection.ts
+++ b/ui/src/app/components/viewer/scene/selection.ts
@@ -251,13 +251,15 @@ export class SceneSelection {
     if (event.button !== 0 || !this.selectionHandlers) {
       return;
     }
-    // On touch there is no prior pointermove, so axis is null and isHovering()
-    // returns false even when the finger is directly over a gizmo handle.
-    // hitTest does a live raycast so touch can still pass through to TC.
+    // On touch — and on a stylus tap without a preceding hover move — there is
+    // no prior pointermove, so axis is null and isHovering() returns false even
+    // when the pointer is directly over a gizmo handle. hitTest does a live
+    // raycast so touch and pen can still pass through to TransformControls.
+    const directHitPointer = event.pointerType === 'touch' || event.pointerType === 'pen';
     const onGizmo =
       this.gizmo.isHovering() ||
       this.gizmo.isDragging() ||
-      (event.pointerType === 'touch' && this.gizmo.hitTest(event, this.camera, this.renderer));
+      (directHitPointer && this.gizmo.hitTest(event, this.camera, this.renderer));
     if (onGizmo) {
       return;
     }

--- a/ui/src/app/components/viewer/viewer.ts
+++ b/ui/src/app/components/viewer/viewer.ts
@@ -283,6 +283,12 @@ export class Viewer {
       this.scene?.setTwoFingerGesture(gesture);
     });
 
+    // React to the palm-rejection ("wrist detection") preference for stylus use.
+    effect(() => {
+      const enabled = this.viewerControl.palmRejection();
+      this.scene?.setPalmRejectionEnabled(enabled);
+    });
+
     // React to field-of-view changes from the 3D-view settings.
     effect(() => {
       const fov = this.viewerControl.fieldOfView();
@@ -689,6 +695,7 @@ export class Viewer {
     this.scene.setObjectMode(this.viewerControl.objectMode());
     this.scene.setView(this.viewerControl.view());
     this.scene.setTwoFingerGesture(this.viewerControl.trackpadTwoFingerGesture());
+    this.scene.setPalmRejectionEnabled(this.viewerControl.palmRejection());
     this.scene.setTheme(this.appTheme.isDarkMode());
     this.gcode = new GcodeOrchestrator(this.scene.contentRoot);
     // Hover-inspect probe for the G-code scalar views: raycasts the visible

--- a/ui/src/app/components/viewer/viewer.ts
+++ b/ui/src/app/components/viewer/viewer.ts
@@ -34,9 +34,10 @@ import {
 
 import { GcodeHoverProbe, type GcodeHoverHit } from './gcode-hover';
 import { GcodeOrchestrator } from './gcode-orchestrator';
+import { preferredHoverPlacement } from './hover-placement';
 import type { GizmoDelta } from './gizmo';
 import { ViewerScene } from './scene';
-import { applyFloating } from '../../shared/floating';
+import { applyFloating, type FloatingPlacement } from '../../shared/floating';
 
 export type ViewerMode = 'model' | 'gcode';
 
@@ -202,6 +203,8 @@ export class Viewer {
     },
   };
   private stopGcodeFloating: (() => void) | null = null;
+  /** Preferred side the G-code tooltip is currently floated to; drives re-anchoring when the input hand/side changes. */
+  private gcodeFloatingPlacement: FloatingPlacement | null = null;
   private shutterTimer: ReturnType<typeof setTimeout> | null = null;
   private polaroidTimer: ReturnType<typeof setTimeout> | null = null;
   private readonly captureSliceThumbnailSink = (request: SliceThumbnailRequest) =>
@@ -224,6 +227,7 @@ export class Viewer {
       }
       this.stopGcodeFloating?.();
       this.stopGcodeFloating = null;
+      this.gcodeFloatingPlacement = null;
       this.clearThumbnailFxTimers();
       this.thumbnailShutterActive.set(false);
       this.thumbnailPolaroidAnimating.set(false);
@@ -232,16 +236,24 @@ export class Viewer {
 
     // Position the G-code inspector tooltip with Floating UI, anchored to a
     // virtual element at the cursor so it flips/shifts to stay on-screen near
-    // the viewport edges instead of clipping.
+    // the viewport edges instead of clipping. The preferred side adapts to the
+    // input: below-right for a mouse, but opposite the hand for a pen (from its
+    // tilt) and above the contact for touch, so the hand never covers it.
     effect(() => {
       const info = this.gcodePreview.hoverInfo();
       const el = this.gcodeTooltipRef()?.nativeElement;
       if (info && el) {
         this.gcodeCursor.x = info.clientX;
         this.gcodeCursor.y = info.clientY;
-        if (!this.stopGcodeFloating) {
+        const placement = preferredHoverPlacement(info);
+        // Placement is fixed when applyFloating is created, so re-anchor when
+        // the desired side changes (e.g. the user switches from mouse to pen,
+        // or tilts the pen across an axis).
+        if (!this.stopGcodeFloating || this.gcodeFloatingPlacement !== placement) {
+          this.stopGcodeFloating?.();
+          this.gcodeFloatingPlacement = placement;
           this.stopGcodeFloating = applyFloating(this.gcodeCursorAnchor, el, {
-            placement: 'right-start',
+            placement,
             strategy: 'fixed',
             offset: 14,
             padding: 8,
@@ -251,6 +263,7 @@ export class Viewer {
       } else if (this.stopGcodeFloating) {
         this.stopGcodeFloating();
         this.stopGcodeFloating = null;
+        this.gcodeFloatingPlacement = null;
       }
     });
 
@@ -529,6 +542,9 @@ export class Viewer {
       t,
       clientX: hit.clientX,
       clientY: hit.clientY,
+      pointerType: hit.pointerType,
+      tiltX: hit.tiltX,
+      tiltY: hit.tiltY,
     });
   }
 

--- a/ui/src/app/components/viewer/viewer.ts
+++ b/ui/src/app/components/viewer/viewer.ts
@@ -363,7 +363,7 @@ export class Viewer {
       if (!req) {
         return;
       }
-      this.scene?.animateToDirection(req.direction, req.up);
+      this.scene?.animateToDirection(req.direction, req.up, req.autoOrtho);
     });
 
     // React to roll requests (viewport-cube roll buttons).

--- a/ui/src/app/components/viewport-cube/viewport-cube.ts
+++ b/ui/src/app/components/viewport-cube/viewport-cube.ts
@@ -579,7 +579,9 @@ export class ViewportCube {
       const mesh = this.pickZone(event);
       if (mesh) {
         const ud = mesh.userData as ZoneUserData;
-        this.viewerControl.lookFrom(ud.direction, WORLD_UP);
+        // Snapping to a cube face/edge/corner also flattens the projection to
+        // orthographic (CAD convention); a later free pan/zoom reverts it.
+        this.viewerControl.lookFrom(ud.direction, WORLD_UP, true);
       }
     }
     canvas.style.cursor = this.pickZone(event) ? 'pointer' : 'grab';

--- a/ui/src/app/pages/settings/general.html
+++ b/ui/src/app/pages/settings/general.html
@@ -69,6 +69,36 @@
 
     <div class="settings-field">
       <span class="settings-field-label">
+        <span class="settings-field-title">Palm rejection</span>
+        <span class="settings-field-desc">
+          Ignore the hand resting on the screen while drawing with an Apple Pencil or stylus, so the
+          palm never orbits or zooms the 3D view. Finger-only gestures are unaffected.
+        </span>
+      </span>
+      <div class="segmented" role="group" aria-label="Palm rejection">
+        <button
+          type="button"
+          class="segmented-btn"
+          [class.is-active]="palmRejection()"
+          [attr.aria-pressed]="palmRejection()"
+          (click)="setPalmRejection(true)"
+        >
+          On
+        </button>
+        <button
+          type="button"
+          class="segmented-btn"
+          [class.is-active]="!palmRejection()"
+          [attr.aria-pressed]="!palmRejection()"
+          (click)="setPalmRejection(false)"
+        >
+          Off
+        </button>
+      </div>
+    </div>
+
+    <div class="settings-field">
+      <span class="settings-field-label">
         <span class="settings-field-title">Scene diagnostics chips</span>
         <span class="settings-field-desc">
           Show FPS and WASM timing chips in the viewer overlay.

--- a/ui/src/app/pages/settings/general.ts
+++ b/ui/src/app/pages/settings/general.ts
@@ -24,6 +24,7 @@ export class GeneralSettings implements OnInit {
   private readonly appVersion = inject(AppVersion);
   protected readonly gesture = this.viewer.trackpadTwoFingerGesture;
   protected readonly statsVisible = this.viewer.statsVisible;
+  protected readonly palmRejection = this.viewer.palmRejection;
   protected readonly fieldOfView = this.viewer.fieldOfView;
   protected readonly antialiasing = this.viewer.antialiasing;
   protected readonly renderQuality = this.viewer.renderQuality;
@@ -60,6 +61,10 @@ export class GeneralSettings implements OnInit {
 
   setStatsVisible(value: boolean): void {
     this.viewer.setStatsVisible(value);
+  }
+
+  setPalmRejection(value: boolean): void {
+    this.viewer.setPalmRejection(value);
   }
 
   setFieldOfView(value: number): void {

--- a/ui/src/app/services/gcode-preview.ts
+++ b/ui/src/app/services/gcode-preview.ts
@@ -563,6 +563,12 @@ export interface GcodeHoverInfo {
   /** Viewport pointer position (px) used as the floating anchor. */
   clientX: number;
   clientY: number;
+  /** Originating pointer type — drives which side the tooltip floats toward. */
+  pointerType: string;
+  /** Pen tilt toward +X in degrees (−90…90); 0 for mouse/touch. */
+  tiltX: number;
+  /** Pen tilt toward +Y in degrees (−90…90); 0 for mouse/touch. */
+  tiltY: number;
 }
 
 // ── Service ───────────────────────────────────────────────────────────────────

--- a/ui/src/app/services/viewer-control.ts
+++ b/ui/src/app/services/viewer-control.ts
@@ -100,6 +100,7 @@ const FIELD_OF_VIEW_KEY = 'nexus.viewer.fieldOfView';
 const ANTIALIASING_KEY = 'nexus.viewer.antialiasing';
 const RENDER_QUALITY_KEY = 'nexus.viewer.renderQuality';
 const USE_FILAMENT_COLOR_KEY = 'nexus.viewer.useFilamentColor';
+const PALM_REJECTION_KEY = 'nexus.viewer.palmRejection';
 
 /**
  * Shared state between the 3D-view toolbar and the viewer component.
@@ -162,6 +163,15 @@ export class ViewerControl {
    * Default is `false` to preserve the existing scene appearance.
    */
   readonly useFilamentColor = signal(this.readUseFilamentColor());
+
+  /**
+   * Whether pen-priority palm rejection ("wrist detection") is active in the
+   * 3D view. When on (the default), touch contacts from the hand resting on
+   * the glass are ignored while an Apple Pencil / stylus is in use, so the palm
+   * never orbits or pinches the camera. Pure-touch gestures are unaffected.
+   * Persisted so the choice survives reloads.
+   */
+  readonly palmRejection = signal(this.readPalmRejection());
 
   /**
    * Currently selected object-manipulation mode. Drives the gizmo shown
@@ -300,6 +310,12 @@ export class ViewerControl {
     this.storage.write(USE_FILAMENT_COLOR_KEY, String(value));
   }
 
+  /** Update the palm-rejection preference and persist it. */
+  setPalmRejection(value: boolean): void {
+    this.palmRejection.set(value);
+    this.storage.write(PALM_REJECTION_KEY, String(value));
+  }
+
   private readTwoFingerGesture(): TwoFingerGesture {
     return this.storage.get(TWO_FINGER_GESTURE_KEY)() === 'pan' ? 'pan' : 'orbit';
   }
@@ -335,6 +351,12 @@ export class ViewerControl {
 
   private readUseFilamentColor(): boolean {
     return this.storage.get(USE_FILAMENT_COLOR_KEY)() === 'true';
+  }
+
+  private readPalmRejection(): boolean {
+    // Default on — palm rejection only changes behaviour once a pen appears,
+    // so it is safe to enable everywhere.
+    return this.storage.get(PALM_REJECTION_KEY)() !== 'false';
   }
 
   /**

--- a/ui/src/app/services/viewer-control.ts
+++ b/ui/src/app/services/viewer-control.ts
@@ -224,9 +224,16 @@ export class ViewerControl {
    * Pending request for the viewer to animate to a specific look direction
    * (e.g. when the user clicks a face of the viewport-cube). Cleared after
    * the viewer consumes it; the `tick` field disambiguates repeated requests
-   * for the same direction.
+   * for the same direction. `autoOrtho` asks the viewer to also snap the
+   * projection to orthographic (viewport-cube behaviour) until the next free
+   * pan/zoom.
    */
-  readonly lookRequest = signal<{ direction: Vector3; up: Vector3; tick: number } | null>(null);
+  readonly lookRequest = signal<{
+    direction: Vector3;
+    up: Vector3;
+    tick: number;
+    autoOrtho: boolean;
+  } | null>(null);
   private lookTick = 0;
 
   /**
@@ -363,13 +370,17 @@ export class ViewerControl {
    * Ask the viewer to animate to a specific camera direction (unit vector
    * from the controls target toward the camera) with the given up vector.
    * The current target and distance are preserved.
+   *
+   * @param autoOrtho  When `true` (viewport-cube snaps), also flatten the
+   *   projection to orthographic until the next free pan/zoom in the viewport.
    */
-  lookFrom(direction: Vector3, up: Vector3): void {
+  lookFrom(direction: Vector3, up: Vector3, autoOrtho = false): void {
     this.lookTick += 1;
     this.lookRequest.set({
       direction: direction.clone().normalize(),
       up: up.clone().normalize(),
       tick: this.lookTick,
+      autoOrtho,
     });
   }
 


### PR DESCRIPTION
## Why

While reviewing cross-platform input support in the 3D viewport, the weak spot was **Apple Pencil / stylus on iPad**. The camera/selection layer treated a pencil like a mouse and had **no palm/wrist rejection**: resting your hand on the glass fired `pointerType === 'touch'` events that OrbitControls read as single-finger rotate — and two palm contacts as a pinch — so the model lurched while you were simply drawing with the pencil. Gizmo handles also required a prior hover to grab, which a pen tap never provides. This was the "clunky, weird" pen behaviour flagged as the key improvement.

For context, the rest of the platform matrix was already solid: macOS trackpad (Shapr3D-style two-finger orbit/pan/pinch + WebKit `gesture*`), Windows/Linux mouse (autoscroll + wheel zoom), and iPad finger touch (custom two-finger pinch/pan/twist).

## What changed

- **New [`PointerArbiter`](ui/src/app/components/viewer/scene/pointer-arbiter.ts)** — pen-priority palm rejection ("wrist detection"). Installed in the **capture phase on the canvas host** (an ancestor of the WebGL canvas) so it runs *before* OrbitControls, selection, and the two-finger touch handlers, and can veto a palm/wrist contact via `stopImmediatePropagation` before any camera gesture starts. No half-finished gesture state to unwind.
  - A touch is judged palm when a pen is **down, hovering, or lifted within `PEN_GRACE_MS`**, or — once a pen has been seen this session — when its **contact patch is palm-sized** (`PALM_CONTACT_MIN_PX`), catching the palm that lands just before the tip on hover-less iPads.
  - **Pure-touch users are never affected**: the size path is gated behind "a pen has been seen", and the pen-active path only fires while a pen is in use. Skips installing listeners entirely on non-touch devices.
- **Pen is now first-class in selection**: [`selection.ts`](ui/src/app/components/viewer/scene/selection.ts) gizmo hit-test accepts `pen` like `touch`, so a pencil tap grabs a handle without a preceding hover move.
- **User control**: persisted, default-on `palmRejection` preference in [`ViewerControl`](ui/src/app/services/viewer-control.ts), wired through the viewer, exposed as a toggle in **Settings → General → Controls → Palm rejection**.
- **Docs**: [viewer README](ui/src/app/components/viewer/README.md) gains an interaction-priority entry (priority 0), a flow diagram, anatomy + See-also entries; a cross-reference note added in `controls.ts`.

## Testing

- **Adds the repo's first UI unit spec** — `isPalmTouch` truth table + a jsdom-driven `PointerArbiter` suite (palm swallowing, grace window, contact-size rejection, disable/dispose). **12/12 pass** under the exact CI command `ng test --watch=false`.
- This flips on CI's gated `ng test` step, which failed to resolve `zone.js/testing` in this zoneless Angular 22 app. Added **`zone.js`** (the standard Angular test polyfill, already a lockfile-pinned optional peer) as a **UI devDependency** — the app runtime stays zoneless; it only satisfies build-time test resolution.
- Prettier clean across the UI; type-check shows **zero errors from the touched files** (remaining errors are pre-existing `Cannot find module '../generated/…'` from gitignored WASM/schema outputs that CI hydrates before build).

## Reviewer notes

- The one honest residual: the very first stroke on a **hover-less** iPad, before any pen event has ever fired, cannot be pre-classified — it self-heals for the rest of the session and is documented.
- Out of scope (noted for later): SpaceMouse/6DoF, pen pressure/tilt, coalesced-event smoothing.

Co-authored-by: Copilot <223556219+Copilot@users.noreply.github.com>
