### PR TITLE
ui: open context menus on touch long-press (iPad)

### DIFF
--- a/ui/src/app/components/list-history/list-history.component.html
+++ b/ui/src/app/components/list-history/list-history.component.html
@@ -5,7 +5,7 @@
 } @else {
   <ul class="lh-list">
     @for (session of history.sessions(); track session.request_uuid) {
-      <li class="lh-item" (contextmenu)="onContextMenu($event, session)">
+      <li class="lh-item" (nexusContextMenu)="onContextMenu($event, session)">
         <button
           class="lh-open"
           type="button"

--- a/ui/src/app/components/list-history/list-history.ts
+++ b/ui/src/app/components/list-history/list-history.ts
@@ -2,6 +2,7 @@ import { Component, inject } from '@angular/core';
 import { Router } from '@angular/router';
 import type { RuntimeHistorySession } from '../../runtime/domain/history-models';
 import { ContextMenuService } from '../../services/context-menu/context-menu.service';
+import { ContextMenuTrigger } from '../../services/context-menu/context-menu-trigger';
 import type { ContextMenuItem } from '../../services/context-menu/context-menu.model';
 import { History } from '../../services/history';
 import { WorkplateNames } from '../../services/workplate-names';
@@ -11,7 +12,7 @@ import { Button } from '../../ui/button/button';
 @Component({
   selector: 'nexus-list-history',
   standalone: true,
-  imports: [Button, Icon],
+  imports: [Button, Icon, ContextMenuTrigger],
   templateUrl: './list-history.component.html',
   styleUrl: './list-history.component.scss',
 })

--- a/ui/src/app/pages/settings/filaments.html
+++ b/ui/src/app/pages/settings/filaments.html
@@ -64,7 +64,7 @@
                     type="button"
                     [class.is-selected]="selectedId() === filament.id"
                     (click)="select(filament.id)"
-                    (contextmenu)="onContextMenu($event, filament)"
+                    (nexusContextMenu)="onContextMenu($event, filament)"
                   >
                     <span class="mgr__card-swatch" [style.background]="filament.color"></span>
                     <span class="mgr__card-info">

--- a/ui/src/app/pages/settings/filaments.ts
+++ b/ui/src/app/pages/settings/filaments.ts
@@ -22,6 +22,7 @@ import { parseSchema } from '../../schema-form/models/schema-parser';
 import type { SchemaGroup } from '../../schema-form/models/field-def';
 import { CloudCatalog } from '../../services/catalog/cloud-catalog';
 import { ContextMenuService } from '../../services/context-menu/context-menu.service';
+import { ContextMenuTrigger } from '../../services/context-menu/context-menu-trigger';
 import type { ContextMenuItem } from '../../services/context-menu/context-menu.model';
 import { Dialog } from '../../services/dialog';
 import { ActiveSelection } from '../../services/profiles/active-selection';
@@ -114,6 +115,7 @@ const PARAM_GROUPS: SchemaGroup[] = (() => {
     Segmented,
     LabelFilterBar,
     LabelPicker,
+    ContextMenuTrigger,
   ],
   templateUrl: './filaments.html',
   styleUrl: './filaments.scss',

--- a/ui/src/app/pages/settings/labels.html
+++ b/ui/src/app/pages/settings/labels.html
@@ -12,7 +12,7 @@
   @if (store.items().length > 0) {
     <div class="profile-list">
       @for (label of store.items(); track label.id) {
-        <div class="profile-card label-row" (contextmenu)="onContextMenu($event, label)">
+        <div class="profile-card label-row" (nexusContextMenu)="onContextMenu($event, label)">
           <button class="label-row__main" type="button" (click)="toggleEditor(label.id)">
             <nexus-label-chip [label]="chipFor(label)" />
             <span class="label-row__usage">

--- a/ui/src/app/pages/settings/labels.ts
+++ b/ui/src/app/pages/settings/labels.ts
@@ -4,6 +4,7 @@ import { ColorSwatchPicker } from '../../components/labels/color-swatch-picker';
 import { FieldShell } from '../../components/profiles/field-shell';
 import { LabelChip } from '../../components/labels/label-chip';
 import { ContextMenuService } from '../../services/context-menu/context-menu.service';
+import { ContextMenuTrigger } from '../../services/context-menu/context-menu-trigger';
 import type { ContextMenuItem } from '../../services/context-menu/context-menu.model';
 import { Dialog } from '../../services/dialog';
 import { FilamentsStore } from '../../services/profiles/filaments-store';
@@ -27,6 +28,7 @@ import { SectionHeader } from '../../ui/section-header/section-header';
     LabelChip,
     ColorSwatchPicker,
     FieldShell,
+    ContextMenuTrigger,
   ],
   templateUrl: './labels.html',
   styleUrl: './labels.scss',

--- a/ui/src/app/pages/settings/printers.html
+++ b/ui/src/app/pages/settings/printers.html
@@ -64,7 +64,7 @@
                     type="button"
                     [class.is-selected]="selectedId() === printer.id"
                     (click)="select(printer.id)"
-                    (contextmenu)="onContextMenu($event, printer)"
+                    (nexusContextMenu)="onContextMenu($event, printer)"
                   >
                     <span
                       class="conn-dot"

--- a/ui/src/app/pages/settings/printers.ts
+++ b/ui/src/app/pages/settings/printers.ts
@@ -33,6 +33,7 @@ import {
 } from '../../models/gcode-templates';
 import { CloudCatalog } from '../../services/catalog/cloud-catalog';
 import { ContextMenuService } from '../../services/context-menu/context-menu.service';
+import { ContextMenuTrigger } from '../../services/context-menu/context-menu-trigger';
 import type { ContextMenuItem } from '../../services/context-menu/context-menu.model';
 import { Dialog } from '../../services/dialog';
 import { PrinterConnectionService } from '../../services/printer-connection';
@@ -132,6 +133,7 @@ const PARAM_GROUPS: SchemaGroup[] = (() => {
     Segmented,
     LabelFilterBar,
     LabelPicker,
+    ContextMenuTrigger,
   ],
   templateUrl: './printers.html',
   styleUrl: './printers.scss',

--- a/ui/src/app/pages/settings/profiles.html
+++ b/ui/src/app/pages/settings/profiles.html
@@ -64,7 +64,7 @@
                     type="button"
                     [class.is-selected]="selectedId() === profile.id"
                     (click)="select(profile.id)"
-                    (contextmenu)="onContextMenu($event, profile)"
+                    (nexusContextMenu)="onContextMenu($event, profile)"
                   >
                     <span class="mgr__card-icon"><nexus-icon name="menu-scale" /></span>
                     <span class="mgr__card-info">

--- a/ui/src/app/pages/settings/profiles.ts
+++ b/ui/src/app/pages/settings/profiles.ts
@@ -15,6 +15,7 @@ import { parseSchema } from '../../schema-form/models/schema-parser';
 import type { SchemaGroup } from '../../schema-form/models/field-def';
 import { CloudCatalog } from '../../services/catalog/cloud-catalog';
 import { ContextMenuService } from '../../services/context-menu/context-menu.service';
+import { ContextMenuTrigger } from '../../services/context-menu/context-menu-trigger';
 import type { ContextMenuItem } from '../../services/context-menu/context-menu.model';
 import { Dialog } from '../../services/dialog';
 import { ActiveSelection } from '../../services/profiles/active-selection';
@@ -82,6 +83,7 @@ const PARAM_GROUPS: SchemaGroup[] = (() => {
     Segmented,
     LabelFilterBar,
     LabelPicker,
+    ContextMenuTrigger,
   ],
   templateUrl: './profiles.html',
   styleUrl: './profiles.scss',

--- a/ui/src/app/services/context-menu/context-menu-trigger.ts
+++ b/ui/src/app/services/context-menu/context-menu-trigger.ts
@@ -1,0 +1,158 @@
+import { Directive, ElementRef, NgZone, OnDestroy, inject, output } from '@angular/core';
+
+/**
+ * How long a touch must be held before it counts as a long-press. Matches the
+ * ~0.5s the native iOS/iPadOS and Android context menus use, so the gesture
+ * feels the same in the browser without any custom CSS animation.
+ */
+const LONG_PRESS_MS = 500;
+/** Movement (px) that reclassifies a press as a scroll/drag and cancels it. */
+const MOVE_CANCEL_PX = 10;
+/**
+ * Window after a long-press fires during which a follow-up native `contextmenu`
+ * (some browsers, e.g. Android Chrome, emit both) is treated as a duplicate.
+ */
+const DEDUPE_MS = 700;
+
+/**
+ * Opens a context menu on right-click *and* touch long-press.
+ *
+ * The `contextmenu` DOM event is all a desktop mouse (or a browser that fires it
+ * on long-press) needs, but iOS/iPadOS Safari never dispatches `contextmenu` for
+ * a long-press on a normal element — so those menus simply never appeared on an
+ * iPad. This directive layers a pointer-based long-press recogniser on top of the
+ * native event to close that gap while leaning on native behaviour everywhere it
+ * already works:
+ *
+ * - **Mouse:** ignored here; the browser's `contextmenu` event drives the menu.
+ * - **Touch / pen:** a held press (no scroll) for {@link LONG_PRESS_MS} opens the
+ *   menu at the finger, matching the native long-press timing.
+ * - **De-duplication:** browsers that emit *both* a long-press and a
+ *   `contextmenu` only open one menu, and the OS menu is always suppressed.
+ *
+ * Emits the originating pointer/mouse event so the host can forward it straight
+ * to {@link ContextMenuService.open}.
+ */
+@Directive({
+  selector: '[nexusContextMenu]',
+  standalone: true,
+})
+export class ContextMenuTrigger implements OnDestroy {
+  /** Fires when a context menu is requested (right-click or touch long-press). */
+  readonly nexusContextMenu = output<MouseEvent>();
+
+  readonly #host = inject<ElementRef<HTMLElement>>(ElementRef).nativeElement;
+  readonly #zone = inject(NgZone);
+
+  #timer: ReturnType<typeof setTimeout> | null = null;
+  #startX = 0;
+  #startY = 0;
+  #lastFire = 0;
+
+  constructor() {
+    this.#host.addEventListener('contextmenu', this.#onContextMenu);
+    this.#host.addEventListener('pointerdown', this.#onPointerDown);
+  }
+
+  ngOnDestroy(): void {
+    this.#host.removeEventListener('contextmenu', this.#onContextMenu);
+    this.#host.removeEventListener('pointerdown', this.#onPointerDown);
+    this.#cancel();
+  }
+
+  /**
+   * Native path: desktop right-click, or a browser that raises `contextmenu` on
+   * long-press. Always swallow the OS menu; the de-dupe guard stops a press that
+   * already opened our menu from opening a second one.
+   */
+  readonly #onContextMenu = (event: MouseEvent): void => {
+    event.preventDefault();
+    this.#fire(event);
+  };
+
+  readonly #onPointerDown = (event: PointerEvent): void => {
+    // A mouse right-click already arrives via `contextmenu`; only touch and pen
+    // need the long-press timer (this is the path iPadOS Safari relies on).
+    if (event.pointerType === 'mouse') {
+      return;
+    }
+    this.#startX = event.clientX;
+    this.#startY = event.clientY;
+    this.#clearTimer();
+    this.#zone.runOutsideAngular(() => {
+      window.addEventListener('pointermove', this.#onPointerMove, { passive: true });
+      window.addEventListener('pointerup', this.#onPointerEnd, { passive: true });
+      window.addEventListener('pointercancel', this.#onPointerEnd, { passive: true });
+      window.addEventListener('scroll', this.#onPointerEnd, { capture: true, passive: true });
+    });
+    this.#timer = setTimeout(() => {
+      this.#stopTracking();
+      this.#suppressTrailingClick();
+      this.#zone.run(() => this.#fire(event));
+    }, LONG_PRESS_MS);
+  };
+
+  readonly #onPointerMove = (event: PointerEvent): void => {
+    if (
+      Math.abs(event.clientX - this.#startX) > MOVE_CANCEL_PX ||
+      Math.abs(event.clientY - this.#startY) > MOVE_CANCEL_PX
+    ) {
+      this.#cancel();
+    }
+  };
+
+  readonly #onPointerEnd = (): void => this.#cancel();
+
+  #fire(event: MouseEvent): void {
+    const now = performance.now();
+    if (now - this.#lastFire < DEDUPE_MS) {
+      return;
+    }
+    this.#lastFire = now;
+    this.#clearTimer();
+    this.nexusContextMenu.emit(event);
+  }
+
+  /**
+   * Lifting the finger after a long-press still synthesises a `click`, which
+   * would activate the element under it (navigate/select). Swallow that single
+   * trailing click on the host; menu-item taps live in a body-level layer and
+   * are left untouched.
+   */
+  #suppressTrailingClick(): void {
+    const cleanup = (): void => {
+      window.removeEventListener('click', swallow, true);
+      clearTimeout(fallback);
+    };
+    const swallow = (event: Event): void => {
+      if (this.#host.contains(event.target as Node)) {
+        event.stopPropagation();
+        event.preventDefault();
+      }
+      cleanup();
+    };
+    const fallback = setTimeout(cleanup, DEDUPE_MS);
+    window.addEventListener('click', swallow, true);
+  }
+
+  #cancel(): void {
+    this.#stopTracking();
+    this.#clearTimer();
+  }
+
+  #stopTracking(): void {
+    window.removeEventListener('pointermove', this.#onPointerMove);
+    window.removeEventListener('pointerup', this.#onPointerEnd);
+    window.removeEventListener('pointercancel', this.#onPointerEnd);
+    window.removeEventListener('scroll', this.#onPointerEnd, {
+      capture: true,
+    } as EventListenerOptions);
+  }
+
+  #clearTimer(): void {
+    if (this.#timer !== null) {
+      clearTimeout(this.#timer);
+      this.#timer = null;
+    }
+  }
+}


### PR DESCRIPTION
## What

Context menus never opened on touch devices (iPads). Right-click on desktop and the native Tauri OS menu worked, but nothing happened on a long-press on iPadOS.

## Why

Every call site bound only the DOM `contextmenu` event, and **iOS/iPadOS Safari does not dispatch `contextmenu` on a long-press** for normal elements — so touch users got no menu at all.

## How

Added a small reusable standalone directive, `ContextMenuTrigger` (`(nexusContextMenu)` output), that opens a context menu on **right-click _and_ touch long-press**, then wired it into all five call sites.

- **Mouse:** untouched — the browser's own `contextmenu` event drives the menu.
- **Touch/pen:** a pointer-based long-press recogniser fires after **500 ms** (with a movement cancel threshold), matching native long-press timing.
- **De-duplication:** browsers that emit _both_ a long-press and a `contextmenu` (e.g. Android Chrome) open only one menu; the OS menu is always suppressed.
- **Trailing-click suppression:** the synthetic `click` after a long-press is swallowed only on the trigger element, so a long-press won't also navigate/select the row — menu-item taps in the body-level floating layer are untouched.
- **No forced CSS.** The native peek/zoom before a menu is WebKit-only for links/images with no web API for custom menus, so the directive stays native by leaning on gesture timing rather than faking an animation.

## Files

- New: `ui/src/app/services/context-menu/context-menu-trigger.ts`
- Switched `(contextmenu)` → `(nexusContextMenu)` and registered the directive in: list-history, and the printers / filaments / profiles / labels settings pages.

## Reviewer notes

- `ng build` compiles cleanly (only pre-existing SCSS budget warnings); Prettier passes on all touched files.
- I don't have a physical iPad in this environment — the long-press path follows the standard Pointer Events pattern and should be smoke-tested on a real touch device.
