### PR TITLE
fix(viewer): stop iPad pen + two-finger touch spazzing the camera

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -85,6 +85,19 @@ these notes and acknowledges contributors. `scripts/gen-changelog-draft.sh` and
 
 ### Fixed
 
+- **iPad Apple Pencil + two-finger navigation "spazzing"** — palm rejection
+  classified each touch on its own, so a stylus user's two-finger pan/pinch could
+  lose exactly one finger — a firm fingertip read as palm-sized, or a flickering
+  pen hover/grace state — collapsing the gesture into an unwanted single-finger
+  camera rotate. The viewport's pointer arbiter now decides **per gesture
+  group**: the first contact is classified, and any finger that lands while
+  another is already down inherits that verdict, so a two-finger gesture is
+  admitted or rejected as a whole and never split. The palm-by-size heuristic is
+  also gated to _recent_ pen use instead of the whole session, so firm fingertips
+  stop being mistaken for a palm long after the pencil is set down. Stale
+  pointer state is now reclaimed by timeout, so a touch or pen event dropped by
+  the OS (a common iPad backgrounding glitch) can no longer wedge the viewport
+  into ignoring all touch until reload.
 - **3MF models loaded at the wrong scale** — the 3MF importer ignored the
   `<model unit="…">` declaration and read every coordinate as raw millimeters, so
   files authored in `meter`, `centimeter`, `inch`, or `foot` opened dramatically

--- a/ui/src/app/components/viewer/README.md
+++ b/ui/src/app/components/viewer/README.md
@@ -189,8 +189,10 @@ raycaster, gizmo), the viewer applies a clear priority order:
    canvas), so it runs before every other consumer. While an Apple Pencil /
    stylus is down, hovering, or was active within the grace window, it swallows
    `pointerType === 'touch'` events — the hand and wrist resting on the glass —
-   so the palm never orbits, pinches, or selects. Genuine finger gestures are
-   untouched whenever no pen is involved.
+   so the palm never orbits, pinches, or selects. It decides **per gesture
+   group** (see the no-tear invariant below), so it can never split a real
+   two-finger gesture into a lone survivor. Genuine finger gestures are untouched
+   whenever no pen is involved.
 1. **Gizmo dragging in progress** — gizmo owns the pointer; OrbitControls
    and the selection raycaster are both suppressed.
 2. **Gizmo hovering** (cursor over a handle, not yet dragging) — the selection
@@ -241,22 +243,43 @@ pencil. [`PointerArbiter`](scene/pointer-arbiter.ts) vetoes those contacts.
 flowchart TD
     E[pointer event on host<br/>capture phase] --> P{pointerType?}
     P -->|pen| T[track pen: penActive + penEverUsed<br/>pass through]
-    P -->|touch| C{palm?}
     P -->|mouse| A[pass through]
-    C -->|pen active, in grace,<br/>or palm-sized after pen use| S[stopImmediatePropagation<br/>swallow]
+    P -->|touch| G{another touch<br/>already down?}
+    G -->|yes| I[inherit group verdict<br/>admit wins over palm]
+    G -->|no · fresh group| C{palm?}
+    C -->|pen active/in grace, or<br/>palm-sized within PEN_SIZE_ARM_MS| S[stopImmediatePropagation<br/>swallow]
     C -->|otherwise| A
+    I -->|palm| S
+    I -->|admit| A
     T --> D[OrbitControls / selection / gizmo]
     A --> D
 ```
 
-A touch is judged palm at its `pointerdown` (`isPalmTouch`, unit-tested) when a
-pen is active — down, hovering, or lifted within `PEN_GRACE_MS` — or, once a pen
-has been seen this session, when its contact patch is palm-sized
-(`PALM_CONTACT_MIN_PX`), which catches the palm that lands just before the tip on
-iPads without pencil hover. Pure-touch users are never affected: the contact-size
-path is gated behind "a pen has been seen", and the pen-active path only fires
-while a pen is in use. The user can turn the whole behaviour off from
-**Settings → General → Controls → Palm rejection** (persisted; default on).
+A **fresh** touch — the first contact of a group, nothing else down — is judged
+palm at its `pointerdown` (`isPalmTouch`, unit-tested) when a pen is active
+(down, hovering, or lifted within `PEN_GRACE_MS`) or, once a pen has been used
+**recently** (`PEN_SIZE_ARM_MS`), when its contact patch is palm-sized
+(`PALM_CONTACT_MIN_PX`) — which catches the palm that lands just before the tip
+on iPads without pencil hover. Pure-touch users are never affected: the
+contact-size path only arms after a pen is seen, and the pen-active path only
+fires while a pen is in use.
+
+**No-tear invariant.** The camera's two-finger handler only engages while two
+touches are down; a lone touch falls to OrbitControls' single-finger rotate. If
+the arbiter ever swallowed exactly one finger of a two-finger gesture, the
+survivor would spin the camera — the "spazzing" a stylus user hits when a
+palm-sized fingertip, or a flickering pen hover/grace state, splits the pair.
+So only the first contact of a fresh group is classified from scratch; any touch
+that lands while another is already down **inherits** the group verdict (admit
+wins over palm). A resting hand is still rejected because its contacts open the
+group as palm (the pencil is the active tool, and a lone palm never lifts, so
+the group stays palm across long pauses between strokes). To keep a dropped
+`pointerup` (an iPad that never delivers the palm's lift) from stranding a
+`palm` verdict that every later finger would inherit — locking out all touch —
+stale verdicts and a stuck pen-down latch are reclaimed by timeout
+(`TOUCH_VERDICT_STALE_MS`, `PEN_CONTACT_STALE_MS`); a contact really still down
+keeps itself fresh. The user can turn the whole behaviour off from **Settings →
+General → Controls → Palm rejection** (persisted; default on).
 
 ### Hand-aware inspector tooltip placement
 
@@ -355,7 +378,7 @@ flowchart LR
 - [scene/camera.ts](scene/camera.ts) — `SceneCamera`
 - [scene/controls.ts](scene/controls.ts) — `SceneControls`
 - [scene/grid.ts](scene/grid.ts) — `SceneGrid`
-- [scene/pointer-arbiter.ts](scene/pointer-arbiter.ts) — `PointerArbiter`, `isPalmTouch`, `PEN_GRACE_MS`, `PALM_CONTACT_MIN_PX`
+- [scene/pointer-arbiter.ts](scene/pointer-arbiter.ts) — `PointerArbiter`, `isPalmTouch`, `PEN_GRACE_MS`, `PALM_CONTACT_MIN_PX`, `PEN_SIZE_ARM_MS`, `PEN_CONTACT_STALE_MS`, `TOUCH_VERDICT_STALE_MS`
 - [scene/selection.ts](scene/selection.ts) — `SceneSelection`
 - [gizmo.ts](gizmo.ts) — `GizmoManager`, `GizmoDelta`, `FacePickResult`, `raycastFace`, `computeSelectionCentroid`
 - [hover-placement.ts](hover-placement.ts) — `preferredHoverPlacement`, `HoverPointerInfo`

--- a/ui/src/app/components/viewer/scene/pointer-arbiter.spec.ts
+++ b/ui/src/app/components/viewer/scene/pointer-arbiter.spec.ts
@@ -1,5 +1,13 @@
 import { afterEach, beforeEach, describe, expect, it } from 'vitest';
-import { isPalmTouch, PALM_CONTACT_MIN_PX, PEN_GRACE_MS, PointerArbiter } from './pointer-arbiter';
+import {
+  isPalmTouch,
+  PALM_CONTACT_MIN_PX,
+  PEN_CONTACT_STALE_MS,
+  PEN_GRACE_MS,
+  PEN_SIZE_ARM_MS,
+  PointerArbiter,
+  TOUCH_VERDICT_STALE_MS,
+} from './pointer-arbiter';
 
 describe('isPalmTouch', () => {
   const base = {
@@ -126,8 +134,8 @@ describe('PointerArbiter', () => {
     expect(dispatch('pointerdown', { pointerType: 'touch', pointerId: 2 })).toBe(true);
   });
 
-  it('rejects a palm-sized contact after the pen lifts (hover-less iPad case)', () => {
-    // Pen used once, then fully gone (past grace).
+  it('rejects a lone palm-sized contact after the pen lifts (hover-less iPad case)', () => {
+    // Pen used once, then fully gone (past grace, still within the size window).
     dispatch('pointerdown', { pointerType: 'pen', pointerId: 9 });
     dispatch('pointerout', { pointerType: 'pen', pointerId: 9 });
     clock.t += PEN_GRACE_MS + 500;
@@ -136,7 +144,9 @@ describe('PointerArbiter', () => {
     expect(
       dispatch('pointerdown', { pointerType: 'touch', pointerId: 2, width: 20, height: 20 }),
     ).toBe(true);
-    // …but a palm-sized one is rejected.
+    // …lift it so the next contact opens a fresh group…
+    dispatch('pointerup', { pointerType: 'touch', pointerId: 2, width: 20, height: 20 });
+    // …and a lone palm-sized one is rejected.
     expect(
       dispatch('pointerdown', {
         pointerType: 'touch',
@@ -145,6 +155,71 @@ describe('PointerArbiter', () => {
         height: PALM_CONTACT_MIN_PX + 20,
       }),
     ).toBe(false);
+  });
+
+  it('does not tear a two-finger gesture when the second finger is palm-sized', () => {
+    // A pen has been used, arming the size heuristic; the pencil is now idle.
+    dispatch('pointerdown', { pointerType: 'pen', pointerId: 9 });
+    dispatch('pointerout', { pointerType: 'pen', pointerId: 9 });
+    clock.t += PEN_GRACE_MS + 500;
+    // First finger (fingertip) opens the group and is admitted.
+    expect(
+      dispatch('pointerdown', { pointerType: 'touch', pointerId: 2, width: 20, height: 20 }),
+    ).toBe(true);
+    // Second finger lands palm-sized but INHERITS the group's admit verdict, so
+    // the pair reaches the two-finger handler instead of collapsing to a lone
+    // single-finger rotate.
+    expect(
+      dispatch('pointerdown', {
+        pointerType: 'touch',
+        pointerId: 3,
+        width: PALM_CONTACT_MIN_PX + 20,
+        height: PALM_CONTACT_MIN_PX + 20,
+      }),
+    ).toBe(true);
+  });
+
+  it('does not tear a two-finger gesture when a pen goes active mid-gesture', () => {
+    // First finger lands with no pen in play → admitted, opens the group.
+    expect(
+      dispatch('pointerdown', { pointerType: 'touch', pointerId: 1, width: 20, height: 20 }),
+    ).toBe(true);
+    // A pen now goes active — a freshly-classified touch would be rejected…
+    dispatch('pointerdown', { pointerType: 'pen', pointerId: 9 });
+    expect(arbiter.isPenActive()).toBe(true);
+    // …but the second finger inherits the group's admit verdict, so both fingers
+    // still reach the two-finger handler (no single-finger-rotate spazz).
+    expect(
+      dispatch('pointerdown', { pointerType: 'touch', pointerId: 2, width: 20, height: 20 }),
+    ).toBe(true);
+  });
+
+  it('rejects both contacts of a resting hand while a pen is down', () => {
+    dispatch('pointerdown', { pointerType: 'pen', pointerId: 9 });
+    // The palm opens the group (pen active → palm) …
+    expect(
+      dispatch('pointerdown', { pointerType: 'touch', pointerId: 1, width: 50, height: 50 }),
+    ).toBe(false);
+    // … and the second wrist/palm contact inherits the palm verdict.
+    expect(
+      dispatch('pointerdown', { pointerType: 'touch', pointerId: 2, width: 50, height: 50 }),
+    ).toBe(false);
+  });
+
+  it('stops rejecting palm-sized contacts once the pen-size window elapses', () => {
+    dispatch('pointerdown', { pointerType: 'pen', pointerId: 9 });
+    dispatch('pointerout', { pointerType: 'pen', pointerId: 9 });
+    // Pencil clearly set down; the user is on fingers now.
+    clock.t += PEN_SIZE_ARM_MS + 100;
+    expect(arbiter.isPenActive()).toBe(false);
+    expect(
+      dispatch('pointerdown', {
+        pointerType: 'touch',
+        pointerId: 2,
+        width: PALM_CONTACT_MIN_PX + 20,
+        height: PALM_CONTACT_MIN_PX + 20,
+      }),
+    ).toBe(true);
   });
 
   it('passes everything through when disabled', () => {
@@ -157,5 +232,67 @@ describe('PointerArbiter', () => {
     dispatch('pointerdown', { pointerType: 'pen', pointerId: 9 });
     arbiter.dispose();
     expect(dispatch('pointerdown', { pointerType: 'touch', pointerId: 1 })).toBe(true);
+  });
+
+  it('never swallows a pointercancel for a non-palm id (lets the reset through)', () => {
+    // `beginTwoFinger` dispatches a synthetic `pointercancel` for its admitted
+    // fingers to reset OrbitControls. The arbiter swallows on up/cancel only for
+    // a stored *palm* verdict, so a cancel for an untracked/admitted id passes
+    // through and the reset is not defeated.
+    dispatch('pointerdown', { pointerType: 'touch', pointerId: 1, width: 20, height: 20 });
+    expect(dispatch('pointercancel', { pointerType: 'touch', pointerId: 1 })).toBe(true);
+    // An id that was never seen at all also passes through.
+    expect(dispatch('pointercancel', { pointerType: 'touch', pointerId: 5 })).toBe(true);
+  });
+
+  it('recovers from a dropped palm-up instead of locking out all touch', () => {
+    // A pen arms rejection; a palm lands and is swallowed…
+    dispatch('pointerdown', { pointerType: 'pen', pointerId: 9 });
+    expect(
+      dispatch('pointerdown', { pointerType: 'touch', pointerId: 1, width: 60, height: 60 }),
+    ).toBe(false);
+    // …but its pointerup is never delivered (OS dropped it) and the pen leaves.
+    dispatch('pointerout', { pointerType: 'pen', pointerId: 9 });
+    // Long enough that both the pen and the phantom palm verdict go stale.
+    clock.t += Math.max(TOUCH_VERDICT_STALE_MS, PEN_SIZE_ARM_MS) + 100;
+    // Without staleness pruning the leaked palm entry would make this new finger
+    // inherit 'palm' and be swallowed — a total touch lockout. It is admitted.
+    expect(
+      dispatch('pointerdown', { pointerType: 'touch', pointerId: 2, width: 20, height: 20 }),
+    ).toBe(true);
+  });
+
+  it('keeps a still-but-live palm rejecting later contacts across the stale window', () => {
+    // A pen arms rejection and a resting palm is swallowed…
+    dispatch('pointerdown', { pointerType: 'pen', pointerId: 9 });
+    expect(
+      dispatch('pointerdown', { pointerType: 'touch', pointerId: 1, width: 60, height: 60 }),
+    ).toBe(false);
+    dispatch('pointerout', { pointerType: 'pen', pointerId: 9 });
+    // The hand shifts between strokes — the still-down palm streams a move that
+    // refreshes its timestamp even though the pen is now idle.
+    clock.t += TOUCH_VERDICT_STALE_MS - 100;
+    expect(dispatch('pointermove', { pointerType: 'touch', pointerId: 1 })).toBe(false);
+    // Enough more time that the palm would be stale from its *original* down,
+    // but not from the refreshing move.
+    clock.t += TOUCH_VERDICT_STALE_MS - 100;
+    // A second contact from the same hand still inherits the live palm verdict
+    // (it was not pruned), so it is swallowed rather than admitted.
+    expect(
+      dispatch('pointerdown', { pointerType: 'touch', pointerId: 2, width: 20, height: 20 }),
+    ).toBe(false);
+  });
+
+  it('times out a stuck pen-contact latch so touch is not disabled forever', () => {
+    // Pen goes down but its up/out is dropped (backgrounded mid-stroke).
+    dispatch('pointerdown', { pointerType: 'pen', pointerId: 9 });
+    expect(arbiter.isPenActive()).toBe(true);
+    clock.t += PEN_CONTACT_STALE_MS + 100;
+    // The latch has gone stale, so the pen no longer counts as active…
+    expect(arbiter.isPenActive()).toBe(false);
+    // …and ordinary finger touch works again.
+    expect(
+      dispatch('pointerdown', { pointerType: 'touch', pointerId: 1, width: 20, height: 20 }),
+    ).toBe(true);
   });
 });

--- a/ui/src/app/components/viewer/scene/pointer-arbiter.ts
+++ b/ui/src/app/components/viewer/scene/pointer-arbiter.ts
@@ -29,10 +29,31 @@
  *     patch is palm-sized ({@link PALM_CONTACT_MIN_PX}). This catches the palm
  *     that lands a moment before the tip on iPads without pencil hover.
  *
- * Pure-touch users are never affected: the contact-size path is gated behind
- * "a pen has been seen this session", and the pen-active path only fires while
- * a pen is actually in use. Genuine two-finger orbit/pinch/pan therefore keeps
- * working exactly as before whenever no pen is involved.
+ * Pure-touch users are never affected: the contact-size path is gated behind a
+ * pen having been used *recently* ({@link PEN_SIZE_ARM_MS}), and the pen-active
+ * path only fires while a pen is actually in use. Genuine two-finger
+ * orbit/pinch/pan therefore keeps working exactly as before whenever no pen is
+ * involved.
+ *
+ * **No-tear invariant.** Palm rejection decides per *gesture group*, not per
+ * isolated pointer. The camera's two-finger handler only engages while two
+ * touches are down; a lone touch drives OrbitControls' single-finger rotate. So
+ * if the arbiter ever swallowed exactly one finger of a two-finger gesture, the
+ * surviving finger would spin the camera — the "spazzing" a stylus user sees
+ * when a palm-sized fingertip, or a flickering pen hover/grace state, splits the
+ * pair. To prevent that, only the *first* contact of a fresh group (nothing else
+ * down) is classified from scratch; every touch that lands while another is
+ * already down inherits that group's verdict (admit wins over palm). A
+ * navigation gesture is thus admitted or rejected as a whole, never split.
+ *
+ * **Self-healing live set.** Because a mid-group contact inherits the group
+ * verdict, a leaked `'palm'` entry (an iPad that drops a `pointerup`/
+ * `pointercancel`) would otherwise be inherited forever and lock out all touch.
+ * Two guards prevent that: touch verdicts whose pointer has produced no event
+ * within {@link TOUCH_VERDICT_STALE_MS} are pruned before each new
+ * classification, and the "pen is down/hovering" latch is bounded by
+ * {@link PEN_CONTACT_STALE_MS}. A pointer really still down keeps refreshing its
+ * timestamp, so only phantom contacts are reclaimed.
  */
 
 /**
@@ -50,6 +71,41 @@ export const PEN_GRACE_MS = 600;
  * this session, so ordinary fat-finger touches on pen-less devices are safe.
  */
 export const PALM_CONTACT_MIN_PX = 45;
+
+/**
+ * Once a pen has been used this session, the palm-by-size heuristic
+ * ({@link PALM_CONTACT_MIN_PX}) stays armed only for this long after the pen's
+ * most recent activity. Beyond it we assume the pencil has been set down and the
+ * user is navigating with fingers again, so firm fingertips are no longer
+ * mistaken for a palm and a stray large single-finger contact stops silently
+ * failing. A palm that never lifts keeps its original verdict via the
+ * group-coherence rule regardless of this window, so an actively-drawing hand is
+ * still rejected across long pauses between strokes.
+ */
+export const PEN_SIZE_ARM_MS = 1500;
+
+/**
+ * Upper bound on how long the "a pen is physically down or hovering"
+ * ({@link PointerArbiter.isPenActive}) latch is trusted without a fresh pen
+ * event. The latch is set on every pen event and normally cleared on the pen's
+ * `pointerup`/`pointerout`. But iOS/WebKit can *drop* that lift (app
+ * backgrounded mid-stroke, cancel storms), which would otherwise pin the latch
+ * on and suppress **all** touch until a reload. An actively used pen streams
+ * `pointermove`s that keep the latch fresh, so this only trips after a genuine
+ * idle — at which point we assume the pencil was parked and let touch resume.
+ */
+export const PEN_CONTACT_STALE_MS = 3000;
+
+/**
+ * How long a live touch verdict survives without any event for its pointer
+ * before it is pruned. Verdicts are normally removed on `pointerup`/
+ * `pointercancel`; this reconciles the set when that lift is *dropped* by the
+ * OS. Without it, a leaked `'palm'` entry would be inherited by every later
+ * contact (see the no-tear rule) and lock out all touch indefinitely. A contact
+ * that is really still down streams `pointermove`s that refresh its timestamp,
+ * so only a phantom (already-lifted) contact goes stale and is reclaimed.
+ */
+export const TOUCH_VERDICT_STALE_MS = 3000;
 
 /**
  * The minimal, side-effect-free inputs needed to decide whether a touch is a
@@ -89,6 +145,16 @@ export function isPalmTouch(state: PalmRejectionState): boolean {
   return false;
 }
 
+/** Whether a live touch pointer is being passed through or swallowed. */
+type TouchVerdict = 'admit' | 'palm';
+
+/** A live touch pointer's verdict plus the clock of its most recent event. */
+interface TouchRecord {
+  verdict: TouchVerdict;
+  /** `now()` of this pointer's last event — used to prune dropped contacts. */
+  lastSeenMs: number;
+}
+
 /**
  * Installs pen-priority palm rejection on a viewport host element and tracks
  * pen presence over time. One instance per {@link ViewerScene}.
@@ -100,8 +166,18 @@ export class PointerArbiter {
   private penContact = false;
   /** `performance.now()` of the most recent pen event, for the grace window. */
   private lastPenActivityMs = Number.NEGATIVE_INFINITY;
-  /** Touch pointer ids currently classified as palm — swallowed for their life. */
-  private readonly palmPointerIds = new Set<number>();
+  /**
+   * Verdict for every touch pointer currently down — `'admit'` (passed through)
+   * or `'palm'` (swallowed for its whole life), each stamped with the time of
+   * its last event. Entries are added at `pointerdown`, refreshed on
+   * `pointermove`, removed at `pointerup`/`pointercancel`, and reclaimed by
+   * staleness if their lift is ever dropped ({@link TOUCH_VERDICT_STALE_MS}).
+   * Tracking the whole live set is what lets the arbiter honour the no-tear
+   * invariant: a touch that lands mid-group inherits the group's verdict instead
+   * of being reclassified in isolation (which could split a two-finger gesture).
+   * See the module doc.
+   */
+  private readonly touchVerdicts = new Map<number, TouchRecord>();
 
   private readonly listenerOptions: AddEventListenerOptions = { capture: true };
 
@@ -133,7 +209,7 @@ export class PointerArbiter {
   setEnabled(enabled: boolean): void {
     this.enabled = enabled;
     if (!enabled) {
-      this.palmPointerIds.clear();
+      this.touchVerdicts.clear();
     }
   }
 
@@ -143,7 +219,7 @@ export class PointerArbiter {
     this.host.removeEventListener('pointerup', this.onPointerUp, this.listenerOptions);
     this.host.removeEventListener('pointercancel', this.onPointerUp, this.listenerOptions);
     this.host.removeEventListener('pointerout', this.onPointerOut, this.listenerOptions);
-    this.palmPointerIds.clear();
+    this.touchVerdicts.clear();
   }
 
   /**
@@ -151,10 +227,14 @@ export class PointerArbiter {
    * Exposed for diagnostics and potential UI affordances.
    */
   isPenActive(): boolean {
-    if (this.penContact) {
+    const idleMs = this.now() - this.lastPenActivityMs;
+    // The `penContact` latch normally clears on the pen's up/out; bound it by
+    // staleness so a dropped lift can't suppress touch forever. A pen in real
+    // use streams moves that keep `lastPenActivityMs` fresh.
+    if (this.penContact && idleMs < PEN_CONTACT_STALE_MS) {
       return true;
     }
-    return this.now() - this.lastPenActivityMs < PEN_GRACE_MS;
+    return idleMs < PEN_GRACE_MS;
   }
 
   private notePenActivity(): void {
@@ -171,14 +251,68 @@ export class PointerArbiter {
     }
   }
 
-  private classify(event: PointerEvent): boolean {
+  /**
+   * True while the palm-by-size heuristic is armed: a pen has been used and its
+   * last activity was within {@link PEN_SIZE_ARM_MS}. Outside that window we no
+   * longer second-guess firm fingertips by contact size (see the constant).
+   */
+  private isSizeHeuristicArmed(): boolean {
+    return this.penEverUsed && this.now() - this.lastPenActivityMs < PEN_SIZE_ARM_MS;
+  }
+
+  /**
+   * Classify a *fresh* touch — the first contact of a group — in isolation.
+   * Later contacts never call this; they inherit the group verdict. See
+   * {@link verdictForNewTouch}.
+   */
+  private classifyFresh(event: PointerEvent): boolean {
     return isPalmTouch({
       enabled: this.enabled,
       penActive: this.isPenActive(),
-      penEverUsed: this.penEverUsed,
+      // The size path is additionally gated on recency; `isPalmTouch` only needs
+      // to know whether that path is live for this contact right now.
+      penEverUsed: this.isSizeHeuristicArmed(),
       contactMaxPx: Math.max(event.width ?? 0, event.height ?? 0),
       palmContactMinPx: PALM_CONTACT_MIN_PX,
     });
+  }
+
+  /**
+   * Drop verdicts whose pointer has produced no event within
+   * {@link TOUCH_VERDICT_STALE_MS} — a contact whose `pointerup`/`pointercancel`
+   * the OS never delivered. Keeps the live set matching physical reality so a
+   * phantom `'palm'` can't be inherited by (and thus lock out) later contacts.
+   */
+  private pruneStaleTouches(): void {
+    const cutoff = this.now() - TOUCH_VERDICT_STALE_MS;
+    for (const [id, record] of this.touchVerdicts) {
+      if (record.lastSeenMs < cutoff) {
+        this.touchVerdicts.delete(id);
+      }
+    }
+  }
+
+  /**
+   * The verdict a newly-pressed touch should take, honouring the no-tear
+   * invariant: the first contact of a fresh group is classified from scratch;
+   * any touch landing while another is already down inherits the group verdict.
+   * Admit wins over palm so a genuine multi-finger gesture is never split into a
+   * lone survivor that OrbitControls would read as a single-finger rotate.
+   */
+  private verdictForNewTouch(event: PointerEvent): TouchVerdict {
+    if (!this.enabled) {
+      return 'admit';
+    }
+    this.pruneStaleTouches();
+    if (this.touchVerdicts.size > 0) {
+      for (const record of this.touchVerdicts.values()) {
+        if (record.verdict === 'admit') {
+          return 'admit';
+        }
+      }
+      return 'palm';
+    }
+    return this.classifyFresh(event) ? 'palm' : 'admit';
   }
 
   private readonly onPointerDown = (event: PointerEvent): void => {
@@ -189,8 +323,9 @@ export class PointerArbiter {
     if (event.pointerType !== 'touch') {
       return;
     }
-    if (this.classify(event)) {
-      this.palmPointerIds.add(event.pointerId);
+    const verdict = this.verdictForNewTouch(event);
+    this.touchVerdicts.set(event.pointerId, { verdict, lastSeenMs: this.now() });
+    if (verdict === 'palm') {
       this.swallow(event);
     }
   };
@@ -203,9 +338,16 @@ export class PointerArbiter {
     if (event.pointerType !== 'touch') {
       return;
     }
-    // A touch already committed to "palm" stays swallowed for its whole life so
-    // its move stream can never leak into a gesture handler.
-    if (this.palmPointerIds.has(event.pointerId)) {
+    const record = this.touchVerdicts.get(event.pointerId);
+    if (!record) {
+      return;
+    }
+    // Keep the contact fresh so staleness pruning only reclaims phantom (dropped)
+    // pointers, never a finger that is really still down.
+    record.lastSeenMs = this.now();
+    // A touch committed to "palm" stays swallowed for its whole life so its move
+    // stream can never leak into a gesture handler.
+    if (record.verdict === 'palm') {
       this.swallow(event);
     }
   };
@@ -219,7 +361,14 @@ export class PointerArbiter {
     if (event.pointerType !== 'touch') {
       return;
     }
-    if (this.palmPointerIds.delete(event.pointerId)) {
+    const record = this.touchVerdicts.get(event.pointerId);
+    this.touchVerdicts.delete(event.pointerId);
+    // Swallow **only** for a palm verdict — never on an admit. The two-finger
+    // controller dispatches a synthetic `pointercancel` for its admitted fingers
+    // to reset OrbitControls; swallowing here would eat that (and real admitted
+    // pointerups, breaking single-tap selection). Deleting an admit entry is
+    // harmless: the finger has already passed the arbiter's gate.
+    if (record?.verdict === 'palm') {
       this.swallow(event);
     }
   };


### PR DESCRIPTION
## Problem

On an iPad, using the Apple Pencil together with a **two-finger touch** gesture (pan/pinch/zoom) made the camera "spazz out" and left ordinary finger interaction unreliable.

## Root cause

The capture-phase [`PointerArbiter`](ui/src/app/components/viewer/scene/pointer-arbiter.ts) (palm rejection, added in #192) classified each touch **independently** at its own `pointerdown`. Two failure modes fell out of that:

1. **Torn gesture into single-finger rotate (the "spazz").** The custom two-finger controller only engages while `touches.size === 2`; a lone finger falls to OrbitControls' `TOUCH.ROTATE`. If the arbiter swallowed **exactly one** of the two fingers, the survivor rotated the camera. The split happened because the per-finger palm verdict is time/size dependent: `penActive` (pen hover / 600 ms grace) could flip between the two `pointerdown`s, and the size heuristic could reject a firm fingertip while the other passed.
2. **Over-rejection.** `penEverUsed` latched for the whole session, so after one pencil touch **every** contact ≥ 45 px was rejected forever — a firm single-finger tap silently failed.

## Fix

- **No-tear group coherence.** Only the *first* contact of a fresh group (nothing else down) is classified from scratch; any touch that lands while another is already down **inherits** the group verdict (admit wins over palm). A navigation gesture is now admitted or rejected as a whole, never split into a lone survivor.
- **Recency-gated size heuristic** (`PEN_SIZE_ARM_MS`, 1.5 s) replaces the session-long latch, so firm fingertips stop being read as a palm once the pencil is set down.
- **Self-healing live set.** Group inheritance would otherwise turn a *dropped* `pointerup` (a common iPad glitch) into a total touch lockout — every later finger inherits the leaked `palm` verdict. Verdicts with no event within `TOUCH_VERDICT_STALE_MS` are pruned, and the pen-down latch is time-bounded by `PEN_CONTACT_STALE_MS`. A pointer really still down keeps refreshing itself, so only phantom contacts are reclaimed.

The resting-hand palm feature is preserved: the pencil goes down/hover first, so the palm opens its group *as* palm and the whole hand inherits that.

## Testing

- `ng test` — **29 passed** (extends the arbiter spec with: no-tear across both split paths, resting-hand rejection, size-window disarm, dropped-`up` recovery, and cancel passthrough).
- Prettier clean; `pointer-arbiter.ts` and its spec type-check clean.
- Design was pressure-tested by a Three.js reviewer sub-agent; its finding that group inheritance *amplifies* a dropped-`up` into a full touch lockout is addressed by the self-healing guards above.

## Out of scope (follow-up)

Bimanual pen + touch navigation (fingers pan/zoom *while* the Pencil hovers, in the style of Procreate) is a deliberate product decision. The current model remains "pen active means reject touch"; enabling bimanual nav would require a size-primary classifier that runs even while the pen is active, and is not part of this bug fix.
