### PR TITLE
viewer: make the viewport-cube snap sticky, and its projection switching honest

### DIFF
--- a/ui/src/app/components/viewer/README.md
+++ b/ui/src/app/components/viewer/README.md
@@ -205,39 +205,50 @@ raycaster, gizmo), the viewer applies a clear priority order:
 
 Clicking a viewport-cube face/edge/corner snaps the camera to that view **and
 flattens the projection to orthographic** — the CAD convention that a snapped
-view is dimension-true. The temporary ortho is held until the user makes a
-**deliberate free-view gesture** on the main viewport — a **pan**, a **zoom**, or
-a **rotate dragged past a sticky intent threshold** — at which point the
-projection reverts to whatever the toolbar preset was (normally perspective).
-Because the revert targets the toolbar `currentView`, leaving the snap lands back
-in perspective only when the user _entered_ it from perspective; a toolbar ortho
-preset stays ortho.
+view is dimension-true. The snap is then **pinned**: it survives until a gesture
+breaks it free — a **pan**, a **zoom**, or a **rotate dragged past the breakout
+distance** — at which point the projection reverts to whatever the toolbar preset
+was (normally perspective). Because the revert targets the toolbar `currentView`,
+leaving the snap lands back in perspective only when the user _entered_ it from
+perspective; a toolbar ortho preset stays ortho.
 
-The rotate trigger is **sticky, Shapr3D-style**: the snapped view holds on
-through casual orbiting, so the mode only ever changes when the user clearly
-means to leave it — never on an accidental jitter or a small screen touch. Only
-after the accumulated orbit travel crosses `ROTATE_REVERT_THRESHOLD_RAD` (~34°,
-≈70 px of left-drag on a ~730 px-tall viewport) within one continuous drag does
-the view release into perspective. Interacting with the cube again always keeps
-ortho.
+The rotate behaviour is a true **detent, Shapr3D-style**. While the snap is held
+the camera does **not move at all**: a rotate gesture shorter than
+`SNAP_BREAKOUT_TRAVEL_PX` (70 px, measured straight-line from where the drag
+started) is absorbed completely, so the dimension-true view survives jitter, a
+small screen touch or a stray nudge — and wiggling back and forth never breaks
+out, because travel is measured from the origin rather than summed along the
+path. Cross that distance and the snap "pops": the camera starts orbiting from
+the snapped orientation and the projection animates back. Interacting with the
+cube again always keeps ortho.
 
-| Action                                                   | Auto-ortho          |
-| -------------------------------------------------------- | ------------------- |
-| Cube face/edge/corner snap                               | engage (→ ortho)    |
-| Small rotate (below threshold)                           | keep                |
-| **Rotate past threshold** (1-finger / left-drag / swipe) | **revert** (sticky) |
-| Cube drag-orbit / roll / re-snap                         | keep                |
-| **Pan** (2-finger / right-drag / ⌥-swipe)                | **revert**          |
-| **Zoom** (pinch / wheel / autoscroll)                    | **revert**          |
-| Toolbar view toggle / home reset                         | cancel (manual)     |
+| Action                                                  | Auto-ortho         |
+| ------------------------------------------------------- | ------------------ |
+| Cube face/edge/corner snap                              | engage (→ ortho)   |
+| Rotate **inside** the breakout distance                 | keep — view frozen |
+| **Rotate past breakout** (1-finger / left-drag / swipe) | **revert** (pops)  |
+| Cube drag-orbit / roll / re-snap                        | keep               |
+| **Pan** (2-finger / right-drag / ⌥-swipe)               | **revert**         |
+| **Zoom** (pinch / wheel / autoscroll)                   | **revert**         |
+| Toolbar view toggle / home reset                        | cancel (manual)    |
 
-This lives across two files. The projection override (`autoOrtho`) is entirely in
-[`SceneCamera`](scene/camera.ts) — it deliberately does **not** touch the toolbar
-`view` signal, so there is no signal-ordering race between the snap animation and
-a view toggle. Engaging animates to the snapped direction at ~1° FOV with an
-apparent-size-preserving distance.
+This lives across two files. Both the projection override (`autoOrtho`) and the
+detent (`snapHoldPose`) are in [`SceneCamera`](scene/camera.ts) — it deliberately
+does **not** touch the toolbar `view` signal, so there is no signal-ordering race
+between the snap animation and a view toggle. Engaging animates to the snapped
+direction at ~1° FOV with an apparent-size-preserving distance, then pins that
+pose on landing.
 
-Reverting **animates** over the same `VIEW_TRANSITION_MS` + easing as the
+**Holding** is enforced by `applySnapHold()`, which the render loop calls _after_
+`OrbitControls.update()` and the inertia step: it restores the pinned pose, so
+whatever rotation those applied is discarded before anything is drawn. Discarding
+it each frame (rather than accumulating) is what makes the hand-off seamless —
+`OrbitControls` re-derives its orbit frame from the camera's current position
+every update, so the instant the pin is released the view simply starts following
+the pointer from the snapped orientation, with no jump and no replay of the
+absorbed movement.
+
+**Reverting** animates over the same `VIEW_TRANSITION_MS` + easing as the
 toolbar's perspective/ortho toggle, so the morph reads identically whichever
 control triggered it. It runs as a projection-only `ProjectionTween`
 (`notifyUserViewGesture` → `advanceProjectionTween`) rather than a full pose
@@ -249,11 +260,12 @@ frame, including frames where `OrbitControls` is driving the camera, so the user
 can keep dragging/zooming straight through the transition.
 
 The revert trigger is emitted only from the genuine pan/zoom input sites and from
-the sticky rotate accumulator in [`SceneControls`](scene/controls.ts)
-(`setRevertGestureSink`) — a below-threshold rotate and cube-driven moves never
-emit it. The stickiness budget is per gesture: it is reset at the start of each
-pointer drag (OrbitControls `start`) and after an idle gap on the trackpad-swipe
-path.
+the pointer-travel breakout detector in [`SceneControls`](scene/controls.ts)
+(`setRevertGestureSink`) — a rotate inside the detent and cube-driven moves never
+emit it. Travel is measured in **pixels**, not camera angle, precisely because a
+held snap does not rotate the camera at all. The budget is per gesture: reset on
+each pointer down/up and, on the trackpad-swipe path (which has no pointer
+brackets), after an idle gap.
 
 ### Pen-priority palm rejection ("wrist detection")
 

--- a/ui/src/app/components/viewer/README.md
+++ b/ui/src/app/components/viewer/README.md
@@ -233,11 +233,27 @@ cube again always keeps ortho.
 | Toolbar view toggle / home reset                        | cancel (manual)    |
 
 This lives across two files. Both the projection override (`autoOrtho`) and the
-detent (`snapHoldPose`) are in [`SceneCamera`](scene/camera.ts) — it deliberately
-does **not** touch the toolbar `view` signal, so there is no signal-ordering race
-between the snap animation and a view toggle. Engaging animates to the snapped
-direction at ~1° FOV with an apparent-size-preserving distance, then pins that
-pose on landing.
+detent (`snapHoldPose`) are in [`SceneCamera`](scene/camera.ts). Engaging
+animates to the snapped direction at ~1° FOV with an apparent-size-preserving
+distance, then pins that pose on landing.
+
+A snap also **tells the toolbar what it did**. Engaging sets `currentView =
+'ortho'` and reports it through `onViewChange` → `ViewerScene.setViewChangeSink`
+→ the UI's `view` signal; a breakout restores the remembered `preSnapView` the
+same way. Earlier the snap deliberately left that signal alone, which desynced
+the button from the screen: the toolbar claimed "perspective" while the view was
+flat, so the button's icon lied and its first press was swallowed re-asserting a
+projection that was already active — you had to press it twice to see anything.
+The viewer guards the echo (`cameraOriginatedView`, armed only when the write
+actually changes the signal) so a camera-originated value is not routed straight
+back into `setView`, which would cancel the in-flight snap and its detent.
+
+The perspective preset is seeded from the FOV the camera is built with
+(`setPerspectiveFov(camera.fov)` at construction). The settings effect that
+applies the user's field-of-view runs before the scene exists, so without this
+the preset kept its built-in default and _restoring_ perspective — the toggle, a
+breakout, or the home reset — snapped the view to that default instead of the FOV
+the user had configured.
 
 **Holding** is enforced by `applySnapHold()`, which the render loop calls _after_
 `OrbitControls.update()` and the inertia step: it restores the pinned pose, so

--- a/ui/src/app/components/viewer/README.md
+++ b/ui/src/app/components/viewer/README.md
@@ -213,11 +213,13 @@ Because the revert targets the toolbar `currentView`, leaving the snap lands bac
 in perspective only when the user _entered_ it from perspective; a toolbar ortho
 preset stays ortho.
 
-The rotate trigger is **sticky, Shapr3D-style**: a small nudge keeps the snap, so
-the mode only ever changes on a clear user intent, never on an accidental jitter
-or a small screen touch. Only after the accumulated orbit travel crosses
-`ROTATE_REVERT_THRESHOLD_RAD` (~8.6°) within one continuous drag does the view
-release into perspective. Interacting with the cube again always keeps ortho.
+The rotate trigger is **sticky, Shapr3D-style**: the snapped view holds on
+through casual orbiting, so the mode only ever changes when the user clearly
+means to leave it — never on an accidental jitter or a small screen touch. Only
+after the accumulated orbit travel crosses `ROTATE_REVERT_THRESHOLD_RAD` (~34°,
+≈70 px of left-drag on a ~730 px-tall viewport) within one continuous drag does
+the view release into perspective. Interacting with the cube again always keeps
+ortho.
 
 | Action                                                   | Auto-ortho          |
 | -------------------------------------------------------- | ------------------- |
@@ -233,14 +235,25 @@ This lives across two files. The projection override (`autoOrtho`) is entirely i
 [`SceneCamera`](scene/camera.ts) — it deliberately does **not** touch the toolbar
 `view` signal, so there is no signal-ordering race between the snap animation and
 a view toggle. Engaging animates to the snapped direction at ~1° FOV with an
-apparent-size-preserving distance; reverting is an **instant** apparent-size-
-preserving FOV swap (`notifyUserViewGesture`) so it never fights the live gesture
-that triggered it. The revert trigger is emitted only from the genuine pan/zoom
-input sites and from the sticky rotate accumulator in
-[`SceneControls`](scene/controls.ts) (`setRevertGestureSink`) — a below-threshold
-rotate and cube-driven moves never emit it. The stickiness threshold keeps the
-budget per gesture: it is reset at the start of each pointer drag (OrbitControls
-`start`) and after an idle gap on the trackpad-swipe path.
+apparent-size-preserving distance.
+
+Reverting **animates** over the same `VIEW_TRANSITION_MS` + easing as the
+toolbar's perspective/ortho toggle, so the morph reads identically whichever
+control triggered it. It runs as a projection-only `ProjectionTween`
+(`notifyUserViewGesture` → `advanceProjectionTween`) rather than a full pose
+animation: only the FOV is driven, and the orbit distance is rescaled
+_incrementally_ each frame (`tan(prevFov/2) / tan(nextFov/2)`) to hold apparent
+size. Because nothing pins the direction, target or distance, the tween never
+fights the gesture that triggered it — the render loop advances it on **every**
+frame, including frames where `OrbitControls` is driving the camera, so the user
+can keep dragging/zooming straight through the transition.
+
+The revert trigger is emitted only from the genuine pan/zoom input sites and from
+the sticky rotate accumulator in [`SceneControls`](scene/controls.ts)
+(`setRevertGestureSink`) — a below-threshold rotate and cube-driven moves never
+emit it. The stickiness budget is per gesture: it is reset at the start of each
+pointer drag (OrbitControls `start`) and after an idle gap on the trackpad-swipe
+path.
 
 ### Pen-priority palm rejection ("wrist detection")
 

--- a/ui/src/app/components/viewer/README.md
+++ b/ui/src/app/components/viewer/README.md
@@ -205,29 +205,42 @@ raycaster, gizmo), the viewer applies a clear priority order:
 
 Clicking a viewport-cube face/edge/corner snaps the camera to that view **and
 flattens the projection to orthographic** — the CAD convention that a snapped
-view is dimension-true. The temporary ortho is held until the user **pans or
-zooms** the main viewport, at which point the projection reverts to whatever the
-toolbar preset was (normally perspective). **Rotating** the view or interacting
-with the cube again keeps ortho.
+view is dimension-true. The temporary ortho is held until the user makes a
+**deliberate free-view gesture** on the main viewport — a **pan**, a **zoom**, or
+a **rotate dragged past a sticky intent threshold** — at which point the
+projection reverts to whatever the toolbar preset was (normally perspective).
+Because the revert targets the toolbar `currentView`, leaving the snap lands back
+in perspective only when the user _entered_ it from perspective; a toolbar ortho
+preset stays ortho.
 
-| Action                                    | Auto-ortho       |
-| ----------------------------------------- | ---------------- |
-| Cube face/edge/corner snap                | engage (→ ortho) |
-| Rotate (1-finger / left-drag / swipe)     | keep             |
-| Cube drag-orbit / roll / re-snap          | keep             |
-| **Pan** (2-finger / right-drag / ⌥-swipe) | **revert**       |
-| **Zoom** (pinch / wheel / autoscroll)     | **revert**       |
-| Toolbar view toggle / home reset          | cancel (manual)  |
+The rotate trigger is **sticky, Shapr3D-style**: a small nudge keeps the snap, so
+the mode only ever changes on a clear user intent, never on an accidental jitter
+or a small screen touch. Only after the accumulated orbit travel crosses
+`ROTATE_REVERT_THRESHOLD_RAD` (~8.6°) within one continuous drag does the view
+release into perspective. Interacting with the cube again always keeps ortho.
 
-This lives entirely in [`SceneCamera`](scene/camera.ts) as a projection override
-(`autoOrtho`) — it deliberately does **not** touch the toolbar `view` signal, so
-there is no signal-ordering race between the snap animation and a view toggle.
-Engaging animates to the snapped direction at ~1° FOV with an apparent-size-
-preserving distance; reverting is an **instant** apparent-size-preserving FOV
-swap (`notifyUserPanOrZoom`) so it never fights the live pan/zoom gesture that
-triggered it. The pan/zoom trigger is emitted only from the genuine pan/zoom
-input sites in [`SceneControls`](scene/controls.ts) (`setRevertGestureSink`) —
-rotate and cube-driven moves never emit it.
+| Action                                                   | Auto-ortho          |
+| -------------------------------------------------------- | ------------------- |
+| Cube face/edge/corner snap                               | engage (→ ortho)    |
+| Small rotate (below threshold)                           | keep                |
+| **Rotate past threshold** (1-finger / left-drag / swipe) | **revert** (sticky) |
+| Cube drag-orbit / roll / re-snap                         | keep                |
+| **Pan** (2-finger / right-drag / ⌥-swipe)                | **revert**          |
+| **Zoom** (pinch / wheel / autoscroll)                    | **revert**          |
+| Toolbar view toggle / home reset                         | cancel (manual)     |
+
+This lives across two files. The projection override (`autoOrtho`) is entirely in
+[`SceneCamera`](scene/camera.ts) — it deliberately does **not** touch the toolbar
+`view` signal, so there is no signal-ordering race between the snap animation and
+a view toggle. Engaging animates to the snapped direction at ~1° FOV with an
+apparent-size-preserving distance; reverting is an **instant** apparent-size-
+preserving FOV swap (`notifyUserViewGesture`) so it never fights the live gesture
+that triggered it. The revert trigger is emitted only from the genuine pan/zoom
+input sites and from the sticky rotate accumulator in
+[`SceneControls`](scene/controls.ts) (`setRevertGestureSink`) — a below-threshold
+rotate and cube-driven moves never emit it. The stickiness threshold keeps the
+budget per gesture: it is reset at the start of each pointer drag (OrbitControls
+`start`) and after an idle gap on the trackpad-swipe path.
 
 ### Pen-priority palm rejection ("wrist detection")
 

--- a/ui/src/app/components/viewer/scene/camera.ts
+++ b/ui/src/app/components/viewer/scene/camera.ts
@@ -37,12 +37,26 @@ interface CameraAnimation {
 }
 
 /**
+ * A *projection-only* transition (see {@link SceneCamera.advanceProjectionTween}).
+ * Unlike {@link CameraAnimation} it drives nothing but the FOV — no direction,
+ * target or `up` lock — so the user's live gesture keeps full control of the
+ * camera while the perspective↔ortho morph plays out underneath it.
+ */
+interface ProjectionTween {
+  startTime: number;
+  duration: number;
+  fromFov: number;
+  toFov: number;
+}
+
+/**
  * Handles camera positioning, view-preset animations, fit-to-content,
  * and near/far plane management for the viewer scene.
  */
 export class SceneCamera {
   private currentView: ViewerView = 'perspective';
   private animation: CameraAnimation | null = null;
+  private projectionTween: ProjectionTween | null = null;
   private printArea: PrintAreaConfig;
   /** User-configurable perspective FOV (degrees); the ortho preset ignores it. */
   private perspectiveFov = PERSPECTIVE_FOV;
@@ -94,10 +108,15 @@ export class SceneCamera {
    */
   setPerspectiveFov(fov: number): void {
     this.perspectiveFov = fov;
-    // While auto-ortho holds the projection at ~1°, only remember the new FOV;
-    // it is applied when the projection reverts. Applying it live here would
-    // fight the forced ortho.
-    if (this.currentView !== 'perspective' || this.animation || this.autoOrtho) {
+    // While auto-ortho holds the projection at ~1° — or a revert tween is
+    // morphing back out of it — only remember the new FOV; it is applied once
+    // the projection settles. Applying it live here would fight that transition.
+    if (
+      this.currentView !== 'perspective' ||
+      this.animation ||
+      this.projectionTween ||
+      this.autoOrtho
+    ) {
       return;
     }
     const target = this.controls.target;
@@ -219,38 +238,72 @@ export class SceneCamera {
    * snap had forced the projection to orthographic, this reverts it to the
    * user's `currentView`: so leaving the snapped view lands back in perspective
    * only when the user *entered* the cube snap from perspective — a toolbar
-   * ortho preset stays ortho. The swap is instantaneous and apparent-size-
-   * preserving (no distance/target lock), so it never fights the in-flight
-   * gesture that triggered it; only the perspective distortion (re)appears. A
-   * no-op when auto-ortho is not engaged.
+   * ortho preset stays ortho.
+   *
+   * The projection **animates** back over {@link VIEW_TRANSITION_MS} with the
+   * same easing as the toolbar's perspective/ortho toggle, so the morph reads
+   * identically no matter which control triggered it. It runs as a
+   * projection-only {@link ProjectionTween} rather than a full pose animation:
+   * direction, target and distance stay under the user's control, so the tween
+   * never fights the in-flight gesture that triggered it. A no-op when
+   * auto-ortho is not engaged.
    */
   notifyUserViewGesture(): void {
     if (!this.autoOrtho) {
       return;
     }
     this.autoOrtho = false;
-    // Cancel any in-flight snap animation so it can't fight the swap, and hand
+    // Cancel any in-flight snap animation so it can't fight the revert, and hand
     // control straight back to the user's live gesture.
     this.animation = null;
     this.controls.enabled = true;
     const targetFov = this.currentView === 'ortho' ? ORTHO_FOV : this.perspectiveFov;
     if (Math.abs(this.camera.fov - targetFov) < 1e-3) {
+      this.projectionTween = null;
       return;
     }
+    this.projectionTween = {
+      startTime: performance.now(),
+      duration: VIEW_TRANSITION_MS,
+      fromFov: this.camera.fov,
+      toFov: targetFov,
+    };
+  }
+
+  /**
+   * Advance an in-flight projection-only transition one frame. Called from the
+   * render loop on *every* frame — including frames where `OrbitControls` is
+   * driving the camera — so the perspective↔ortho morph can play out while the
+   * user keeps panning, zooming or rotating.
+   *
+   * Apparent size is preserved *incrementally*: each frame the orbit distance is
+   * rescaled by `tan(prevFov/2) / tan(nextFov/2)` relative to wherever the user
+   * has meanwhile moved the camera. That keeps content the same on-screen size
+   * through the morph without ever pinning the distance to a precomputed value,
+   * which is what lets a live zoom keep working mid-transition.
+   */
+  advanceProjectionTween(): void {
+    const tween = this.projectionTween;
+    if (!tween) {
+      return;
+    }
+    const t = Math.min(1, (performance.now() - tween.startTime) / tween.duration);
+    const fov = lerp(tween.fromFov, tween.toFov, easeInOutCubic(t));
+    const prevTan = Math.tan(((this.camera.fov / 2) * Math.PI) / 180);
+    const nextTan = Math.tan(((fov / 2) * Math.PI) / 180);
     const target = this.controls.target;
     const offset = this.camera.position.clone().sub(target);
-    const distance = Math.max(offset.length(), 1);
-    const dir = offset.divideScalar(distance);
-    // Preserve apparent size: distance × tan(fov/2) is held constant so content
-    // does not jump size when the projection changes.
-    const apparent = distance * Math.tan(((this.camera.fov / 2) * Math.PI) / 180);
-    const newDistance = apparent / Math.tan(((targetFov / 2) * Math.PI) / 180);
-    this.camera.fov = targetFov;
-    this.camera.position.copy(target).addScaledVector(dir, newDistance);
-    this.updateNearFar(newDistance, Math.max(newDistance * 0.5, 1));
-    this.camera.lookAt(target);
+    const distance = offset.length();
+    if (distance > 1e-6 && nextTan > 1e-9) {
+      const scaled = distance * (prevTan / nextTan);
+      this.camera.position.copy(target).addScaledVector(offset.divideScalar(distance), scaled);
+      this.updateNearFar(scaled, Math.max(scaled * 0.5, 1));
+    }
+    this.camera.fov = fov;
     this.camera.updateProjectionMatrix();
-    this.controls.update();
+    if (t >= 1) {
+      this.projectionTween = null;
+    }
   }
 
   orbitBy(azimuth: number, polar: number): void {
@@ -446,6 +499,9 @@ export class SceneCamera {
       fromDistance > 1e-6 ? offset.clone().divideScalar(fromDistance) : DEFAULT_VIEW_DIR.clone();
     const fromUp = this.camera.up.clone().normalize();
     this.controls.enabled = false;
+    // A full pose animation drives the FOV itself — drop any projection-only
+    // tween so the two can't fight over it.
+    this.projectionTween = null;
     this.animation = {
       startTime: performance.now(),
       duration: VIEW_TRANSITION_MS,

--- a/ui/src/app/components/viewer/scene/camera.ts
+++ b/ui/src/app/components/viewer/scene/camera.ts
@@ -64,13 +64,24 @@ export class SceneCamera {
    * True while the projection has been *temporarily* forced to orthographic by
    * a viewport-cube snap (see {@link animateToDirection}). Distinct from the
    * user's `currentView`: the cube engages this without touching the toolbar
-   * preset, and a deliberate free-view gesture in the main viewport — a pan, a
-   * zoom, or a rotate dragged past the sticky intent threshold — reverts it
-   * ({@link notifyUserViewGesture}) back to `currentView`. A small rotate below
-   * that threshold, or further cube interaction, keeps it engaged, so the mode
-   * only ever changes on a clear user intent (Shapr3D-style stickiness).
+   * preset. It is released together with the {@link snapHoldPose} detent once a
+   * gesture breaks the snap free — a pan, a zoom, or a rotate dragged past
+   * `SNAP_BREAKOUT_TRAVEL_PX` ({@link notifyUserViewGesture}) — reverting to
+   * `currentView`. Everything below that distance, and any further cube
+   * interaction, keeps it engaged.
    */
   private autoOrtho = false;
+
+  /**
+   * Pose the camera is *pinned* to while a viewport-cube snap is held — the
+   * detent. While set, {@link applySnapHold} restores this pose after every
+   * frame's `OrbitControls.update()`, so a rotate gesture inside the breakout
+   * distance moves the view **not at all** instead of drifting off the snapped
+   * orientation. Cleared when the snap breaks free
+   * ({@link notifyUserViewGesture}), when the cube itself orbits/rolls the view
+   * ({@link orbitBy}), or when a toolbar preset takes over.
+   */
+  private snapHoldPose: { position: Vector3; up: Vector3; target: Vector3 } | null = null;
 
   constructor(
     private readonly camera: PerspectiveCamera,
@@ -138,6 +149,8 @@ export class SceneCamera {
     if (!sphere) {
       return;
     }
+    // Re-framing moves the camera, so the snap detent no longer applies.
+    this.snapHoldPose = null;
     const fovRad = (this.camera.fov * Math.PI) / 180;
     const distance = (sphere.radius * padding) / Math.sin(fovRad / 2);
     this.camera.position.copy(sphere.center).addScaledVector(DEFAULT_VIEW_DIR, distance);
@@ -150,6 +163,7 @@ export class SceneCamera {
   setView(view: ViewerView): void {
     // A manual toolbar view change takes over from any temporary cube ortho.
     this.autoOrtho = false;
+    this.snapHoldPose = null;
     if (view === this.currentView && !this.animation) {
       return;
     }
@@ -159,6 +173,7 @@ export class SceneCamera {
 
   resetView(): void {
     this.autoOrtho = false;
+    this.snapHoldPose = null;
     this.currentView = 'perspective';
     const pose = this.initialPoseForBed();
     this.animateToPose({
@@ -232,13 +247,13 @@ export class SceneCamera {
   }
 
   /**
-   * Called when the user performs a deliberate free-view gesture on the *main
-   * viewport* — a pan, a zoom, or a rotate dragged past the sticky intent
-   * threshold (a small rotate and cube gestures do not call this). If a cube
-   * snap had forced the projection to orthographic, this reverts it to the
-   * user's `currentView`: so leaving the snapped view lands back in perspective
-   * only when the user *entered* the cube snap from perspective — a toolbar
-   * ortho preset stays ortho.
+   * Called when a gesture breaks a held viewport-cube snap free — a pan, a zoom,
+   * or a rotate dragged past `SNAP_BREAKOUT_TRAVEL_PX` (a rotate inside that
+   * distance never gets here, and neither do cube gestures). Releases both the
+   * {@link snapHoldPose} detent, so the camera starts following the gesture, and
+   * the forced orthographic projection, reverting to the user's `currentView` —
+   * so leaving the snap lands back in perspective only when the user *entered*
+   * it from perspective; a toolbar ortho preset stays ortho.
    *
    * The projection **animates** back over {@link VIEW_TRANSITION_MS} with the
    * same easing as the toolbar's perspective/ortho toggle, so the morph reads
@@ -253,6 +268,7 @@ export class SceneCamera {
       return;
     }
     this.autoOrtho = false;
+    this.snapHoldPose = null;
     // Cancel any in-flight snap animation so it can't fight the revert, and hand
     // control straight back to the user's live gesture.
     this.animation = null;
@@ -267,6 +283,40 @@ export class SceneCamera {
       duration: VIEW_TRANSITION_MS,
       fromFov: this.camera.fov,
       toFov: targetFov,
+    };
+  }
+
+  /**
+   * Re-pin the camera to the held snap pose. Called from the render loop *after*
+   * `OrbitControls.update()` and the inertia step, so whatever rotation those
+   * applied this frame is undone before anything is drawn — the snapped view
+   * therefore appears completely motionless until the gesture travels past
+   * `SNAP_BREAKOUT_TRAVEL_PX` and {@link notifyUserViewGesture} releases the pin.
+   *
+   * Discarding the rotation each frame (rather than accumulating it) is what
+   * makes the hand-off seamless: `OrbitControls` derives its orbit frame from
+   * the camera's *current* position on every update, so the instant the pin is
+   * released the view simply starts following the pointer from the snapped
+   * orientation — no jump, no replay of the absorbed movement.
+   */
+  applySnapHold(): void {
+    const pose = this.snapHoldPose;
+    // A snap/roll animation owns the camera while it runs; it re-pins on finish.
+    if (!pose || this.animation) {
+      return;
+    }
+    this.camera.position.copy(pose.position);
+    this.camera.up.copy(pose.up);
+    this.controls.target.copy(pose.target);
+    this.camera.lookAt(pose.target);
+  }
+
+  /** Pin the current pose as the snap detent. */
+  private captureSnapHold(): void {
+    this.snapHoldPose = {
+      position: this.camera.position.clone(),
+      up: this.camera.up.clone(),
+      target: this.controls.target.clone(),
     };
   }
 
@@ -308,6 +358,10 @@ export class SceneCamera {
 
   orbitBy(azimuth: number, polar: number): void {
     this.animation = null;
+    // Dragging the cube itself is an explicit orbit request, so it releases the
+    // detent (the view must follow the drag) while deliberately keeping the
+    // ortho projection engaged.
+    this.snapHoldPose = null;
     this.controls.enabled = true;
     const target = this.controls.target;
     const offset = this.camera.position.clone().sub(target);
@@ -566,6 +620,12 @@ export class SceneCamera {
       this.controls.enabled = true;
       this.controls.update();
       this.animation = null;
+      // The cube snap has landed — pin this pose as the detent so the snapped
+      // view stays perfectly still until a gesture travels far enough to break
+      // it free. Also re-pins after a roll, which keeps the snap sticky.
+      if (this.autoOrtho) {
+        this.captureSnapHold();
+      }
     }
   }
 }

--- a/ui/src/app/components/viewer/scene/camera.ts
+++ b/ui/src/app/components/viewer/scene/camera.ts
@@ -50,9 +50,11 @@ export class SceneCamera {
    * True while the projection has been *temporarily* forced to orthographic by
    * a viewport-cube snap (see {@link animateToDirection}). Distinct from the
    * user's `currentView`: the cube engages this without touching the toolbar
-   * preset, and a free pan/zoom in the main viewport reverts it
-   * ({@link notifyUserPanOrZoom}) back to `currentView`. Rotating or further
-   * cube interaction keep it engaged.
+   * preset, and a deliberate free-view gesture in the main viewport — a pan, a
+   * zoom, or a rotate dragged past the sticky intent threshold — reverts it
+   * ({@link notifyUserViewGesture}) back to `currentView`. A small rotate below
+   * that threshold, or further cube interaction, keeps it engaged, so the mode
+   * only ever changes on a clear user intent (Shapr3D-style stickiness).
    */
   private autoOrtho = false;
 
@@ -155,9 +157,10 @@ export class SceneCamera {
    * When `forceOrtho` is set (every cube snap does), the projection is also
    * driven to orthographic and {@link autoOrtho} is engaged, matching the CAD
    * convention that clicking a cube face gives a flat, dimension-true view. The
-   * user's toolbar `currentView` is deliberately left untouched so a later free
-   * pan/zoom can revert to it ({@link notifyUserPanOrZoom}); rotating or further
-   * cube snaps keep ortho.
+   * user's toolbar `currentView` is deliberately left untouched so a later
+   * deliberate free-view gesture can revert to it ({@link notifyUserViewGesture});
+   * a small rotate below the sticky threshold, or a further cube snap, keeps
+   * ortho.
    */
   animateToDirection(direction: Vector3, up: Vector3, forceOrtho = false): void {
     const target = this.controls.target.clone();
@@ -210,14 +213,18 @@ export class SceneCamera {
   }
 
   /**
-   * Called when the user pans or zooms the *main viewport* (not a rotate, not a
-   * cube gesture). If a cube snap had forced the projection to orthographic,
-   * this reverts it to the user's `currentView`. The swap is instantaneous and
-   * apparent-size-preserving (no distance/target lock), so it never fights the
-   * in-flight pan/zoom gesture that triggered it; only the perspective
-   * distortion (re)appears. A no-op when auto-ortho is not engaged.
+   * Called when the user performs a deliberate free-view gesture on the *main
+   * viewport* — a pan, a zoom, or a rotate dragged past the sticky intent
+   * threshold (a small rotate and cube gestures do not call this). If a cube
+   * snap had forced the projection to orthographic, this reverts it to the
+   * user's `currentView`: so leaving the snapped view lands back in perspective
+   * only when the user *entered* the cube snap from perspective — a toolbar
+   * ortho preset stays ortho. The swap is instantaneous and apparent-size-
+   * preserving (no distance/target lock), so it never fights the in-flight
+   * gesture that triggered it; only the perspective distortion (re)appears. A
+   * no-op when auto-ortho is not engaged.
    */
-  notifyUserPanOrZoom(): void {
+  notifyUserViewGesture(): void {
     if (!this.autoOrtho) {
       return;
     }

--- a/ui/src/app/components/viewer/scene/camera.ts
+++ b/ui/src/app/components/viewer/scene/camera.ts
@@ -83,6 +83,25 @@ export class SceneCamera {
    */
   private snapHoldPose: { position: Vector3; up: Vector3; target: Vector3 } | null = null;
 
+  /**
+   * Toolbar preset to restore when a cube snap is released. A snap genuinely
+   * switches the projection to orthographic — and says so, via
+   * {@link onViewChange} — so `currentView` becomes `'ortho'` for its duration
+   * and this remembers what to go back to. Without it the toolbar would claim
+   * "perspective" while the screen showed a flat view, and the button's first
+   * press would be swallowed re-asserting a projection that was already active.
+   */
+  private preSnapView: ViewerView = 'perspective';
+
+  /**
+   * Notified whenever the *effective* projection changes for a reason the
+   * toolbar did not initiate — i.e. a cube snap engaging ortho, or a breakout
+   * restoring the previous preset. Lets the UI's `view` signal track what is
+   * actually on screen. The listener must not route the value back into
+   * {@link setView}, which would cancel the in-flight snap and its detent.
+   */
+  onViewChange: ((view: ViewerView) => void) | null = null;
+
   constructor(
     private readonly camera: PerspectiveCamera,
     private readonly controls: OrbitControls,
@@ -161,9 +180,11 @@ export class SceneCamera {
   }
 
   setView(view: ViewerView): void {
-    // A manual toolbar view change takes over from any temporary cube ortho.
+    // A manual toolbar view change takes over from any temporary cube ortho, and
+    // becomes the preset a later snap will hand back to.
     this.autoOrtho = false;
     this.snapHoldPose = null;
+    this.preSnapView = view;
     if (view === this.currentView && !this.animation) {
       return;
     }
@@ -175,6 +196,7 @@ export class SceneCamera {
     this.autoOrtho = false;
     this.snapHoldPose = null;
     this.currentView = 'perspective';
+    this.preSnapView = 'perspective';
     const pose = this.initialPoseForBed();
     this.animateToPose({
       position: pose.position,
@@ -228,7 +250,19 @@ export class SceneCamera {
     let toFov = this.camera.fov;
     let toDistance = distance;
     if (forceOrtho) {
+      // Remember the preset being interrupted only on the *first* snap — a
+      // re-snap while already engaged must not overwrite it with 'ortho'.
+      if (!this.autoOrtho) {
+        this.preSnapView = this.currentView;
+      }
       this.autoOrtho = true;
+      // The projection really is orthographic now, so say so: `currentView` and
+      // the toolbar both track it, which keeps the button's icon honest and its
+      // next press meaningful (one press → perspective).
+      if (this.currentView !== 'ortho') {
+        this.currentView = 'ortho';
+        this.onViewChange?.('ortho');
+      }
       toFov = ORTHO_FOV;
       // Grow the distance so the flattened (~1° FOV) view frames the same
       // apparent size — advanceAnimation interpolates in apparent-size space,
@@ -273,6 +307,12 @@ export class SceneCamera {
     // control straight back to the user's live gesture.
     this.animation = null;
     this.controls.enabled = true;
+    // Hand the preset back to whatever the toolbar had before the snap, and tell
+    // the UI so its button matches the projection the user is about to see.
+    if (this.currentView !== this.preSnapView) {
+      this.currentView = this.preSnapView;
+      this.onViewChange?.(this.currentView);
+    }
     const targetFov = this.currentView === 'ortho' ? ORTHO_FOV : this.perspectiveFov;
     if (Math.abs(this.camera.fov - targetFov) < 1e-3) {
       this.projectionTween = null;

--- a/ui/src/app/components/viewer/scene/controls.ts
+++ b/ui/src/app/components/viewer/scene/controls.ts
@@ -17,6 +17,21 @@ const TWO_FINGER_DOLLY_DEAD_ZONE_PX = 1.5;
 const TWO_FINGER_ROLL_DEAD_ZONE_RAD = 0.01;
 /** Right-drag travel (px) before it counts as a pan for the auto-ortho revert. */
 const RIGHT_PAN_REVERT_THRESHOLD_PX = 3;
+/**
+ * Accumulated orbit travel (radians, azimuth + polar) within a single
+ * continuous rotate gesture before it counts as a deliberate "leave the snapped
+ * view" intent and releases the viewport-cube's temporary orthographic
+ * projection. Sticky, Shapr3D-style: small nudges keep the snap, so the mode
+ * only ever changes on a clear user intent — never on an accidental jitter or a
+ * small screen touch. ~8.6°, comfortably above pointer/finger noise.
+ */
+const ROTATE_REVERT_THRESHOLD_RAD = 0.15;
+/**
+ * Idle gap (ms) that ends one trackpad two-finger-swipe rotate burst. That mac
+ * wheel-orbit path has no pointer up/down to bracket the gesture, so a pause
+ * longer than this starts a fresh stickiness budget.
+ */
+const ROTATE_REVERT_IDLE_MS = 150;
 
 /**
  * Safari/WebKit-proprietary gesture event (not in the standard DOM lib types).
@@ -91,6 +106,15 @@ export class SceneControls {
   private orbitVelAzimuth = 0;
   private orbitVelPolar = 0;
   private orbitVelTarget = new Vector3();
+  /**
+   * Sticky auto-ortho release state. Accumulates orbit travel across the
+   * current rotate gesture; once it crosses {@link ROTATE_REVERT_THRESHOLD_RAD}
+   * the revert fires exactly once (`…Emitted`). Reset per pointer drag (via the
+   * OrbitControls `start` event) and per trackpad-swipe burst (idle gap).
+   */
+  private rotateRevertAccumRad = 0;
+  private rotateRevertEmitted = false;
+  private rotateRevertLastWheelTime = 0;
   private autoscroll: AutoscrollState | null = null;
   private readonly raycaster = new Raycaster();
   private readonly ndcScratch = new Vector2();
@@ -113,11 +137,14 @@ export class SceneControls {
   private twoFingerGesture: 'orbit' | 'pan' = 'orbit';
 
   /**
-   * Fired whenever the user *pans or zooms* the main viewport (never on a
-   * rotate). Used by the viewport-cube auto-ortho behaviour to revert the
-   * temporary orthographic projection back to the user's chosen view. Rotate
-   * and cube-driven camera moves deliberately do not fire it. See
-   * {@link SceneCamera.notifyUserPanOrZoom}.
+   * Fired whenever the user performs a deliberate free-view gesture on the main
+   * viewport — a pan, a zoom, or a rotate dragged past the sticky
+   * {@link ROTATE_REVERT_THRESHOLD_RAD} intent threshold. Used by the
+   * viewport-cube auto-ortho behaviour to revert the temporary orthographic
+   * projection back to the user's chosen view. A small rotate (below the
+   * threshold) and cube-driven camera moves deliberately do not fire it, so the
+   * mode never flips on an accidental nudge. See
+   * {@link SceneCamera.notifyUserViewGesture}.
    */
   private revertGestureSink: (() => void) | null = null;
 
@@ -166,9 +193,9 @@ export class SceneControls {
   }
 
   /**
-   * Register a callback fired whenever the user pans or zooms the main viewport
-   * (never on a rotate or a cube gesture). Drives the viewport-cube auto-ortho
-   * revert. Pass `null` to clear.
+   * Register a callback fired whenever the user pans, zooms, or rotates the main
+   * viewport past the sticky intent threshold (never on a small rotate or a cube
+   * gesture). Drives the viewport-cube auto-ortho revert. Pass `null` to clear.
    */
   setRevertGestureSink(sink: (() => void) | null): void {
     this.revertGestureSink = sink;
@@ -176,6 +203,30 @@ export class SceneControls {
 
   private emitRevertGesture(): void {
     this.revertGestureSink?.();
+  }
+
+  /** Begin a fresh stickiness budget for the next rotate gesture. */
+  private resetRotateRevertIntent(): void {
+    this.rotateRevertAccumRad = 0;
+    this.rotateRevertEmitted = false;
+  }
+
+  /**
+   * Feed one increment of orbit travel (radians) into the sticky auto-ortho
+   * release. Fires {@link emitRevertGesture} exactly once per gesture, and only
+   * after the accumulated travel crosses {@link ROTATE_REVERT_THRESHOLD_RAD} —
+   * so a deliberate drag leaves the snapped ortho view while a small nudge keeps
+   * it. A no-op when the delta is non-positive or the gesture already fired.
+   */
+  private accumulateRotateRevertIntent(deltaRad: number): void {
+    if (this.rotateRevertEmitted || !(deltaRad > 0)) {
+      return;
+    }
+    this.rotateRevertAccumRad += deltaRad;
+    if (this.rotateRevertAccumRad >= ROTATE_REVERT_THRESHOLD_RAD) {
+      this.rotateRevertEmitted = true;
+      this.emitRevertGesture();
+    }
   }
 
   applyOrbitInertia(dt: number): void {
@@ -621,6 +672,17 @@ export class SceneControls {
       .addScaledVector(e1, r * sinPhi * Math.cos(newTheta))
       .addScaledVector(e2, r * sinPhi * Math.sin(newTheta));
     this.camera.position.copy(target).add(offset);
+    // Sticky auto-ortho release for a trackpad two-finger-swipe rotate (mirrors
+    // the OrbitControls rotate path). This channel has no pointer up/down, so an
+    // idle gap between events starts a fresh stickiness budget. Emitted after
+    // the pose is set so the revert's apparent-size-preserving distance swap is
+    // not overwritten by this frame's orbit.
+    const nowMs = performance.now();
+    if (nowMs - this.rotateRevertLastWheelTime > ROTATE_REVERT_IDLE_MS) {
+      this.resetRotateRevertIntent();
+    }
+    this.rotateRevertLastWheelTime = nowMs;
+    this.accumulateRotateRevertIntent(Math.abs(dAz) + Math.abs(dPol));
     this.controls.update();
   }
 
@@ -631,6 +693,7 @@ export class SceneControls {
   private installOrbitInertia(): void {
     this.controls.addEventListener('start', () => {
       this.orbitInteracting = true;
+      this.resetRotateRevertIntent();
       this.orbitLastSampleTime = performance.now();
       this.orbitLastAzimuth = this.controls.getAzimuthalAngle();
       this.orbitLastPolar = this.controls.getPolarAngle();
@@ -643,6 +706,19 @@ export class SceneControls {
       if (!this.orbitInteracting) {
         return;
       }
+      // Sticky auto-ortho release: accumulate this drag's orbit travel and, once
+      // it crosses ROTATE_REVERT_THRESHOLD_RAD (a clear intent to leave the
+      // snapped view), revert the viewport-cube's temporary ortho. A right-drag
+      // pan leaves azimuth/polar unchanged so it never trips this (it reverts
+      // via its own detector); cube drag-orbit never sets `orbitInteracting`, so
+      // it is likewise excluded and keeps ortho. Sampled before the inertia
+      // bookkeeping below advances `orbitLast*`, so both read the same baseline.
+      let dAzIntent = this.controls.getAzimuthalAngle() - this.orbitLastAzimuth;
+      if (dAzIntent > Math.PI) dAzIntent -= 2 * Math.PI;
+      else if (dAzIntent < -Math.PI) dAzIntent += 2 * Math.PI;
+      const dPolIntent = this.controls.getPolarAngle() - this.orbitLastPolar;
+      this.accumulateRotateRevertIntent(Math.abs(dAzIntent) + Math.abs(dPolIntent));
+
       const now = performance.now();
       const dt = (now - this.orbitLastSampleTime) / 1000;
       this.orbitLastSampleTime = now;

--- a/ui/src/app/components/viewer/scene/controls.ts
+++ b/ui/src/app/components/viewer/scene/controls.ts
@@ -21,11 +21,14 @@ const RIGHT_PAN_REVERT_THRESHOLD_PX = 3;
  * Accumulated orbit travel (radians, azimuth + polar) within a single
  * continuous rotate gesture before it counts as a deliberate "leave the snapped
  * view" intent and releases the viewport-cube's temporary orthographic
- * projection. Sticky, Shapr3D-style: small nudges keep the snap, so the mode
- * only ever changes on a clear user intent — never on an accidental jitter or a
- * small screen touch. ~8.6°, comfortably above pointer/finger noise.
+ * projection. Sticky, Shapr3D-style: the snapped view holds on through casual
+ * orbiting, so the mode only ever changes when the user clearly means to leave
+ * it — never on an accidental jitter or a small screen touch. ~34°, which on a
+ * ~730 px-tall viewport is ≈70 px of left-drag (OrbitControls rotates
+ * `2π · Δpx / clientHeight`): easy to reach on purpose, essentially impossible
+ * to trip by accident.
  */
-const ROTATE_REVERT_THRESHOLD_RAD = 0.15;
+const ROTATE_REVERT_THRESHOLD_RAD = 0.6;
 /**
  * Idle gap (ms) that ends one trackpad two-finger-swipe rotate burst. That mac
  * wheel-orbit path has no pointer up/down to bracket the gesture, so a pause

--- a/ui/src/app/components/viewer/scene/controls.ts
+++ b/ui/src/app/components/viewer/scene/controls.ts
@@ -18,23 +18,25 @@ const TWO_FINGER_ROLL_DEAD_ZONE_RAD = 0.01;
 /** Right-drag travel (px) before it counts as a pan for the auto-ortho revert. */
 const RIGHT_PAN_REVERT_THRESHOLD_PX = 3;
 /**
- * Accumulated orbit travel (radians, azimuth + polar) within a single
- * continuous rotate gesture before it counts as a deliberate "leave the snapped
- * view" intent and releases the viewport-cube's temporary orthographic
- * projection. Sticky, Shapr3D-style: the snapped view holds on through casual
- * orbiting, so the mode only ever changes when the user clearly means to leave
- * it — never on an accidental jitter or a small screen touch. ~34°, which on a
- * ~730 px-tall viewport is ≈70 px of left-drag (OrbitControls rotates
- * `2π · Δpx / clientHeight`): easy to reach on purpose, essentially impossible
- * to trip by accident.
+ * Straight-line pointer travel (px) that breaks a viewport-cube snap free.
+ *
+ * Sticky, Shapr3D-style: while a snap is held the camera does **not move at
+ * all** — a rotate gesture below this distance is absorbed completely, so the
+ * dimension-true view survives accidental jitter, a small screen touch or a
+ * stray nudge. Cross it and the snap "pops": the camera starts orbiting from
+ * that point and the projection animates back (see
+ * {@link SceneCamera.applySnapHold}).
+ *
+ * Measured from where the drag *started*, so wiggling back and forth never
+ * breaks out — you have to genuinely pull away from the detent.
  */
-const ROTATE_REVERT_THRESHOLD_RAD = 0.6;
+const SNAP_BREAKOUT_TRAVEL_PX = 70;
 /**
  * Idle gap (ms) that ends one trackpad two-finger-swipe rotate burst. That mac
  * wheel-orbit path has no pointer up/down to bracket the gesture, so a pause
- * longer than this starts a fresh stickiness budget.
+ * longer than this starts a fresh breakout budget.
  */
-const ROTATE_REVERT_IDLE_MS = 150;
+const SNAP_BREAKOUT_IDLE_MS = 150;
 
 /**
  * Safari/WebKit-proprietary gesture event (not in the standard DOM lib types).
@@ -110,14 +112,17 @@ export class SceneControls {
   private orbitVelPolar = 0;
   private orbitVelTarget = new Vector3();
   /**
-   * Sticky auto-ortho release state. Accumulates orbit travel across the
-   * current rotate gesture; once it crosses {@link ROTATE_REVERT_THRESHOLD_RAD}
-   * the revert fires exactly once (`…Emitted`). Reset per pointer drag (via the
-   * OrbitControls `start` event) and per trackpad-swipe burst (idle gap).
+   * Snap-breakout state. Tracks how far the pointer has travelled from where the
+   * current rotate gesture started; crossing {@link SNAP_BREAKOUT_TRAVEL_PX}
+   * fires the release exactly once (`…Emitted`). Reset per pointer drag and per
+   * trackpad-swipe burst (idle gap). Pixel travel — not camera angle — is the
+   * metric precisely because a held snap does not rotate the camera at all.
    */
-  private rotateRevertAccumRad = 0;
-  private rotateRevertEmitted = false;
-  private rotateRevertLastWheelTime = 0;
+  private breakoutStart = new Vector2();
+  private breakoutPointerId: number | null = null;
+  private breakoutEmitted = false;
+  private breakoutWheelPx = 0;
+  private breakoutLastWheelTime = 0;
   private autoscroll: AutoscrollState | null = null;
   private readonly raycaster = new Raycaster();
   private readonly ndcScratch = new Vector2();
@@ -140,18 +145,17 @@ export class SceneControls {
   private twoFingerGesture: 'orbit' | 'pan' = 'orbit';
 
   /**
-   * Fired whenever the user performs a deliberate free-view gesture on the main
-   * viewport — a pan, a zoom, or a rotate dragged past the sticky
-   * {@link ROTATE_REVERT_THRESHOLD_RAD} intent threshold. Used by the
-   * viewport-cube auto-ortho behaviour to revert the temporary orthographic
-   * projection back to the user's chosen view. A small rotate (below the
-   * threshold) and cube-driven camera moves deliberately do not fire it, so the
-   * mode never flips on an accidental nudge. See
+   * Fired when a gesture breaks a held viewport-cube snap free — a pan, a zoom,
+   * or a rotate dragged past {@link SNAP_BREAKOUT_TRAVEL_PX}. Used by the
+   * auto-ortho behaviour to release the detent and revert the temporary
+   * orthographic projection to the user's chosen view. A rotate inside the
+   * breakout distance and cube-driven camera moves deliberately do not fire it,
+   * so the snapped view never slips on an accidental nudge. See
    * {@link SceneCamera.notifyUserViewGesture}.
    */
   private revertGestureSink: (() => void) | null = null;
 
-  /** Handlers for the right-drag (pan) revert detector, retained for cleanup. */
+  /** Handlers for the pointer-drag revert detectors, retained for cleanup. */
   private rightPanPointerDownHandler: ((event: PointerEvent) => void) | null = null;
   private rightPanPointerMoveHandler: ((event: PointerEvent) => void) | null = null;
   private rightPanPointerUpHandler: ((event: PointerEvent) => void) | null = null;
@@ -196,9 +200,11 @@ export class SceneControls {
   }
 
   /**
-   * Register a callback fired whenever the user pans, zooms, or rotates the main
-   * viewport past the sticky intent threshold (never on a small rotate or a cube
-   * gesture). Drives the viewport-cube auto-ortho revert. Pass `null` to clear.
+  /**
+   * Register a callback fired whenever the user pans, zooms, or drags the main
+   * viewport far enough to break a viewport-cube snap free (never on a small
+   * rotate inside the detent, nor on a cube gesture). Drives the auto-ortho
+   * revert. Pass `null` to clear.
    */
   setRevertGestureSink(sink: (() => void) | null): void {
     this.revertGestureSink = sink;
@@ -208,28 +214,25 @@ export class SceneControls {
     this.revertGestureSink?.();
   }
 
-  /** Begin a fresh stickiness budget for the next rotate gesture. */
-  private resetRotateRevertIntent(): void {
-    this.rotateRevertAccumRad = 0;
-    this.rotateRevertEmitted = false;
+  /** Begin a fresh breakout budget for the next rotate gesture. */
+  private resetBreakout(): void {
+    this.breakoutWheelPx = 0;
+    this.breakoutEmitted = false;
   }
 
   /**
-   * Feed one increment of orbit travel (radians) into the sticky auto-ortho
-   * release. Fires {@link emitRevertGesture} exactly once per gesture, and only
-   * after the accumulated travel crosses {@link ROTATE_REVERT_THRESHOLD_RAD} —
-   * so a deliberate drag leaves the snapped ortho view while a small nudge keeps
-   * it. A no-op when the delta is non-positive or the gesture already fired.
+   * Report how far the pointer has travelled in the current rotate gesture.
+   * Fires {@link emitRevertGesture} exactly once, the moment the travel crosses
+   * {@link SNAP_BREAKOUT_TRAVEL_PX} — releasing a held snap so the camera can
+   * start orbiting. Below that distance nothing is emitted and the snap stays
+   * pinned, which is what makes the detent feel sticky.
    */
-  private accumulateRotateRevertIntent(deltaRad: number): void {
-    if (this.rotateRevertEmitted || !(deltaRad > 0)) {
+  private reportBreakoutTravel(travelPx: number): void {
+    if (this.breakoutEmitted || travelPx <= SNAP_BREAKOUT_TRAVEL_PX) {
       return;
     }
-    this.rotateRevertAccumRad += deltaRad;
-    if (this.rotateRevertAccumRad >= ROTATE_REVERT_THRESHOLD_RAD) {
-      this.rotateRevertEmitted = true;
-      this.emitRevertGesture();
-    }
+    this.breakoutEmitted = true;
+    this.emitRevertGesture();
   }
 
   applyOrbitInertia(dt: number): void {
@@ -369,48 +372,74 @@ export class SceneControls {
   }
 
   // -------------------------------------------------------------------------
-  // Right-drag (pan) revert detection
+  // Pointer-drag revert detection (right-drag pan + rotate snap breakout)
   // -------------------------------------------------------------------------
 
   /**
-   * OrbitControls maps the right mouse button to PAN. Panning is handled
-   * internally by OrbitControls (not by our custom helpers), so to notify the
-   * auto-ortho revert we watch the right-button drag ourselves. We only observe
-   * — we never call `preventDefault`/`stopPropagation` — so OrbitControls still
-   * performs the pan. A small travel threshold avoids reverting on a bare
-   * right-click that never moves.
+   * Watches raw pointer drags to drive the auto-ortho revert. Two cases share
+   * these listeners:
+   *
+   * - **Right-drag = pan.** OrbitControls pans internally (not via our helpers),
+   *   so we observe the drag to notify the revert. A tiny travel threshold
+   *   avoids reverting on a bare right-click that never moves.
+   * - **Left-drag / touch / pen = rotate.** Distance from the drag origin is the
+   *   snap-breakout metric. It has to be measured in *pixels* here rather than
+   *   in camera angle, because while a snap is held the camera does not rotate
+   *   at all ({@link SceneCamera.applySnapHold}) — there is no angle to measure.
+   *
+   * We only observe — never `preventDefault`/`stopPropagation` — so
+   * OrbitControls still performs the gesture.
    */
   private installRightPanRevertDetection(): void {
     const el = this.renderer.domElement;
-    let pointerId: number | null = null;
-    let startX = 0;
-    let startY = 0;
-    let emitted = false;
+    let panPointerId: number | null = null;
+    let panStartX = 0;
+    let panStartY = 0;
+    let panEmitted = false;
 
     this.rightPanPointerDownHandler = (event: PointerEvent): void => {
-      if (event.button !== 2) {
+      if (event.button === 2) {
+        panPointerId = event.pointerId;
+        panStartX = event.clientX;
+        panStartY = event.clientY;
+        panEmitted = false;
         return;
       }
-      pointerId = event.pointerId;
-      startX = event.clientX;
-      startY = event.clientY;
-      emitted = false;
+      // Primary button (or a touch/pen contact) starts a rotate: open a fresh
+      // breakout budget measured from here. Skipped while `controls` is disabled
+      // — that means a gizmo/selection drag (or a snap animation) owns the
+      // pointer, and dragging an object must not pop the view out of its snap.
+      if (event.button === 0 && this.controls.enabled) {
+        this.breakoutPointerId = event.pointerId;
+        this.breakoutStart.set(event.clientX, event.clientY);
+        this.resetBreakout();
+      }
     };
     this.rightPanPointerMoveHandler = (event: PointerEvent): void => {
-      if (event.pointerId !== pointerId || emitted) {
+      if (event.pointerId === panPointerId && !panEmitted) {
+        if (
+          Math.hypot(event.clientX - panStartX, event.clientY - panStartY) >
+          RIGHT_PAN_REVERT_THRESHOLD_PX
+        ) {
+          panEmitted = true;
+          this.emitRevertGesture();
+        }
         return;
       }
-      if (
-        Math.hypot(event.clientX - startX, event.clientY - startY) > RIGHT_PAN_REVERT_THRESHOLD_PX
-      ) {
-        emitted = true;
-        this.emitRevertGesture();
+      if (event.pointerId === this.breakoutPointerId && this.controls.enabled) {
+        this.reportBreakoutTravel(
+          Math.hypot(event.clientX - this.breakoutStart.x, event.clientY - this.breakoutStart.y),
+        );
       }
     };
     this.rightPanPointerUpHandler = (event: PointerEvent): void => {
-      if (event.pointerId === pointerId) {
-        pointerId = null;
-        emitted = false;
+      if (event.pointerId === panPointerId) {
+        panPointerId = null;
+        panEmitted = false;
+      }
+      if (event.pointerId === this.breakoutPointerId) {
+        this.breakoutPointerId = null;
+        this.resetBreakout();
       }
     };
 
@@ -675,17 +704,17 @@ export class SceneControls {
       .addScaledVector(e1, r * sinPhi * Math.cos(newTheta))
       .addScaledVector(e2, r * sinPhi * Math.sin(newTheta));
     this.camera.position.copy(target).add(offset);
-    // Sticky auto-ortho release for a trackpad two-finger-swipe rotate (mirrors
-    // the OrbitControls rotate path). This channel has no pointer up/down, so an
-    // idle gap between events starts a fresh stickiness budget. Emitted after
-    // the pose is set so the revert's apparent-size-preserving distance swap is
-    // not overwritten by this frame's orbit.
+    // Snap breakout for a trackpad two-finger-swipe rotate (mirrors the pointer
+    // rotate path). This channel has no pointer up/down to bracket the gesture,
+    // so an idle gap starts a fresh budget and travel is summed from the wheel
+    // deltas instead of measured from a drag origin.
     const nowMs = performance.now();
-    if (nowMs - this.rotateRevertLastWheelTime > ROTATE_REVERT_IDLE_MS) {
-      this.resetRotateRevertIntent();
+    if (nowMs - this.breakoutLastWheelTime > SNAP_BREAKOUT_IDLE_MS) {
+      this.resetBreakout();
     }
-    this.rotateRevertLastWheelTime = nowMs;
-    this.accumulateRotateRevertIntent(Math.abs(dAz) + Math.abs(dPol));
+    this.breakoutLastWheelTime = nowMs;
+    this.breakoutWheelPx += Math.abs(dxPx) + Math.abs(dyPx);
+    this.reportBreakoutTravel(this.breakoutWheelPx);
     this.controls.update();
   }
 
@@ -696,7 +725,6 @@ export class SceneControls {
   private installOrbitInertia(): void {
     this.controls.addEventListener('start', () => {
       this.orbitInteracting = true;
-      this.resetRotateRevertIntent();
       this.orbitLastSampleTime = performance.now();
       this.orbitLastAzimuth = this.controls.getAzimuthalAngle();
       this.orbitLastPolar = this.controls.getPolarAngle();
@@ -709,19 +737,6 @@ export class SceneControls {
       if (!this.orbitInteracting) {
         return;
       }
-      // Sticky auto-ortho release: accumulate this drag's orbit travel and, once
-      // it crosses ROTATE_REVERT_THRESHOLD_RAD (a clear intent to leave the
-      // snapped view), revert the viewport-cube's temporary ortho. A right-drag
-      // pan leaves azimuth/polar unchanged so it never trips this (it reverts
-      // via its own detector); cube drag-orbit never sets `orbitInteracting`, so
-      // it is likewise excluded and keeps ortho. Sampled before the inertia
-      // bookkeeping below advances `orbitLast*`, so both read the same baseline.
-      let dAzIntent = this.controls.getAzimuthalAngle() - this.orbitLastAzimuth;
-      if (dAzIntent > Math.PI) dAzIntent -= 2 * Math.PI;
-      else if (dAzIntent < -Math.PI) dAzIntent += 2 * Math.PI;
-      const dPolIntent = this.controls.getPolarAngle() - this.orbitLastPolar;
-      this.accumulateRotateRevertIntent(Math.abs(dAzIntent) + Math.abs(dPolIntent));
-
       const now = performance.now();
       const dt = (now - this.orbitLastSampleTime) / 1000;
       this.orbitLastSampleTime = now;

--- a/ui/src/app/components/viewer/scene/index.ts
+++ b/ui/src/app/components/viewer/scene/index.ts
@@ -563,6 +563,10 @@ export class ViewerScene {
       this.controls.update();
       this._controls.applyOrbitInertia(dt);
     }
+    // Runs on every frame — including frames driven by OrbitControls above — so
+    // the viewport-cube's ortho→perspective revert can animate while the user's
+    // pan/zoom/rotate gesture is still live.
+    this._camera.advanceProjectionTween();
 
     this._grid.updateAdaptiveGrid();
     this._grid.updateGridFade();

--- a/ui/src/app/components/viewer/scene/index.ts
+++ b/ui/src/app/components/viewer/scene/index.ts
@@ -206,9 +206,11 @@ export class ViewerScene {
     this._controls = new SceneControls(this.camera, this.controls, this.renderer, () =>
       this._selection.cancelActiveDrag(),
     );
-    // Free pan/zoom in the main viewport reverts the viewport-cube's temporary
-    // orthographic snap; rotate and cube gestures never fire this.
-    this._controls.setRevertGestureSink(() => this._camera.notifyUserPanOrZoom());
+    // A deliberate free-view gesture in the main viewport — pan, zoom, or a
+    // rotate dragged past the sticky intent threshold — reverts the viewport-
+    // cube's temporary orthographic snap; a small rotate and cube gestures never
+    // fire this, so the mode only changes on a clear user intent.
+    this._controls.setRevertGestureSink(() => this._camera.notifyUserViewGesture());
     this._grid = new SceneGrid(this.scene, this.camera, this.controls, this.renderer, printArea);
 
     // Wire gizmo callbacks.

--- a/ui/src/app/components/viewer/scene/index.ts
+++ b/ui/src/app/components/viewer/scene/index.ts
@@ -563,6 +563,10 @@ export class ViewerScene {
       this.controls.update();
       this._controls.applyOrbitInertia(dt);
     }
+    // Re-pin a held viewport-cube snap. Runs *after* OrbitControls and inertia
+    // so their rotation is discarded before drawing — the snapped view stays
+    // perfectly still until the gesture travels far enough to break it free.
+    this._camera.applySnapHold();
     // Runs on every frame — including frames driven by OrbitControls above — so
     // the viewport-cube's ortho→perspective revert can animate while the user's
     // pan/zoom/rotate gesture is still live.

--- a/ui/src/app/components/viewer/scene/index.ts
+++ b/ui/src/app/components/viewer/scene/index.ts
@@ -200,6 +200,12 @@ export class ViewerScene {
     //   SceneCamera → GizmoManager → SceneSelection (needs gizmo)
     //   → SceneControls (needs cancelDrag callback) → SceneGrid
     this._camera = new SceneCamera(this.camera, this.controls, this.contentRoot, printArea);
+    // Seed the perspective preset from the FOV the camera was actually built
+    // with. Without this the preset keeps its built-in default while the camera
+    // runs at the user's configured FOV, so *restoring* perspective — the
+    // toolbar toggle, a cube-snap breakout, or the home reset — would snap the
+    // view to the default instead of the FOV the user chose.
+    this._camera.setPerspectiveFov(this.camera.fov);
     this.gizmo = new GizmoManager(this.scene, this.camera, this.renderer);
     this._selection = new SceneSelection(this.scene, this.camera, this.renderer, this.gizmo);
 
@@ -324,6 +330,16 @@ export class ViewerScene {
 
   setView(view: ViewerView): void {
     this._camera.setView(view);
+  }
+
+  /**
+   * Register a listener for projection changes the toolbar did not initiate — a
+   * viewport-cube snap engaging ortho, or a breakout restoring the previous
+   * preset. Lets the UI's `view` signal mirror what is actually on screen. The
+   * listener must not feed the value back into {@link setView}.
+   */
+  setViewChangeSink(sink: ((view: ViewerView) => void) | null): void {
+    this._camera.onViewChange = sink;
   }
 
   resetView(): void {

--- a/ui/src/app/components/viewer/viewer.ts
+++ b/ui/src/app/components/viewer/viewer.ts
@@ -37,6 +37,7 @@ import { GcodeOrchestrator } from './gcode-orchestrator';
 import { preferredHoverPlacement } from './hover-placement';
 import type { GizmoDelta } from './gizmo';
 import { ViewerScene } from './scene';
+import type { ViewerView } from './scene';
 import { applyFloating, type FloatingPlacement } from '../../shared/floating';
 
 export type ViewerMode = 'model' | 'gcode';
@@ -160,6 +161,14 @@ export class Viewer {
   readonly thumbnailPolaroidAnimating = signal(false);
 
   private scene: ViewerScene | null = null;
+  /**
+   * View value most recently pushed *from* the camera into
+   * `viewerControl.view` (a cube snap engaging ortho, or a breakout restoring
+   * the previous preset). Armed only when the write actually changes the
+   * signal, so the effect it triggers can skip echoing it straight back into the
+   * camera. Cleared by that skip.
+   */
+  private cameraOriginatedView: ViewerView | null = null;
   private gcode: GcodeOrchestrator | null = null;
   private gcodeHover: GcodeHoverProbe | null = null;
   private currentAbort: AbortController | null = null;
@@ -278,9 +287,17 @@ export class Viewer {
       this.applySource(mode, model);
     });
 
-    // React to view-preset changes from the toolbar.
+    // React to view-preset changes from the toolbar. Changes the *camera*
+    // originated (a cube snap engaging ortho, or a breakout restoring the
+    // previous preset) are echoed into the same signal so the toolbar button
+    // always matches the screen; those must not be routed back into the camera,
+    // which would cancel the in-flight snap and its detent.
     effect(() => {
       const view = this.viewerControl.view();
+      if (view === this.cameraOriginatedView) {
+        this.cameraOriginatedView = null;
+        return;
+      }
       this.scene?.setView(view);
     });
 
@@ -365,7 +382,6 @@ export class Viewer {
       }
       this.scene?.animateToDirection(req.direction, req.up, req.autoOrtho);
     });
-
     // React to roll requests (viewport-cube roll buttons).
     effect(() => {
       const req = this.viewerControl.rollRequest();
@@ -548,6 +564,21 @@ export class Viewer {
     });
   }
 
+  /**
+   * Mirror a camera-originated projection change into the toolbar's `view`
+   * signal, so the projection button's icon, tooltip and next press always match
+   * what is on screen. Arms {@link cameraOriginatedView} only when the signal
+   * actually changes — that is exactly when the effect will fire and needs to
+   * skip pushing the value back into the camera.
+   */
+  private syncViewFromCamera(view: ViewerView): void {
+    if (this.viewerControl.view() === view) {
+      return;
+    }
+    this.cameraOriginatedView = view;
+    this.viewerControl.view.set(view);
+  }
+
   private handleSelect(stringId: string, _additive: boolean): void {
     const id = parseWasmId(stringId);
     if (id === null) {
@@ -710,6 +741,9 @@ export class Viewer {
     // whatever view / object mode the user already had selected.
     this.scene.setObjectMode(this.viewerControl.objectMode());
     this.scene.setView(this.viewerControl.view());
+    // Keep the toolbar's projection button honest when the viewport cube (not
+    // the toolbar) changes the projection.
+    this.scene.setViewChangeSink((view) => this.syncViewFromCamera(view));
     this.scene.setTwoFingerGesture(this.viewerControl.trackpadTwoFingerGesture());
     this.scene.setPalmRejectionEnabled(this.viewerControl.palmRejection());
     this.scene.setTheme(this.appTheme.isDarkMode());


### PR DESCRIPTION
Clicking a viewport-cube face snaps the camera to that view and flattens the projection to orthographic. This PR makes that snap behave like a proper CAD detent, animates the way out of it, and fixes the ortho/perspective button that had drifted out of sync with what was actually on screen.

## The problems

1. **You could never rotate your way out of ortho.** The temporary ortho was released only by a pan or a zoom. Rotating deliberately *kept* it — so entering a snap from perspective left you stuck in a flat view no matter how much you dragged.
2. **The snap wasn't sticky.** A small drag immediately turned the camera off the snapped orientation (only the flat projection lingered), so the dimension-true view slipped away on the slightest nudge.
3. **The projection change was an instant pop**, unlike the toolbar's animated toggle.
4. **The ortho/perspective button needed two presses** after a snap, and showed the wrong state.
5. **Toggling projection destroyed your configured field of view** — a 20° view came back as 45°.

## The changes

### A real detent (`snapHoldPose`)

The snapped pose is now **pinned**. `applySnapHold()` restores it every frame from the render loop, *after* `OrbitControls.update()` and the inertia step, so any rotation those applied is discarded before anything is drawn. The view sits perfectly still — pixel-identical frames — until the gesture pulls out of it.

Discarding the rotation each frame rather than accumulating it is what makes the release seamless: `OrbitControls` re-derives its orbit frame from the camera's current position on every update, so the moment the pin drops the view starts following the pointer from the snapped orientation, with no jump and no replay of the absorbed movement.

Breakout is **straight-line pointer travel** (`SNAP_BREAKOUT_TRAVEL_PX` = 70), not camera angle — a pinned view has no angle to measure. Measuring from the drag origin means wiggling back and forth never breaks out. The detector rides the existing pointer listeners and is skipped while controls are disabled, so dragging an object or gizmo can't pop the view out of its snap. Cube drag-orbit still releases the pin (it must follow the drag) while keeping ortho engaged.

### Animated revert (`ProjectionTween`)

Leaving the snap now animates over the same `VIEW_TRANSITION_MS` + easing as the toolbar toggle, so the morph reads identically whichever control triggered it.

It is a **projection-only** tween rather than a full pose animation — the latter sets `controls.enabled = false` and is skipped by the render loop's `else` branch, which would have frozen the very gesture that triggered the revert. Only the FOV is driven; the orbit distance is rescaled *incrementally* each frame by `tan(prevFov/2) / tan(nextFov/2)` to hold apparent size. Nothing pins the direction, target or distance, so you can keep dragging or zooming straight through the transition.

### An honest projection button

- A snap now **reports itself** (`onViewChange` → `setViewChangeSink` → the UI's `view` signal) and remembers the preset it interrupted (`preSnapView`) to restore on breakout. Previously the toolbar claimed "perspective" while the screen was flat, so the first press was swallowed re-asserting a projection that was already active. The viewer guards the echo (`cameraOriginatedView`, armed only when the write actually changes the signal) so a camera-originated value is never routed back into `setView`, which would cancel the in-flight snap and its detent.
- The perspective preset is **seeded from the camera's real FOV** at construction. `ViewerScene` builds its camera with the user's configured field of view, but `SceneCamera.perspectiveFov` kept its built-in 45° default because the settings effect runs before the scene exists — so any restore to perspective (toggle, breakout, or home reset) jumped to 45° instead of the FOV the user chose.

## Verification

Measured in a real browser against the running dev build.

| Check | Result |
| --- | --- |
| Drag 10→60 px inside the detent | 6 **pixel-identical** frames — zero movement |
| Drag past 70 px | frames change; view orbits free |
| Revert animation, pointer held still | 6 distinct frames, settling at **603 ms** (matches `VIEW_TRANSITION_MS`) |
| Load → toggle → toggle | FOV 20 → 1 → **20** (was 45) |
| Cube snap, then **one** press | button ortho → perspective, FOV 1 → 20 (previously did nothing) |

## Notes for reviewers

- `SNAP_BREAKOUT_TRAVEL_PX` (70) and the tween duration are single named constants — easy to retune if the feel is off.
- No behaviour tests exist for this subsystem; changed files were validated by isolated transpile plus the browser measurements above. All temporary debug instrumentation used during investigation was removed and verified absent.
- Docs: the auto-ortho section of `ui/src/app/components/viewer/README.md` is rewritten to cover the detent, the tween, and the toolbar sync.
- Two red herrings worth knowing: a backgrounded browser tab pauses `requestAnimationFrame` entirely (freezing the render loop and invalidating naive measurements), and the icon component *does* react correctly to state changes — an earlier suspicion to the contrary was an artifact of that frozen tab.
