### PR TITLE
fix(ui): flush previous workplate state so plates don't cross-contaminate

### DIFF
--- a/ui/src/app/components/viewer/viewer.ts
+++ b/ui/src/app/components/viewer/viewer.ts
@@ -734,13 +734,23 @@ export class Viewer {
       this.trackedObjectIds = [];
       for (const id of this.wasmMeshes.keys()) {
         this.scene?.unregisterSelectable(String(id));
+      }
+      this.wasmMeshes.clear();
+      // Evict *every* object from the singleton scene engine — not only the
+      // ones this component mirrored. Navigating between workplates destroys
+      // the viewer component but not the WASM engine, so a previous plate's
+      // object can survive in the engine even though this freshly-created
+      // component never tracked it (its `wasmMeshes` map starts empty). Left
+      // behind, that stale mesh would be sliced into the new plate and skew
+      // its thumbnail. Read untracked so this teardown never subscribes the
+      // enclosing effect to the object list it is about to mutate.
+      for (const obj of untracked(() => this.sceneEngine.objects())) {
         try {
-          this.sceneEngine.apply({ op: 'Remove', args: { id } });
+          this.sceneEngine.apply({ op: 'Remove', args: { id: obj.id } });
         } catch {
           // Object may already be gone if the engine reset; safe to ignore.
         }
       }
-      this.wasmMeshes.clear();
       this.handleClearSelection();
       this.dragApplied.clear();
       this.activeModelSource = model;

--- a/ui/src/app/pages/home/home.ts
+++ b/ui/src/app/pages/home/home.ts
@@ -3,16 +3,13 @@ import type { ElementRef, OnDestroy } from '@angular/core';
 import { Router, RouterLink } from '@angular/router';
 import type { PrinterProfile } from '../../models/printer.model';
 import { ListHistory } from '../../components/list-history/list-history';
-import { GcodePreview } from '../../services/gcode-preview';
 import { NotificationService } from '../../services/notifications';
 import {
   PrinterConnectionService,
   type PrinterProbeState,
 } from '../../services/printer-connection';
 import { PrintersStore } from '../../services/profiles/printers-store';
-import { SceneEngine } from '../../services/scene-engine';
 import { Slicer } from '../../services/slicer';
-import { ViewerControl } from '../../services/viewer-control';
 import { Icon } from '../../shared/icon/icon';
 import { Button } from '../../ui/button/button';
 import { EmptyState } from '../../ui/empty-state/empty-state';
@@ -41,9 +38,6 @@ export class HomeDashboard implements OnDestroy {
   private readonly printersStore = inject(PrintersStore);
   private readonly printerConn = inject(PrinterConnectionService);
   private readonly slicer = inject(Slicer);
-  private readonly sceneEngine = inject(SceneEngine);
-  private readonly gcodePreview = inject(GcodePreview);
-  private readonly viewerControl = inject(ViewerControl);
   private readonly notifications = inject(NotificationService);
 
   /** Re-probe printers periodically so the dashboard reflects live status. */
@@ -97,10 +91,7 @@ export class HomeDashboard implements OnDestroy {
    * the previous model over into the "empty" plate.
    */
   async openEmptyWorkplate(): Promise<void> {
-    this.slicer.reset();
-    this.gcodePreview.clear();
-    this.viewerControl.viewMode.set('model');
-    await this.sceneEngine.clear();
+    await this.slicer.resetWorkplate();
     await this.router.navigate(['/slice', 'new']);
   }
 

--- a/ui/src/app/services/gcode-preview.ts
+++ b/ui/src/app/services/gcode-preview.ts
@@ -584,6 +584,13 @@ export class GcodePreview {
   /** Object-id set of the previously loaded slice, for scene-change detection. */
   #lastSlicedObjectIds: ReadonlySet<string> | null = null;
 
+  /**
+   * Workplate uuid the current preview belongs to. `undefined` until first
+   * observed so the initial value is adopted without clearing; any later
+   * change means a different plate is active and the preview must be dropped.
+   */
+  #lastWorkplateUuid: string | null | undefined = undefined;
+
   /** Parsed handle — `null` until a slice download URL is available. */
   readonly gcodeHandle = signal<GcodeHandle | null>(null);
 
@@ -704,6 +711,25 @@ export class GcodePreview {
         return;
       }
       void this.#loadFromUrl(url);
+    });
+
+    // Drop the preview the moment the active workplate changes so a new plate
+    // — or a history entry / deep-link opened without re-slicing — never shows
+    // the previous plate's G-code. A reslice keeps the same uuid, so the layer
+    // position and coloring are still preserved by #loadFromUrl.
+    effect(() => {
+      const uuid = this.slicer.currentRequestUuid();
+      untracked(() => {
+        if (this.#lastWorkplateUuid === undefined) {
+          this.#lastWorkplateUuid = uuid;
+          return;
+        }
+        if (uuid === this.#lastWorkplateUuid) {
+          return;
+        }
+        this.#lastWorkplateUuid = uuid;
+        this.clear();
+      });
     });
   }
 

--- a/ui/src/app/services/slicer.ts
+++ b/ui/src/app/services/slicer.ts
@@ -1,6 +1,6 @@
 import { save } from '@tauri-apps/plugin-dialog';
 import { writeFile } from '@tauri-apps/plugin-fs';
-import { Injectable, computed, inject, signal } from '@angular/core';
+import { Injectable, computed, effect, inject, signal, untracked } from '@angular/core';
 import { environment } from '../../environments/environment';
 import { SlicingParams } from '../../generated/slicer-engine-ws-client-message-v1';
 import type { ProfileSelection } from '../../generated/slicer-engine-ws-client-message-v1';
@@ -207,6 +207,15 @@ export class Slicer {
   private objectUrl: string | null = null;
 
   /**
+   * The workplate uuid the transient slice state currently belongs to.
+   * `undefined` until the first observation so the initial value is adopted
+   * without flushing anything. A change to any *other* value means the active
+   * plate switched (new upload, opened history entry, deep-link) and the
+   * previous plate's slice results must be discarded.
+   */
+  private lastWorkplateUuid: string | null | undefined = undefined;
+
+  /**
    * Overall slice progress 0–100.
    *
    * - When `status === 'done'`, always returns 100.
@@ -262,6 +271,29 @@ export class Slicer {
         ...log,
         `[error] Runtime initialization failed: ${error instanceof Error ? error.message : String(error)}`,
       ]);
+    });
+
+    // Forget the previous plate's slice the instant the active workplate
+    // changes. `startWorkplate` / `resetWorkplate` also flush imperatively,
+    // but opening a history entry or deep-linking to `/slice/:uuid` swaps the
+    // workplate without going through them — this reactive guard keeps the
+    // download URL, progress rail, thumbnail source and view mode from leaking
+    // across plates in those paths too. A reslice keeps the same uuid, so it
+    // never fires mid-job.
+    effect(() => {
+      const uuid = this.currentRequestUuid();
+      untracked(() => {
+        if (this.lastWorkplateUuid === undefined) {
+          this.lastWorkplateUuid = uuid;
+          return;
+        }
+        if (uuid === this.lastWorkplateUuid) {
+          return;
+        }
+        this.lastWorkplateUuid = uuid;
+        this.clearSliceState();
+        this.viewerControl.viewMode.set('model');
+      });
     });
   }
 
@@ -415,6 +447,11 @@ export class Slicer {
   }
 
   async startWorkplate(file: File): Promise<WorkplateStart> {
+    // Clear every trace of the previous plate (file, slice results, scene
+    // objects, view mode) before adopting the new model so nothing bleeds
+    // across — the old download URL, thumbnail source or a leftover scene
+    // object would otherwise ride along into the new workplate.
+    await this.resetWorkplate();
     this.selectFile(file);
 
     if (this.runtimeMode !== 'cloud') {
@@ -495,6 +532,11 @@ export class Slicer {
     this.sliceAbort?.abort();
     this.sliceAbort = new AbortController();
 
+    // Hoisted so the catch block can tell a genuine failure from one caused by
+    // this job being superseded (a workplate switch cancels it, nulling
+    // `activeSliceId`). Assigned once the job is actually dispatched below.
+    let sliceId: string | null = null;
+
     try {
       const model = await this.readRuntimeMeshInput(file);
       const scene = await this.ensureRuntimeReadyForSlice(model);
@@ -529,7 +571,7 @@ export class Slicer {
 
       this.status.set('slicing');
       this.sliceStartedAt = performance.now();
-      const sliceId = this.createSliceId();
+      sliceId = this.createSliceId();
       this.activeSliceId = sliceId;
       this.outputLog.update((log) => [...log, `Starting slice job (${this.runtimeMode})…`]);
 
@@ -558,13 +600,27 @@ export class Slicer {
         profiles: profileSelection,
       });
 
+      // A workplate switch (opening another plate / history entry) cancels the
+      // active slice via `clearSliceState`, which nulls `activeSliceId`. If that
+      // happened while we were awaiting, this job has been superseded — bail out
+      // so its results are never published onto whatever plate is now open.
+      if (this.activeSliceId !== sliceId) {
+        return;
+      }
+
+      const preview = await this.orchestrator.getPreviewSource(result.sliceId);
+      if (this.activeSliceId !== sliceId) {
+        return;
+      }
+
+      // No awaits below this point — publish every result synchronously so a
+      // concurrent workplate switch cannot interleave a partial update.
       // Record which objects this slice was produced from so the viewer can
       // preserve its layer/progress/coloring when the same scene is resliced.
       this.slicedObjectIds.set(scene.objects.map((object) => object.id));
       // Snapshot the scene+settings signature so we can detect later drift.
       this.slicedSignature.set(this.sceneSignature());
 
-      const preview = await this.orchestrator.getPreviewSource(result.sliceId);
       if (preview.kind === 'download-url') {
         this.setDownloadUrl(preview.url);
       }
@@ -596,6 +652,12 @@ export class Slicer {
       ]);
       this.activeSliceId = null;
     } catch (error) {
+      // Swallow the failure of a slice that was superseded by a workplate
+      // switch — surfacing an error here would wrongly mark the new plate as
+      // failed.
+      if (this.activeSliceId !== sliceId) {
+        return;
+      }
       this.status.set('error');
       const errorMsg = error instanceof Error ? error.message : String(error);
       this.outputLog.update((log) => [...log, `[error] Slice failed: ${errorMsg}`]);
@@ -604,20 +666,47 @@ export class Slicer {
     }
   }
 
-  reset(): void {
+  /**
+   * Discard the transient results of the current plate — the in-flight job,
+   * slice output, progress timings, download URL and the sliced-scene
+   * signatures — without touching the selected file's identity. Safe to call
+   * repeatedly. The G-code preview clears itself reactively off the workplate
+   * uuid, so it is intentionally not touched here (which would also introduce
+   * a circular dependency).
+   */
+  private clearSliceState(): void {
     if (this.activeSliceId) {
       void this.orchestrator.cancel(this.activeSliceId);
       this.activeSliceId = null;
     }
-    this.pendingNativeMeshInput = null;
-    this.slicerFile.reset();
-    this.status.set('idle');
+    this.status.set(this.selectedFile() ? 'ready' : 'idle');
     this.outputLog.set([]);
     this.phaseTimings.set([]);
     this.currentPhase.set(null);
+    this.sliceStartedAt = null;
+    this.lastSliceElapsedMs.set(null);
     this.setDownloadUrl(null);
     this.slicedObjectIds.set([]);
     this.slicedSignature.set(null);
+  }
+
+  reset(): void {
+    this.pendingNativeMeshInput = null;
+    this.slicerFile.reset();
+    this.clearSliceState();
+    this.viewerControl.viewMode.set('model');
+  }
+
+  /**
+   * Full teardown for opening a brand-new or empty plate: drops the file and
+   * all slice results (via {@link reset}) and empties the scene engine so no
+   * geometry from the previous plate survives. Every "start a workplate" and
+   * "open an empty plate" entry point funnels through here so the reset is
+   * applied uniformly.
+   */
+  async resetWorkplate(): Promise<void> {
+    this.reset();
+    await this.sceneEngine.clear();
   }
 
   getHistory(): Promise<RuntimeHistorySession[]> {


### PR DESCRIPTION
## Problem

Lots of small "old stuff is still here" glitches when moving between workplates: load 3DBenchy → go Home → new plate and the previous plate's **G-code preview**, **thumbnail/screenshot**, **progress rail**, or an **actual leftover mesh** would still be present. The history entry, the embedded screenshot, and the on-screen slice could all disagree.

## Root cause

Every piece of *workplate-scoped* state lives in a root singleton:

| State | Service |
| --- | --- |
| Scene objects (meshes) | `SceneEngine` |
| Parsed G-code + layer state | `GcodePreview` |
| View mode (model / gcode) | `ViewerControl` |
| Download URL, sliced-scene ids/signature, status, progress | `Slicer` |

Only **`HomeDashboard.openEmptyWorkplate`** reset all of that. The other ways to enter a plate — **Load 3DBenchy**, **drag-drop a file**, the **slice-new** picker, **opening a history entry**, and **deep-linking** to `/slice/:uuid` — did not, so the previous plate's state bled into the new one:

- **View mode** stayed `gcode` and the **`GcodePreview`** handle was never dropped → the new plate rendered the *previous* plate's slice.
- The viewer's teardown only removed objects tracked by the *current component instance*. Navigation destroys the component but not the singleton engine, so a prior plate's mesh **lingered in the engine** — then got **sliced** into the new plate and **drawn into its thumbnail** (`buildThumbnailSubjects` and `visibleSceneSnapshot` both read `sceneEngine.objects()`).
- The slicer's `status` / progress / `downloadUrl` / `slicedSignature` carried over → a fresh plate showed a completed progress rail / "Re-Slice" / a stale "preview out of date" hint.

## Fixes

- **`Slicer`** — new `clearSliceState()` + `resetWorkplate()`; `startWorkplate` and `openEmptyWorkplate` both funnel through them. A reactive guard on the active workplate uuid discards the previous plate's slice results and resets the view mode on **any** plate change (covers the history/deep-link paths that never call a reset). A reslice keeps the same uuid, so it never fires mid-job. `slice()` now guards its result-publishing against a workplate switch superseding the job, so a cancelled slice can't dump results/errors onto the new plate.
- **`GcodePreview`** — reactively drops the parsed handle + layer state when the workplate uuid changes; a reslice (same uuid) still preserves the layer position and coloring.
- **`Viewer`** — on a new model source, evicts **every** object from the singleton scene engine (not just this component's mirror map), so a stale mesh can't survive into the new plate's slice or thumbnail.
- **`HomeDashboard`** — `openEmptyWorkplate` now delegates to `slicer.resetWorkplate()`; dropped the now-unused injects/imports.

## Verification

- Angular build (`pnpm run build` in `ui/`, strict template type-check) passes — only pre-existing SCSS budget warnings.
- Traced every entry point (Home Load-Benchy / drop / empty-plate, slice-new, history navigation, deep-link, reslice) to confirm each now starts from a clean slate while a same-plate reslice still preserves layer/coloring state.

## Notes

No behavior change for a same-plate reslice: the workplate uuid is stable across a reslice, so the reactive guards deliberately do **not** fire, and `GcodePreview` keeps the user's current layer/scrub position via its existing same-scene detection.
