### PR TITLE
ui: fix Monaco G-code editors on WASM + GitHub Pages deploy

### DIFF
--- a/ui/src/app/components/code-editor/code-editor.ts
+++ b/ui/src/app/components/code-editor/code-editor.ts
@@ -97,23 +97,43 @@ export class CodeEditor {
   }
 
   private async initMonaco(): Promise<void> {
-    // Tell Monaco where to find its web workers. Blob URLs allow workers
-    // to be spawned without a separate worker bundle entry point.
+    // Tell Monaco where to find its web workers. Each worker is referenced via
+    // `new Worker(new URL(..., import.meta.url))` so the bundler (esbuild)
+    // emits a real, content-hashed worker asset and rewrites the URL relative
+    // to the deployed base href. The previous Blob + `importScripts('bare
+    // specifier')` approach produced URLs that only resolved at the site root,
+    // so on a static/GitHub Pages deploy served from a sub-path the workers
+    // 404'd and Monaco failed to initialise.
     if (!window.MonacoEnvironment) {
       window.MonacoEnvironment = {
         getWorker(_moduleId: string, label: string): Worker {
-          const workerUrls: Record<string, string> = {
-            json: 'monaco-editor/esm/vs/language/json/json.worker',
-            css: 'monaco-editor/esm/vs/language/css/css.worker',
-            html: 'monaco-editor/esm/vs/language/html/html.worker',
-            typescript: 'monaco-editor/esm/vs/language/typescript/ts.worker',
-            javascript: 'monaco-editor/esm/vs/language/typescript/ts.worker',
-          };
-          const workerPath = workerUrls[label] ?? 'monaco-editor/esm/vs/editor/editor.worker';
-          const blob = new Blob([`importScripts('${workerPath}');`], {
-            type: 'application/javascript',
-          });
-          return new Worker(URL.createObjectURL(blob));
+          switch (label) {
+            case 'json':
+              return new Worker(new URL('./workers/json.worker', import.meta.url), {
+                type: 'module',
+              });
+            case 'css':
+            case 'scss':
+            case 'less':
+              return new Worker(new URL('./workers/css.worker', import.meta.url), {
+                type: 'module',
+              });
+            case 'html':
+            case 'handlebars':
+            case 'razor':
+              return new Worker(new URL('./workers/html.worker', import.meta.url), {
+                type: 'module',
+              });
+            case 'typescript':
+            case 'javascript':
+              return new Worker(new URL('./workers/ts.worker', import.meta.url), {
+                type: 'module',
+              });
+            default:
+              return new Worker(new URL('./workers/editor.worker', import.meta.url), {
+                type: 'module',
+              });
+          }
         },
       };
     }

--- a/ui/src/app/components/code-editor/workers/css.worker.ts
+++ b/ui/src/app/components/code-editor/workers/css.worker.ts
@@ -1,0 +1,3 @@
+// Local worker entry point for Monaco's CSS language worker. See
+// editor.worker.ts for why the worker is wrapped in a local module.
+import 'monaco-editor/language/css/css.worker.js';

--- a/ui/src/app/components/code-editor/workers/editor.worker.ts
+++ b/ui/src/app/components/code-editor/workers/editor.worker.ts
@@ -1,0 +1,6 @@
+// Local worker entry point for Monaco's base editor worker. Importing the
+// module for its side effects wires up `self.onmessage`. Referencing this file
+// via `new Worker(new URL('./editor.worker', import.meta.url))` lets the
+// bundler (esbuild) emit a real, base-href-relative worker asset — unlike a
+// bare module specifier, which esbuild cannot resolve inside `new URL(...)`.
+import 'monaco-editor/editor/editor.worker.js';

--- a/ui/src/app/components/code-editor/workers/html.worker.ts
+++ b/ui/src/app/components/code-editor/workers/html.worker.ts
@@ -1,0 +1,3 @@
+// Local worker entry point for Monaco's HTML language worker. See
+// editor.worker.ts for why the worker is wrapped in a local module.
+import 'monaco-editor/language/html/html.worker.js';

--- a/ui/src/app/components/code-editor/workers/json.worker.ts
+++ b/ui/src/app/components/code-editor/workers/json.worker.ts
@@ -1,0 +1,3 @@
+// Local worker entry point for Monaco's JSON language worker. See
+// editor.worker.ts for why the worker is wrapped in a local module.
+import 'monaco-editor/language/json/json.worker.js';

--- a/ui/src/app/components/code-editor/workers/ts.worker.ts
+++ b/ui/src/app/components/code-editor/workers/ts.worker.ts
@@ -1,0 +1,3 @@
+// Local worker entry point for Monaco's TypeScript/JavaScript language worker.
+// See editor.worker.ts for why the worker is wrapped in a local module.
+import 'monaco-editor/language/typescript/ts.worker.js';


### PR DESCRIPTION
## What

The printer-settings G-code editors (Start / Layer change / End G-code) broke on the simplest **WASM + GitHub Pages** deploy — Monaco failed to initialise and the settings panel broke.

## Why

`CodeEditor` configured `MonacoEnvironment.getWorker` to spawn a Blob worker that called `importScripts('monaco-editor/esm/vs/...')` with **bare module specifiers**. Those aren't real URLs: at runtime the browser resolved them against the site root, ignoring the Pages sub-path base href, so the worker request 404'd. With no worker, Monaco never came up.

## How

Switched to the bundler-native worker pattern so Angular's esbuild emits real, content-hashed worker chunks whose URLs resolve relative to the chunk (base-href independent):

- `getWorker` now returns `new Worker(new URL('./workers/<x>.worker', import.meta.url), { type: 'module' })`.
- Added thin local worker entry wrappers under `ui/src/app/components/code-editor/workers/` (`editor`, `json`, `css`, `html`, `ts`) that side-effect-import the corresponding `monaco-editor/<path>` worker. esbuild can't resolve a bare specifier inside `new URL(...)`, so the wrappers give it real relative modules to bundle. Import paths use `monaco-editor/<path>` (not `esm/vs/<path>`) to match the package's `exports` map.

## Verification

- `ng build --configuration web-slicer` succeeds and emits a worker reference resolved via `import.meta.url` (`new Worker(new URL(\`worker-XXXX.js\`, import.meta.url))`).
- Served the production `dist` as an SPA and loaded `/settings/printers` in a browser: all **3 Monaco editors mount** with **zero console errors and zero failed requests**.

## Notes for reviewers

- Change is UI-only; no runtime/engine code touched.
- The new `workers/*.worker.ts` files are intentionally one-line side-effect imports — they exist solely so esbuild can bundle each Monaco worker as a relative module.
