### PR TITLE
fix(docs): use absolute logo URL so README embed doesn't break Pages deploy

### DIFF
--- a/README.md
+++ b/README.md
@@ -1,6 +1,6 @@
 <div align="center">
 
-<img src="ui/public/logo_hero.png" alt="Cold Crabby mascot - a crab hugging an ice cube" width="200" />
+<img src="https://raw.githubusercontent.com/ColdCrabby/slicer/main/ui/public/logo_hero.png" alt="Cold Crabby mascot - a crab hugging an ice cube" width="200" />
 
 # Cold Crabby
 


### PR DESCRIPTION
## Problem

The **Deploy Web Slicer + Docs to GitHub Pages** workflow has been failing on `main` since #187 ("docs: refresh README as Cold Crabby landing page"). Every push to `main` that touches the deploy paths fails, so the production Pages site is not being updated.

The failing step is **Build with VitePress**:

```
[vite]: Rollup failed to resolve import "ui/public/logo_hero.png"
        from ".../docs/guide/index.md".
```

## Root cause

`docs/.vitepress/config.ts` auto-generates `docs/guide/index.md` as a *thin wrapper* that `<!--@include:-->`s the root `README.md` ("the docs site stays a thin shell — never a copy"). That pulls the README's markup into the docs build, including its header image:

```html
<img src="ui/public/logo_hero.png" ... />
```

The path is **repo-root-relative** — correct when GitHub renders the README, but when the same content is included into `docs/guide/index.md`, Vite/Rollup treats `ui/public/logo_hero.png` as a bundled asset to resolve *relative to the docs page*. It doesn't exist there, so `vitepress build` aborts and the whole Pages deploy fails.

A repo-relative path fundamentally can't work in both places: the README is served from the repo root **and** from `/docs/guide/`.

## Fix

Point the logo at the canonical **absolute raw URL**:

```html
<img src="https://raw.githubusercontent.com/ColdCrabby/slicer/main/ui/public/logo_hero.png" ... />
```

- Renders identically on GitHub (absolute URL)
- Left untouched by Vite/Rollup (external `http(s)` URL, never bundled)
- Loads on the deployed docs page (verified `200 image/png`)

One-line change; no code or workflow changes needed.

## Verification

`pnpm --filter slicer-engine-docs docs:build` reproduced the failure before the change and **succeeds** after it. The built `guide/index.html` references the absolute URL, and no stray `ui/public/...` import remains in the output.
