### PR TITLE
fix(slicing): remove tiny wasted extrusions — Arachne splats, gap fill under surfaces, sparse dashes, and grazing-angle surface slivers

### DIFF
--- a/.github/instructions/slicing-visual-verification.instructions.md
+++ b/.github/instructions/slicing-visual-verification.instructions.md
@@ -1,0 +1,172 @@
+---
+description: "Use when changing anything that alters sliced G-code geometry — walls, infill, surfaces, gap fill, bridges, adhesion, ordering — and when opening or updating a PR for such a change. Defines the visual verification contract: render the actual toolpaths as capsules at their true bead width, before vs. after, and attach that image to the PR so a human can check the result without re-deriving the math."
+name: "Slicing Changes: Prove It With a Picture"
+applyTo: "src/core/**, src/walls/**, src/infill/**, src/adhesion/**, src/gcode/**, tools/gcode-analysis/**"
+---
+
+# Slicing Changes — Prove It With a Picture
+
+Slicing is computational geometry: Clipper2 booleans, offsets, medial axes,
+winding rules, scanlines. A reviewer **cannot** check that kind of change by
+reading a diff, and neither can the author. Numbers alone are not enough either
+— they are summaries, and summaries hide things.
+
+So: **every change that alters sliced geometry ships with a before/after render
+of the real toolpaths, attached to the PR.** The picture is the artifact that
+lets a human agree or disagree in five seconds.
+
+This is not decoration. It is the verification step.
+
+## The one rule that matters: draw beads at their true width
+
+**Never verify with a centerline plot.** Centerlines lie.
+
+Two beads whose centerlines sit 0.3 mm apart look like two tidy, separate lines.
+Drawn at their real 0.4–0.56 mm widths they are visibly **the same material laid
+down twice**. That is the difference between "looks fine" and a defect.
+
+This is not hypothetical. On the 3DBenchy rear rail a gap-fill bead ran directly
+underneath the top-surface fill — 6 mm² per layer of genuine double extrusion.
+It was invisible in a centerline plot, and `overlap.py` *also* missed it because
+its ¼-nozzle erosion is designed to strip expected boundary seams and it ate the
+thin bead entirely. A true-width capsule render showed it instantly.
+
+Corollary: **when a metric says "clean" but the part looks wrong, trust the
+picture and go find out why the metric lied.** A metric that disagrees with the
+geometry is a bug in the metric's applicability, not a clean bill of health.
+
+## Workflow
+
+### 1. Slice both states
+
+Build and slice the parent commit and your HEAD with identical settings. Only
+the code may differ.
+
+```bash
+printf '[slicing]\nwall_generator = "arachne"\n' > /tmp/ar.toml
+
+git stash -u                                     # park work in progress
+git checkout <parent> -- src/core/ src/walls/    # or check out the parent commit
+cargo build && ./target/debug/slicer-engine slice -i 3DBenchy.stl \
+    --config /tmp/ar.toml -o /tmp/before.gcode
+
+git checkout HEAD -- src/core/ src/walls/ && git stash pop
+cargo build && ./target/debug/slicer-engine slice -i 3DBenchy.stl \
+    --config /tmp/ar.toml -o /tmp/after.gcode
+```
+
+Always confirm the tree is restored (`git status`) before moving on.
+
+### 2. Render the diff
+
+[`tools/gcode-analysis/beaddiff.py`](../../tools/gcode-analysis/beaddiff.py)
+does the before/after capsule render, role-coloured, on a shared scale, and
+counts isolated short paths (the "tiny extrude / splat" defect class) in each
+title:
+
+```bash
+# whole layer, auto-fit
+python3 tools/gcode-analysis/beaddiff.py /tmp/before.gcode /tmp/after.gcode 41 /tmp/diff.png
+
+# zoom a feature: cx cy half-window, flag anything under 1.5 mm
+python3 tools/gcode-analysis/beaddiff.py /tmp/before.gcode /tmp/after.gcode \
+    201 /tmp/rail.png 0.9 -12 2.2 --short=1.5
+```
+
+Pick the layer that shows the defect, not a layer that shows nothing. If the
+change is meant to be a no-op somewhere, render that too — an unchanged panel is
+evidence.
+
+Related tools, all in [`tools/gcode-analysis/`](../../tools/gcode-analysis/README.md):
+`zoom.py` (single-file capsules), `voids.py` (unfilled wall-zone gaps),
+`overlap.py` (cross-role double extrusion), `widthdist.py`,
+`coincident.py`. `--debug-geometry <dir>` dumps the *regions* (interior, solid
+surface, infill) as SVG when you need to see what the booleans produced rather
+than what was printed.
+
+### 3. Pair the picture with numbers, and with `classic`
+
+The image shows *what* changed; the numbers show it generalises and costs
+little. Report both, and compare against the **`classic` wall generator** — the
+trusted reference. "Better than before" is weak; "and still well inside what
+classic does" is an argument.
+
+Measure across several models (`3DBenchy.stl`, `Voron_Design_Cube_v7.stl`,
+`Filament_Card_Caddy_25.stl`, `bottom_panel_hinge_x2.stl`) so the fix is not
+tuned to one shape, and state explicitly that no model got worse. Always report
+the **cost** (material or path length lost) next to the win.
+
+### 4. Attach it to the PR
+
+Upload the PNG to GitHub's user-attachments API and embed the returned URL. Keep
+untrusted values in quoted shell variables and let `--url-query` encode them.
+
+```bash
+FILE='/tmp/diff.png'; NAME='benchy-layer41-before-after.png'; MIME='image/png'
+REPO='<owner>/<repo>'
+REPO_ID="$(gh api "repos/$REPO" --jq .id)"
+URL="$(curl --fail-with-body -sS -X POST \
+  "https://uploads.github.com/user-attachments/assets" \
+  --url-query "name=$NAME" --url-query "content_type=$MIME" \
+  --url-query "repository_id=$REPO_ID" \
+  -H "Content-Type: application/octet-stream" \
+  -H "X-GitHub-Api-Version: 2022-11-28" \
+  -H "Authorization: token $(gh auth token)" \
+  --data-binary "@$FILE" | jq -r .url)"
+case "$URL" in https://*) ;; *) echo "upload failed: $URL" >&2; exit 1;; esac
+
+gh pr comment <N> --repo "$REPO" --body "![before/after]($URL)"
+```
+
+Verify a `https://` URL came back before embedding — a failed upload must fail
+the step, not silently post a broken image. For a follow-up fix on an existing
+PR, post a **comment** rather than rewriting the description, so the
+investigation reads in order.
+
+Caption every image. State what the reader should look at ("green gap-fill bead
+runs under the red top surface"), not just what it is.
+
+## Writing it up
+
+Structure the PR body / comment as: **symptom → root cause → fix → evidence.**
+
+- **Symptom** in the user's words where possible.
+- **Root cause** — the actual mechanism, named concretely (which boolean, which
+  region, which winding). "Fixed infill bug" is not a root cause.
+- **Fix** — and why *this* fix rather than the obvious one. If you attacked a
+  cause instead of a symptom, say so; that is the reviewable decision.
+- **Evidence** — the image, a small table of numbers, and the `classic`
+  comparison.
+
+Prefer removing the cause over filtering the symptom, and say which you did. A
+minimum-length filter that hides short artifacts leaves the *long* artifacts
+from the same broken region in place; erasing the region fixes both.
+
+## Gotchas that have burned this repo
+
+- **Parsing G-code:** a move only extrudes if E **increased** *and* X/Y changed.
+  Retract, un-retract, prime and Z-hop all change E without moving — counting
+  them creates phantom zero-length paths and wrecks every statistic.
+- **Path vs. segment:** a *path* is a contiguous run of extruding moves between
+  travels. "Tiny extrude" defects are about **paths** (each costs a
+  retract/travel/un-retract); per-segment counts are meaningless here because a
+  long bead is made of many short segments.
+- **Stale output.** Re-slice after *every* rebuild and confirm the binary is
+  current. More than one wrong conclusion here came from measuring a `.gcode`
+  produced by the previous build.
+- **Ring vs. hole.** A region that should be solid but prints as two bands is
+  usually a CCW outer contour with a **CW hole** punched in it. Check
+  `signed_area()` per sub-path in the `--debug-geometry` SVG — a negative area
+  is a hole. That single check found the rail-roof defect.
+- **Debug SVG flips Y.** Negate Y when comparing SVG coordinates to G-code.
+- **Layer indexing.** These scripts are 1-based over `;LAYER_CHANGE`; the UI
+  viewer may number differently. Confirm via `;Z:` before claiming a layer
+  number, and quote the Z height alongside it.
+- **Do not name a helper module `gc.py`** — it shadows Python's built-in `gc`
+  and the import fails confusingly.
+
+## See also
+
+- [`tools/gcode-analysis/README.md`](../../tools/gcode-analysis/README.md) — the full toolkit.
+- `AGENTS.md` → "Slicing Pipeline — Deep Knowledge" — the invariants a geometry
+  change must not break. **Update it** when a change teaches something new.

--- a/.github/instructions/slicing-visual-verification.instructions.md
+++ b/.github/instructions/slicing-visual-verification.instructions.md
@@ -96,7 +96,38 @@ Measure across several models (`3DBenchy.stl`, `Voron_Design_Cube_v7.stl`,
 tuned to one shape, and state explicitly that no model got worse. Always report
 the **cost** (material or path length lost) next to the win.
 
-### 4. Attach it to the PR
+### 4. Run the slicing quality gate — locally, before pushing
+
+**This is not optional and it is easy to forget:** the gate is `#[ignore]`d, so
+a plain `cargo test` skips it and reports all-green on a change that CI will
+reject.
+
+```bash
+QA_FULL=1 cargo test --test slicing_quality -- --ignored
+```
+
+It slices the whole fixture corpus with both generators and fails on any metric
+drifting >5 % from `tests/qa/baselines/*.json`. It exists precisely to catch the
+model you *didn't* look at.
+
+It works. A morphological opening of the infill area, validated by eye and by
+metrics on the Benchy, looked like a clean win — and the gate caught that it had
+erased 35 % of the filament caddy's infill (`caddy/classic: role infill
+13170.1 -> 8505.5`), a fixture whose thin hollow-box lattice the change could
+not distinguish from an artifact.
+
+When it fails, **read the failing fixture before touching the baselines**:
+
+- A **`classic`** delta from a change meant to affect only Arachne is a red flag
+  — investigate, don't rebaseline.
+- Reproduce the flagged case, render it, and confirm the new output is
+  genuinely better. If it is not, the *fix* is wrong, not the baseline.
+- Only when a delta is the intended, verified effect, refresh with
+  `QA_FULL=1 UPDATE_QA_BASELINES=1 cargo test --test slicing_quality -- --ignored`,
+  then **diff `tests/qa/baselines/` and justify every line** in the commit
+  message. An unexplained baseline movement is a silent regression.
+
+### 5. Attach it to the PR
 
 Upload the PNG to GitHub's user-attachments API and embed the returned URL. Keep
 untrusted values in quoted shell variables and let `--url-query` encode them.
@@ -162,6 +193,15 @@ from the same broken region in place; erasing the region fixes both.
 - **Layer indexing.** These scripts are 1-based over `;LAYER_CHANGE`; the UI
   viewer may number differently. Confirm via `;Z:` before claiming a layer
   number, and quote the Z height alongside it.
+- **A thin channel is not automatically an artifact.** A sliver left by
+  subtracting a *solid region* is one; a thin wall-to-wall cavity in a hollow
+  box is a real feature whose lattice must survive. Key such a correction to the
+  thing that *caused* the sliver (here, `solid_regions`) so it is a provable
+  no-op elsewhere — never to the infill area as a whole.
+- **`git stash` in a shared worktree.** Check `git stash list` first: a `pop`
+  can restore *someone else's* older stash if your own `stash -u` found nothing
+  to save. Prefer `git checkout <ref> -- <paths>` for temporary A/B builds, and
+  verify `git status` afterwards.
 - **Do not name a helper module `gc.py`** — it shadows Python's built-in `gc`
   and the import fails confusingly.
 

--- a/.github/instructions/slicing-visual-verification.instructions.md
+++ b/.github/instructions/slicing-visual-verification.instructions.md
@@ -1,212 +1,69 @@
 ---
-description: "Use when changing anything that alters sliced G-code geometry — walls, infill, surfaces, gap fill, bridges, adhesion, ordering — and when opening or updating a PR for such a change. Defines the visual verification contract: render the actual toolpaths as capsules at their true bead width, before vs. after, and attach that image to the PR so a human can check the result without re-deriving the math."
-name: "Slicing Changes: Prove It With a Picture"
+description: "Use when a code change alters sliced geometry. Keep verification simple: generate before/after images of real bead geometry and attach them to the PR."
+name: "Slicing Changes: Picture-First Verification"
 applyTo: "src/core/**, src/walls/**, src/infill/**, src/adhesion/**, src/gcode/**, tools/gcode-analysis/**"
 ---
 
-# Slicing Changes — Prove It With a Picture
+# Slicing Changes: Picture-First Verification
 
-Slicing is computational geometry: Clipper2 booleans, offsets, medial axes,
-winding rules, scanlines. A reviewer **cannot** check that kind of change by
-reading a diff, and neither can the author. Numbers alone are not enough either
-— they are summaries, and summaries hide things.
+If geometry changes, always show a **before/after picture** in the PR.
 
-So: **every change that alters sliced geometry ships with a before/after render
-of the real toolpaths, attached to the PR.** The picture is the artifact that
-lets a human agree or disagree in five seconds.
+## 1) Slice before and after with identical settings
 
-This is not decoration. It is the verification step.
-
-## The one rule that matters: draw beads at their true width
-
-**Never verify with a centerline plot.** Centerlines lie.
-
-Two beads whose centerlines sit 0.3 mm apart look like two tidy, separate lines.
-Drawn at their real 0.4–0.56 mm widths they are visibly **the same material laid
-down twice**. That is the difference between "looks fine" and a defect.
-
-This is not hypothetical. On the 3DBenchy rear rail a gap-fill bead ran directly
-underneath the top-surface fill — 6 mm² per layer of genuine double extrusion.
-It was invisible in a centerline plot, and `overlap.py` *also* missed it because
-its ¼-nozzle erosion is designed to strip expected boundary seams and it ate the
-thin bead entirely. A true-width capsule render showed it instantly.
-
-Corollary: **when a metric says "clean" but the part looks wrong, trust the
-picture and go find out why the metric lied.** A metric that disagrees with the
-geometry is a bug in the metric's applicability, not a clean bill of health.
-
-## Workflow
-
-### 1. Slice both states
-
-Build and slice the parent commit and your HEAD with identical settings. Only
-the code may differ.
+Only the code may differ.
 
 ```bash
 printf '[slicing]\nwall_generator = "arachne"\n' > /tmp/ar.toml
 
-git stash -u                                     # park work in progress
-git checkout <parent> -- src/core/ src/walls/    # or check out the parent commit
-cargo build && ./target/debug/slicer-engine slice -i 3DBenchy.stl \
-    --config /tmp/ar.toml -o /tmp/before.gcode
+# before
+git checkout <parent> -- src/core/ src/walls/ src/infill/ src/adhesion/ src/gcode/
+cargo build
+./target/debug/slicer-engine slice -i 3DBenchy.stl --config /tmp/ar.toml -o /tmp/before.gcode
 
-git checkout HEAD -- src/core/ src/walls/ && git stash pop
-cargo build && ./target/debug/slicer-engine slice -i 3DBenchy.stl \
-    --config /tmp/ar.toml -o /tmp/after.gcode
+# after
+git checkout HEAD -- src/core/ src/walls/ src/infill/ src/adhesion/ src/gcode/
+cargo build
+./target/debug/slicer-engine slice -i 3DBenchy.stl --config /tmp/ar.toml -o /tmp/after.gcode
 ```
 
-Always confirm the tree is restored (`git status`) before moving on.
+## 2) Render real beads (not centerlines)
 
-### 2. Render the diff
-
-[`tools/gcode-analysis/beaddiff.py`](../../tools/gcode-analysis/beaddiff.py)
-does the before/after capsule render, role-coloured, on a shared scale, and
-counts isolated short paths (the "tiny extrude / splat" defect class) in each
-title:
+Use the existing tool:
 
 ```bash
-# whole layer, auto-fit
+# whole layer
 python3 tools/gcode-analysis/beaddiff.py /tmp/before.gcode /tmp/after.gcode 41 /tmp/diff.png
 
-# zoom a feature: cx cy half-window, flag anything under 1.5 mm
+# zoomed area
 python3 tools/gcode-analysis/beaddiff.py /tmp/before.gcode /tmp/after.gcode \
-    201 /tmp/rail.png 0.9 -12 2.2 --short=1.5
+  201 /tmp/zoom.png 0.9 -12 2.2 --short=1.5
 ```
 
-Pick the layer that shows the defect, not a layer that shows nothing. If the
-change is meant to be a no-op somewhere, render that too — an unchanged panel is
-evidence.
+Pick the layer/zoom where the change is visible.
 
-Related tools, all in [`tools/gcode-analysis/`](../../tools/gcode-analysis/README.md):
-`zoom.py` (single-file capsules), `voids.py` (unfilled wall-zone gaps),
-`overlap.py` (cross-role double extrusion), `widthdist.py`,
-`coincident.py`. `--debug-geometry <dir>` dumps the *regions* (interior, solid
-surface, infill) as SVG when you need to see what the booleans produced rather
-than what was printed.
+## 3) Attach image(s) to the PR
 
-### 3. Pair the picture with numbers, and with `classic`
-
-The image shows *what* changed; the numbers show it generalises and costs
-little. Report both, and compare against the **`classic` wall generator** — the
-trusted reference. "Better than before" is weak; "and still well inside what
-classic does" is an argument.
-
-Measure across several models (`3DBenchy.stl`, `Voron_Design_Cube_v7.stl`,
-`Filament_Card_Caddy_25.stl`, `bottom_panel_hinge_x2.stl`) so the fix is not
-tuned to one shape, and state explicitly that no model got worse. Always report
-the **cost** (material or path length lost) next to the win.
-
-### 4. Run the slicing quality gate — locally, before pushing
-
-**This is not optional and it is easy to forget:** the gate is `#[ignore]`d, so
-a plain `cargo test` skips it and reports all-green on a change that CI will
-reject.
+Upload and post:
 
 ```bash
-QA_FULL=1 cargo test --test slicing_quality -- --ignored
-```
-
-It slices the whole fixture corpus with both generators and fails on any metric
-drifting >5 % from `tests/qa/baselines/*.json`. It exists precisely to catch the
-model you *didn't* look at.
-
-It works. A morphological opening of the infill area, validated by eye and by
-metrics on the Benchy, looked like a clean win — and the gate caught that it had
-erased 35 % of the filament caddy's infill (`caddy/classic: role infill
-13170.1 -> 8505.5`), a fixture whose thin hollow-box lattice the change could
-not distinguish from an artifact.
-
-When it fails, **read the failing fixture before touching the baselines**:
-
-- A **`classic`** delta from a change meant to affect only Arachne is a red flag
-  — investigate, don't rebaseline.
-- Reproduce the flagged case, render it, and confirm the new output is
-  genuinely better. If it is not, the *fix* is wrong, not the baseline.
-- Only when a delta is the intended, verified effect, refresh with
-  `QA_FULL=1 UPDATE_QA_BASELINES=1 cargo test --test slicing_quality -- --ignored`,
-  then **diff `tests/qa/baselines/` and justify every line** in the commit
-  message. An unexplained baseline movement is a silent regression.
-
-### 5. Attach it to the PR
-
-Upload the PNG to GitHub's user-attachments API and embed the returned URL. Keep
-untrusted values in quoted shell variables and let `--url-query` encode them.
-
-```bash
-FILE='/tmp/diff.png'; NAME='benchy-layer41-before-after.png'; MIME='image/png'
+FILE='/tmp/diff.png'; NAME='before-after.png'; MIME='image/png'
 REPO='<owner>/<repo>'
 REPO_ID="$(gh api "repos/$REPO" --jq .id)"
 URL="$(curl --fail-with-body -sS -X POST \
   "https://uploads.github.com/user-attachments/assets" \
-  --url-query "name=$NAME" --url-query "content_type=$MIME" \
+  --url-query "name=$NAME" \
+  --url-query "content_type=$MIME" \
   --url-query "repository_id=$REPO_ID" \
   -H "Content-Type: application/octet-stream" \
   -H "X-GitHub-Api-Version: 2022-11-28" \
   -H "Authorization: token $(gh auth token)" \
   --data-binary "@$FILE" | jq -r .url)"
-case "$URL" in https://*) ;; *) echo "upload failed: $URL" >&2; exit 1;; esac
-
 gh pr comment <N> --repo "$REPO" --body "![before/after]($URL)"
 ```
 
-Verify a `https://` URL came back before embedding — a failed upload must fail
-the step, not silently post a broken image. For a follow-up fix on an existing
-PR, post a **comment** rather than rewriting the description, so the
-investigation reads in order.
+Add one short caption: what to look at.
 
-Caption every image. State what the reader should look at ("green gap-fill bead
-runs under the red top surface"), not just what it is.
+## Optional helpers
 
-## Writing it up
-
-Structure the PR body / comment as: **symptom → root cause → fix → evidence.**
-
-- **Symptom** in the user's words where possible.
-- **Root cause** — the actual mechanism, named concretely (which boolean, which
-  region, which winding). "Fixed infill bug" is not a root cause.
-- **Fix** — and why *this* fix rather than the obvious one. If you attacked a
-  cause instead of a symptom, say so; that is the reviewable decision.
-- **Evidence** — the image, a small table of numbers, and the `classic`
-  comparison.
-
-Prefer removing the cause over filtering the symptom, and say which you did. A
-minimum-length filter that hides short artifacts leaves the *long* artifacts
-from the same broken region in place; erasing the region fixes both.
-
-## Gotchas that have burned this repo
-
-- **Parsing G-code:** a move only extrudes if E **increased** *and* X/Y changed.
-  Retract, un-retract, prime and Z-hop all change E without moving — counting
-  them creates phantom zero-length paths and wrecks every statistic.
-- **Path vs. segment:** a *path* is a contiguous run of extruding moves between
-  travels. "Tiny extrude" defects are about **paths** (each costs a
-  retract/travel/un-retract); per-segment counts are meaningless here because a
-  long bead is made of many short segments.
-- **Stale output.** Re-slice after *every* rebuild and confirm the binary is
-  current. More than one wrong conclusion here came from measuring a `.gcode`
-  produced by the previous build.
-- **Ring vs. hole.** A region that should be solid but prints as two bands is
-  usually a CCW outer contour with a **CW hole** punched in it. Check
-  `signed_area()` per sub-path in the `--debug-geometry` SVG — a negative area
-  is a hole. That single check found the rail-roof defect.
-- **Debug SVG flips Y.** Negate Y when comparing SVG coordinates to G-code.
-- **Layer indexing.** These scripts are 1-based over `;LAYER_CHANGE`; the UI
-  viewer may number differently. Confirm via `;Z:` before claiming a layer
-  number, and quote the Z height alongside it.
-- **A thin channel is not automatically an artifact.** A sliver left by
-  subtracting a *solid region* is one; a thin wall-to-wall cavity in a hollow
-  box is a real feature whose lattice must survive. Key such a correction to the
-  thing that *caused* the sliver (here, `solid_regions`) so it is a provable
-  no-op elsewhere — never to the infill area as a whole.
-- **`git stash` in a shared worktree.** Check `git stash list` first: a `pop`
-  can restore *someone else's* older stash if your own `stash -u` found nothing
-  to save. Prefer `git checkout <ref> -- <paths>` for temporary A/B builds, and
-  verify `git status` afterwards.
-- **Do not name a helper module `gc.py`** — it shadows Python's built-in `gc`
-  and the import fails confusingly.
-
-## See also
-
-- [`tools/gcode-analysis/README.md`](../../tools/gcode-analysis/README.md) — the full toolkit.
-- `AGENTS.md` → "Slicing Pipeline — Deep Knowledge" — the invariants a geometry
-  change must not break. **Update it** when a change teaches something new.
+- `tools/gcode-analysis/zoom.py` for single-file closeups.
+- `tools/gcode-analysis/voids.py` and `tools/gcode-analysis/overlap.py` for extra numeric checks.

--- a/AGENTS.md
+++ b/AGENTS.md
@@ -506,6 +506,31 @@ and is kept (sparse infill would skip that sub-nozzle channel). Model-wide this
 took `GapFill × TopSurface` from 7.3 → 0.5 mm² by pruning ~3 long beads, with no
 new wall-zone void where the surface already covers the strip.
 
+**The solid surface must _cover_ a sandwiched gap bead's footprint, not carve
+it out.** Pruning the redundant bead (above) is only half the fix: if the
+surface region still has the bead-wide corridor carved out of it, that corridor
+becomes a **hole** in `solid_regions`. On a thin roof (the 3DBenchy rear rail,
+≈ layer 201) the hole (a) splits the top-surface serpentine into **two
+disconnected bands** and (b) is re-filled by **sparse-infill dashes** over the
+void the pruned bead left — the "two infill surfaces plus tiny blobs of goo"
+defect. The corridor was carved from **two** places, so both must stop carving a
+sandwiched bead:
+
+- `blocked_for_surface`'s explicit gap-fill term now uses
+  `compute_gap_fill_footprint_excluding_sandwiched`, and
+- `compute_wall_bead_footprint` — which also lists `GapFill` — is called with
+  `include_gap_fill = false` for the surface trim (the walls-only variant),
+  because the gap fill is accounted for by that separate, sandwich-aware term.
+
+The sandwich test there runs against the layer's **combined detected surface**
+(`combined_surface_region(bridge, bottom, top)`, pre-trim) so a centre bead is
+recognised as redundant before the trim would hole the surface. Result: the roof
+fills as **one** solid region, the bead is pruned, and no sparse infill leaks in.
+Genuine one-sided necks are still carved (surface abuts, never welds). Verify
+with a true-width capsule render (grey wall + one red top surface, no green bead,
+no orange dash) and the debug SVG (`--debug-geometry`): the rail `solid_surface`
+must be **one CCW polygon**, not a CCW ring with a CW hole.
+
 ### Clipper2 Fill Rules — When to Use Which
 
 | Operation                                                                 | Fill rule  | Why                                                                                                                                    |

--- a/AGENTS.md
+++ b/AGENTS.md
@@ -629,6 +629,36 @@ is why the Arachne `gap_fill` role length rises after the fix.
 then subtracts the eroded wall-bead footprint before generating solid infill
 lines.
 
+**The sparse-infill area is morphologically _opened_ before the scanline runs.**
+That area is `interior − solid_regions − gap_fill − wall_band`, and each of
+those boundaries is jagged in its own way — most of all the solid surface, whose
+edge follows its rectilinear fill's **stepped serpentine extent**. The result is
+a thin crescent **sliver** surviving between the solid region and the wall band
+all along a curved perimeter (plainly visible on the 3DBenchy hull, layers
+≈ 40–42). The scanline shatters that sliver into a swarm of sub-millimetre
+dashes — 31 on layer 41 alone — each an isolated dab that costs a full
+retract → travel → un-retract to reach. That cycle pushes ~4.8 mm³ of filament
+back and forth through the nozzle to deposit ~0.04 mm³: the "infill produces
+tiny extrudes" defect, pure waste and a grinding risk, with zero structural
+gain (the sliver is already flanked by the solid surface on one side and a wall
+bead on the other).
+
+`add_infill_to_layers` therefore applies `morphological_open` at
+`INFILL_MIN_CHANNEL_WIDTH_NOZZLE_MULT × nozzle / 2`, erasing channels narrower
+than `2.5 × nozzle` (1.0 mm at 0.4 mm). The multiplier deliberately **matches
+`SURFACE_MIN_INTERIOR_WIDTH_NOZZLE_MULT`**: that is already the minimum width an
+interior must reach to host a *rectilinear top/bottom surface fill*, and sparse
+infill is the same rectilinear-fill-in-a-thin-channel problem — only less
+critical, being a sparse lattice rather than a solid skin.
+
+Attack the **cause** (the sliver region), not the symptom: a plain
+minimum-length filter keeps the *longer* but equally useless dashes inside the
+same sliver, whereas the opening removes the whole channel. `min_infill_extrusion_mm`
+still guards the residual sub-threshold segments a legitimate region's tapering
+corners produce. Measured: isolated sparse dashes 114 → 21 (3DBenchy), 45 → 23
+(Voron cube), 2 → 0 (filament caddy), never worse — for **0.28 %** of infill
+length, with wall-zone void still less than half the `classic` reference.
+
 ### Thin Wall-Band Channels — Opened-Interior Surface Clip
 
 `calculate_interior_region` uses a **per-island _average_** wall count

--- a/AGENTS.md
+++ b/AGENTS.md
@@ -629,35 +629,43 @@ is why the Arachne `gap_fill` role length rises after the fix.
 then subtracts the eroded wall-bead footprint before generating solid infill
 lines.
 
-**The sparse-infill area is morphologically _opened_ before the scanline runs.**
-That area is `interior − solid_regions − gap_fill − wall_band`, and each of
-those boundaries is jagged in its own way — most of all the solid surface, whose
-edge follows its rectilinear fill's **stepped serpentine extent**. The result is
-a thin crescent **sliver** surviving between the solid region and the wall band
-all along a curved perimeter (plainly visible on the 3DBenchy hull, layers
-≈ 40–42). The scanline shatters that sliver into a swarm of sub-millimetre
-dashes — 31 on layer 41 alone — each an isolated dab that costs a full
-retract → travel → un-retract to reach. That cycle pushes ~4.8 mm³ of filament
-back and forth through the nozzle to deposit ~0.04 mm³: the "infill produces
-tiny extrudes" defect, pure waste and a grinding risk, with zero structural
-gain (the sliver is already flanked by the solid surface on one side and a wall
-bead on the other).
+**`solid_regions` is grown by one bead before being subtracted from the
+sparse-infill area.** `solid_regions` is a nominal polygon, but the surface is
+actually printed as a rectilinear serpentine whose **stepped extent** only
+approximates it, and the surface pass has already trimmed it back off the wall
+band. Subtracting the raw outline therefore leaves a thin crescent **sliver**
+between the solid region and the wall all along a curved perimeter (plainly
+visible on the 3DBenchy hull, layers ≈ 40–42). The scanline shatters that sliver
+into a swarm of sub-millimetre dashes — 31 on layer 41 alone — each an isolated
+dab costing a full retract → travel → un-retract. That cycle pushes ~4.8 mm³ of
+filament back and forth through the nozzle to deposit ~0.04 mm³: the "infill
+produces tiny extrudes" defect, pure waste and a grinding risk, with zero
+structural gain (the space is already flanked by the solid surface on one side
+and a wall bead on the other).
 
-`add_infill_to_layers` therefore applies `morphological_open` at
-`INFILL_MIN_CHANNEL_WIDTH_NOZZLE_MULT × nozzle / 2`, erasing channels narrower
-than `2.5 × nozzle` (1.0 mm at 0.4 mm). The multiplier deliberately **matches
-`SURFACE_MIN_INTERIOR_WIDTH_NOZZLE_MULT`**: that is already the minimum width an
-interior must reach to host a *rectilinear top/bottom surface fill*, and sparse
-infill is the same rectilinear-fill-in-a-thin-channel problem — only less
-critical, being a sparse lattice rather than a solid skin.
+`add_infill_to_layers` therefore subtracts `inflate(solid_regions,
+SOLID_MARGIN_NOZZLE_MULT × nozzle)` — one bead width, since the surface's own
+fill lines are `d` wide about their centerlines and the nominal polygon
+under-states the deposited material by up to half a bead per side. Measured on
+3DBenchy layer 41: isolated sub-1.5 mm infill paths fall 33 → 6 at `1.0`, while
+`0.5` leaves all 33 (the sliver is simply wider than half a bead).
 
-Attack the **cause** (the sliver region), not the symptom: a plain
-minimum-length filter keeps the *longer* but equally useless dashes inside the
-same sliver, whereas the opening removes the whole channel. `min_infill_extrusion_mm`
-still guards the residual sub-threshold segments a legitimate region's tapering
-corners produce. Measured: isolated sparse dashes 114 → 21 (3DBenchy), 45 → 23
-(Voron cube), 2 → 0 (filament caddy), never worse — for **0.28 %** of infill
-length, with wall-zone void still less than half the `classic` reference.
+**Key this correction to `solid_regions`, never to the infill area as a whole.**
+Doing so makes it an exact **no-op on layers with no solid surface**, so a
+genuinely thin wall-to-wall cavity keeps its full sparse lattice. A first
+attempt instead morphologically **opened** the whole infill area to erase
+channels narrower than `2.5 × nozzle`. That cannot distinguish an artifact
+sliver from a real thin cavity: it erased the filament caddy's hollow-box
+lattice outright — wall-zone void more than doubled (62 → 146 mm²) and 35 % of
+its infill vanished — and the **slicing quality gate caught it**
+(`caddy/classic: role infill 13170.1 → 8505.5`). A sweep confirmed there is no
+safe threshold for that approach: even `1.0 × nozzle` destroyed the caddy
+lattice while artifacts only cleared at `≥ 1.5`. The regression test
+`test_thin_cavity_without_solid_surface_keeps_its_infill` pins the correct
+behaviour.
+
+`min_infill_extrusion_mm` still guards the residual sub-threshold segments a
+legitimate region's tapering corners produce.
 
 ### Thin Wall-Band Channels — Opened-Interior Surface Clip
 

--- a/AGENTS.md
+++ b/AGENTS.md
@@ -728,6 +728,49 @@ inside the walls, are rounded). Key points:
   `… × Bridge` overlap pair on the Benchy matches `classic` to within noise
   (`Gap infill × Bridge` 8.6 → 0, `Inner wall × Bridge` 8.3 → 0.16 = classic).
 
+### Sub-Bead Slivers — Grazing-Angle Surface Fill
+
+The wall-band trim above subtracts the eroded wall-bead footprint from a surface
+region whose outline does **not** follow that footprint exactly. Where the two
+boundaries meet at a **grazing angle** the subtraction leaves a long crescent far
+narrower than one bead. The scanline still fills it, but because the fill
+direction is then near-parallel to the crescent **every span is a stub**.
+
+Measured on the Filament Card Caddy's hexagon logo (0.44 mm extrusion,
+`wall_count = 3`): the `solid_surface` region carried separate sliver sub-paths
+of ≈4.5 mm² and ≈0.22 mm mean width along exactly the two hexagon edges lying
+15° off the fill direction. A 135° scanline crossing a 0.22 mm strip at 150°
+gives span `0.22/sin 15° ≈ 0.85 mm` — matching the observed repeating
+**0.82 mm line / 0.62 mm connector** micro-serpentine. **93 % of that material
+was already covered** by the flanking wall bead or the normal surface, so it
+bought ≈0.5 mm² of real coverage for ~20 mm of sub-millimetre moves.
+
+`open_surface_region_for_fill` (applied to `bottom_region` / `top_region` after
+the wall-band trim, before `add_solid_infill_for_region`) removes them:
+
+- **Threshold is physical, not heuristic.** Erode by
+  `SURFACE_FILL_MIN_WIDTH_FRACTION (0.5) × solid-surface extrusion width`, i.e.
+  an erosion *diameter* of exactly one bead. A strip narrower than one bead
+  cannot hold a bead by construction.
+- **It is a _width_ filter, not an area filter.** Small-but-printable surfaces
+  survive intact (measured: 79 mm² and 37 mm² regions untouched while six
+  slivers went to zero).
+- **Corners are preserved.** A plain morphological opening rounds convex
+  corners, and a rounded corner makes the scanline emit *extra* stub spans —
+  the very artifact being removed (measured +31 stubs on the Voron cube). So
+  the surviving core is re-grown by `SURFACE_FILL_REGROW_FACTOR (2.0) × radius`
+  and **clipped back to the original region**, restoring exact original shape.
+  That took the cube from +31 stubs to −1.
+- Use **`FillRule::NonZero`** for the final clip so CW hole sub-paths stay holes.
+- This defect is **not** Arachne-specific — `arachne` and `classic` produced
+  byte-identical stub measurements on the caddy hexagon, because it originates
+  in the surface fill, not the wall generator.
+
+Measured effect (user profile, whole model): coverage change ≤ 0.004 % on
+Benchy / Voron cube / caddy, with sub-1 mm segments −19 / −1 / −55 and the
+caddy's two grazing edges dropping **22.9 → 2.4 mm** and **24.1 → 2.8 mm** of
+sub-1 mm top surface. QA gate passes with **no baseline drift**.
+
 ### `generate_rectilinear_infill` — Scanline Even-Odd Fill
 
 The scanline fills cells using an even-odd intersection count (pairs of sorted

--- a/AGENTS.md
+++ b/AGENTS.md
@@ -471,6 +471,41 @@ count, ~3× the mean bead length, no void-coverage change). Keep that floor near
 spurs, and a much larger floor erodes genuine sub-millimetre features into
 voids. Walls are untouched, so this never affects the coincidence-free property.
 
+**Isolated gap-fill "splat" beads are dropped by a `2·d` minimum run length.**
+Separate from the *spur* prune above, `emit_medial_beads` and the residual
+pre-filter (`emit_residual_medial_fill`) both discard any emitted gap-fill *run*
+shorter than [`gap_fill_min_run_len_mm`](src/walls/arachne/generate.rs) —
+`gap_fill_min_length_mm` when the user set it (`> 0`), else `2·d` (0.8 mm at a
+0.4 mm nozzle). The old auto-default was `d`, which let ~270 sub-`2·d` beads
+survive on the 3DBenchy: each an isolated dab of material that still costs a full
+retract → travel → un-retract to reach — the "tiny inner-body splat" that wastes
+time and grinds filament. The residual such a splat would fill is bridged by the
+squish of the flanking wall beads, so `classic` (which has no gap fill) leaves
+the same curved/tapering wall corners bead-free with **no** measurable wall-zone
+void (`voids.py`). Matching the spur floor is deliberate: a run below the same
+`2·d` that separates a real gap spine from facet noise *is* facet noise once
+isolated as its own bead.
+
+**Redundant gap fill *under* a solid surface is pruned two ways.**
+[`prune_redundant_gap_fill`](src/core/surfaces.rs) drops a `GapFill` bead when
+either (1) a majority of its vertices lie **inside** `solid_regions`, or (2) it
+is **sandwiched** — solid surface on *both* perpendicular sides
+(`gap_fill_sandwiched_by_surface`). Case (2) exists because
+`blocked_for_surface` unions the gap-fill footprint *out* of the surface region
+(so the surface *abuts* genuine thin necks), which carves a bead-wide corridor
+in `solid_regions` exactly where each bead sits — so a bead running down the
+centre of a thin solid strip is never "inside" the surface, yet the surface's
+full-width rectilinear zig-zag still deposits straight over it. Measured on the
+3DBenchy rear rail (≈ layer 200): 6 mm²/layer of `GapFill × TopSurface`
+double-extrusion that a footprint-erosion overlap scan (`overlap.py`) *hides*
+because the bead is thin — use a true-width capsule intersection to see it. The
+sandwich probe reaches `half-width + 0.5·d` to either side, just past the carved
+corridor: a bead the surface *surrounds* has surface on both probes and is
+dropped; a genuine neck that merely *abuts* a surface edge has it on at most one
+and is kept (sparse infill would skip that sub-nozzle channel). Model-wide this
+took `GapFill × TopSurface` from 7.3 → 0.5 mm² by pruning ~3 long beads, with no
+new wall-zone void where the surface already covers the strip.
+
 ### Clipper2 Fill Rules — When to Use Which
 
 | Operation                                                                 | Fill rule  | Why                                                                                                                                    |

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -106,13 +106,27 @@ these notes and acknowledges contributors. `scripts/gen-changelog-draft.sh` and
     that leaked sparse-infill dashes. A bead that merely abuts a surface on one
     side (a genuine thin neck) is still kept and abutted. Cut model-wide
     gap-fill-under-surface double-extrusion from 7.3 → 0.5 mm² with no new voids.
-- **Tiny sparse-infill "splat" dashes** — `min_infill_extrusion_mm` (default
-  0.4 mm) now also filters *sparse* infill, not just solid surface fill.
-  Isolated sub-threshold infill dashes in narrow corners — each a full
-  retract/travel/un-retract for a mechanically-insignificant dab — are dropped.
-  Combined with the gap-fill fixes this cut isolated sub-0.8 mm extrusions on the
-  3DBenchy by ~68 % (356 → 114) and removed ~160 retract cycles, with no change
-  to strength (the flanking walls fill the corner).
+- **Tiny sparse-infill "splat" dashes** — two complementary fixes:
+  - The sparse-infill area is now **morphologically opened** before the scanline
+    runs, erasing channels narrower than `2.5 × nozzle` (matching the existing
+    minimum width for a rectilinear *surface* fill). The infill area is
+    `interior − solid − gap fill − wall band`, and the solid surface's stepped
+    serpentine edge left a thin crescent sliver hugging the wall all along a
+    curved perimeter; the scanline shattered it into a swarm of sub-millimetre
+    dashes (31 on one 3DBenchy layer alone), each an isolated dab costing a full
+    retract/travel/un-retract for no structural gain — the sliver is already
+    flanked by the solid surface on one side and a wall bead on the other.
+    Removing the sliver itself also clears the *longer* useless dashes inside it
+    that a minimum-length filter would keep. Isolated sparse dashes drop
+    114 → 21 (3DBenchy), 45 → 23 (Voron cube), 2 → 0 (filament caddy), never
+    worse — for 0.28 % of infill length and no new wall-zone void.
+  - `min_infill_extrusion_mm` (default 0.4 mm) now also filters *sparse* infill,
+    not just solid surface fill, catching the residual sub-threshold segments a
+    legitimate region's tapering corners produce.
+
+  Together with the gap-fill fixes this cut isolated sub-0.8 mm extrusions on the
+  3DBenchy by ~94 % (356 → 21) and removed ~300 retract cycles, with no change
+  to strength (the flanking walls and solid surface fill the space).
 
 - **iPad Apple Pencil + two-finger navigation "spazzing"** — palm rejection
   classified each touch on its own, so a stylus user's two-finger pan/pinch could

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -96,17 +96,22 @@ these notes and acknowledges contributors. `scripts/gen-changelog-draft.sh` and
     beads would have filled is covered by the squish of the flanking wall beads,
     so no wall-zone void opens (verified against the `classic` generator).
   - A redundant gap-fill bead running down the centre of a thin solid strip
-    (e.g. the Benchy rear rail, ≈ layer 200) that double-extruded straight under
-    the top-surface fill is now pruned. Gap fill sandwiched by solid surface on
-    both sides is removed as redundant, while a bead that merely abuts a surface
-    on one side (a genuine thin neck) is kept. Cut model-wide gap-fill-under-
-    surface double-extrusion from 7.3 → 0.5 mm² with no new voids.
+    (e.g. the Benchy rear-rail roof, ≈ layer 201) that double-extruded straight
+    under the top-surface fill is now pruned **and** the solid surface fills the
+    strip in its place. Gap fill sandwiched by solid surface on both sides is
+    removed as redundant; crucially the surface no longer carves that bead's
+    footprint out of itself (neither via its explicit gap-fill term nor via the
+    shared wall-bead footprint, which also lists gap fill), so the roof fills as
+    **one** coherent top surface instead of a split ring with a central hole
+    that leaked sparse-infill dashes. A bead that merely abuts a surface on one
+    side (a genuine thin neck) is still kept and abutted. Cut model-wide
+    gap-fill-under-surface double-extrusion from 7.3 → 0.5 mm² with no new voids.
 - **Tiny sparse-infill "splat" dashes** — `min_infill_extrusion_mm` (default
   0.4 mm) now also filters *sparse* infill, not just solid surface fill.
   Isolated sub-threshold infill dashes in narrow corners — each a full
   retract/travel/un-retract for a mechanically-insignificant dab — are dropped.
   Combined with the gap-fill fixes this cut isolated sub-0.8 mm extrusions on the
-  3DBenchy by ~66 % (356 → 120) and removed ~160 retract cycles, with no change
+  3DBenchy by ~68 % (356 → 114) and removed ~160 retract cycles, with no change
   to strength (the flanking walls fill the corner).
 - **3MF models loaded at the wrong scale** — the 3MF importer ignored the
   `<model unit="…">` declaration and read every coordinate as raw millimeters, so

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -85,6 +85,24 @@ these notes and acknowledges contributors. `scripts/gen-changelog-draft.sh` and
 
 ### Fixed
 
+- **Top-surface "squiggles" where solid fill grazes a wall** — a surface whose
+  boundary meets the wall band at a shallow angle was filled with a dense
+  micro-serpentine of sub-millimetre stubs hugging the wall, interleaved with
+  unfilled wedge voids. The wall-band trim leaves a crescent narrower than one
+  bead there, and because the fill direction is near-parallel to it every
+  scanline span is a stub. On the Filament Card Caddy's hexagon logo the two
+  edges lying 15° off the fill direction carried ≈0.22 mm-wide slivers filled
+  with a repeating 0.8 mm-line / 0.6 mm-connector zig-zag whose material was
+  **93 % already covered** by the flanking wall bead. Solid top/bottom surface
+  regions are now width-filtered before filling: anything narrower than one
+  extrusion width is dropped (it cannot hold a bead by construction), while
+  thicker geometry is preserved at its **exact original shape**, sharp corners
+  included. The two affected caddy edges drop from 22.9 → 2.4 mm and
+  24.1 → 2.8 mm of sub-1 mm top surface with total material coverage unchanged
+  (≤ 0.004 % on Benchy, Voron cube and caddy alike). This was **not** an
+  Arachne-only defect — `classic` produced identical stubs, because the cause
+  is in the surface fill rather than the wall generator.
+
 - **Arachne "splat" gap-fill and gap fill printed under top surfaces** — two
   Benchy-visible quality defects in the Arachne wall generator:
   - Isolated sub-millimetre gap-fill beads (≈ 270 on a 3DBenchy) that added

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -85,6 +85,29 @@ these notes and acknowledges contributors. `scripts/gen-changelog-draft.sh` and
 
 ### Fixed
 
+- **Arachne "splat" gap-fill and gap fill printed under top surfaces** — two
+  Benchy-visible quality defects in the Arachne wall generator:
+  - Isolated sub-millimetre gap-fill beads (≈ 270 on a 3DBenchy) that added
+    nothing but a full retract → travel → un-retract cycle each — wasting time
+    and risking filament grinding — are now dropped. The automatic minimum
+    gap-fill run length rose from one nozzle diameter to `2·d` (0.8 mm at a
+    0.4 mm nozzle), matching the medial-skeleton spur floor. Set
+    `gap_fill_min_length_mm` explicitly to override. The residual such short
+    beads would have filled is covered by the squish of the flanking wall beads,
+    so no wall-zone void opens (verified against the `classic` generator).
+  - A redundant gap-fill bead running down the centre of a thin solid strip
+    (e.g. the Benchy rear rail, ≈ layer 200) that double-extruded straight under
+    the top-surface fill is now pruned. Gap fill sandwiched by solid surface on
+    both sides is removed as redundant, while a bead that merely abuts a surface
+    on one side (a genuine thin neck) is kept. Cut model-wide gap-fill-under-
+    surface double-extrusion from 7.3 → 0.5 mm² with no new voids.
+- **Tiny sparse-infill "splat" dashes** — `min_infill_extrusion_mm` (default
+  0.4 mm) now also filters *sparse* infill, not just solid surface fill.
+  Isolated sub-threshold infill dashes in narrow corners — each a full
+  retract/travel/un-retract for a mechanically-insignificant dab — are dropped.
+  Combined with the gap-fill fixes this cut isolated sub-0.8 mm extrusions on the
+  3DBenchy by ~66 % (356 → 120) and removed ~160 retract cycles, with no change
+  to strength (the flanking walls fill the corner).
 - **3MF models loaded at the wrong scale** — the 3MF importer ignored the
   `<model unit="…">` declaration and read every coordinate as raw millimeters, so
   files authored in `meter`, `centimeter`, `inch`, or `foot` opened dramatically

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -107,26 +107,25 @@ these notes and acknowledges contributors. `scripts/gen-changelog-draft.sh` and
     side (a genuine thin neck) is still kept and abutted. Cut model-wide
     gap-fill-under-surface double-extrusion from 7.3 → 0.5 mm² with no new voids.
 - **Tiny sparse-infill "splat" dashes** — two complementary fixes:
-  - The sparse-infill area is now **morphologically opened** before the scanline
-    runs, erasing channels narrower than `2.5 × nozzle` (matching the existing
-    minimum width for a rectilinear *surface* fill). The infill area is
-    `interior − solid − gap fill − wall band`, and the solid surface's stepped
-    serpentine edge left a thin crescent sliver hugging the wall all along a
-    curved perimeter; the scanline shattered it into a swarm of sub-millimetre
+  - `layer.solid_regions` is now **grown by one bead width before being
+    subtracted** from the sparse-infill area. The solid surface is printed as a
+    stepped serpentine whose extent only approximates its nominal polygon, so
+    subtracting the raw outline left a thin crescent sliver hugging the wall
+    along every curved perimeter; the scanline shattered it into sub-millimetre
     dashes (31 on one 3DBenchy layer alone), each an isolated dab costing a full
-    retract/travel/un-retract for no structural gain — the sliver is already
+    retract/travel/un-retract for no structural gain — the space is already
     flanked by the solid surface on one side and a wall bead on the other.
-    Removing the sliver itself also clears the *longer* useless dashes inside it
-    that a minimum-length filter would keep. Isolated sparse dashes drop
-    114 → 21 (3DBenchy), 45 → 23 (Voron cube), 2 → 0 (filament caddy), never
-    worse — for 0.28 % of infill length and no new wall-zone void.
+    Isolated sub-1.5 mm infill paths on that layer drop 33 → 6. Because the
+    correction is keyed to `solid_regions`, it is an exact **no-op on layers
+    with no solid surface**, so genuinely thin wall-to-wall cavities (hollow-box
+    lattices) keep their infill untouched.
   - `min_infill_extrusion_mm` (default 0.4 mm) now also filters *sparse* infill,
     not just solid surface fill, catching the residual sub-threshold segments a
     legitimate region's tapering corners produce.
 
   Together with the gap-fill fixes this cut isolated sub-0.8 mm extrusions on the
-  3DBenchy by ~94 % (356 → 21) and removed ~300 retract cycles, with no change
-  to strength (the flanking walls and solid surface fill the space).
+  3DBenchy by ~76 % (356 → 87) with no change to strength (the flanking walls and
+  solid surface fill the space).
 
 - **iPad Apple Pencil + two-finger navigation "spazzing"** — palm rejection
   classified each touch on its own, so a stylus user's two-finger pan/pinch could

--- a/src/core/infill.rs
+++ b/src/core/infill.rs
@@ -2,35 +2,40 @@ use clipper2::*;
 
 use super::types::{ExtrusionRole, SliceLayer};
 
-/// Minimum width — as a multiple of the nozzle diameter — a **sparse-infill
-/// area** channel must reach before infill lines are generated inside it.
+/// Extra margin — as a multiple of the nozzle diameter — by which
+/// `layer.solid_regions` is **grown before being subtracted** from the sparse-
+/// infill area.
 ///
-/// The infill area is `interior − solid_regions − gap_fill − wall_band`.  Every
-/// one of those boundaries is jagged in its own way (most of all the solid
-/// surface, whose edge follows its rectilinear fill's stepped serpentine
-/// extent), so a **thin crescent sliver** survives between the solid region and
-/// the wall band all along a curved perimeter.  The scanline shatters that
-/// sliver into a swarm of sub-millimetre dashes — each an isolated dab costing a
-/// full retract → travel → un-retract, churning far more filament through the
-/// nozzle than it deposits (the jam risk), for no structural gain: the sliver is
-/// already flanked by solid surface on one side and a wall bead on the other.
+/// `solid_regions` is a nominal polygon, but the top/bottom surface is actually
+/// printed as a rectilinear serpentine whose stepped extent only approximates
+/// it, and the surface pass has already trimmed it back off the wall band.
+/// Subtracting the raw outline therefore leaves a thin crescent **sliver**
+/// between the solid region and the wall all along a curved perimeter.  The
+/// scanline shatters that sliver into a swarm of sub-millimetre dashes — 31 on
+/// 3DBenchy layer 41 alone — each an isolated dab costing a full
+/// retract → travel → un-retract, churning far more filament through the nozzle
+/// than it deposits (the jam risk) for no structural gain: the space is already
+/// flanked by the solid surface on one side and a wall bead on the other.
 ///
-/// A morphological opening at `MULT × nozzle / 2` erases channels narrower than
-/// `MULT × nozzle`.  `2.5` deliberately matches
-/// [`SURFACE_MIN_INTERIOR_WIDTH_NOZZLE_MULT`](super::surfaces): that constant is
-/// already the minimum width an interior region must reach to host a
-/// *rectilinear top/bottom surface fill*, and sparse infill is the same
-/// rectilinear-fill-in-a-thin-channel problem — only less critical, since it is
-/// a sparse lattice rather than a solid skin.  Genuine infill regions keep their
-/// full extent (only their convex corners, which sit against the walls, are
-/// rounded).
+/// One bead width (`1.0 × d`) is what actually clears the sliver: the surface's
+/// own fill lines are `d` wide about their centerlines, so the nominal polygon
+/// under-states the deposited material by up to half a bead on each side.
+/// Measured on 3DBenchy layer 41, isolated sub-1.5 mm infill paths fall 33 → 6
+/// at `1.0`, while `0.5` leaves all 33 (the sliver is simply wider than half a
+/// bead). Larger values buy almost nothing (`2.0` → 5) and only pull sparse
+/// infill further from the surface it should abut.
 ///
-/// Measured across the corpus (0.4 mm nozzle): isolated sparse dashes drop
-/// 114 → 21 on the 3DBenchy, 45 → 23 on the Voron cube, 2 → 0 on the filament
-/// caddy, and never increase — for **0.28 %** of total infill length. Wall-zone
-/// void stays less than half the `classic` reference (34 vs 72 mm² over the
-/// sampled layers), confirming nothing printable was lost.
-const INFILL_MIN_CHANNEL_WIDTH_NOZZLE_MULT: f64 = 2.5;
+/// **Keying this to `solid_regions` is the whole point.** It makes the
+/// correction an exact **no-op on layers that carry no solid surface**, so a
+/// genuinely thin wall-to-wall cavity — the hollow-box mid-height layers of the
+/// filament caddy, which are walls + sparse lattice and nothing else — keeps its
+/// full lattice (verified: wall-zone void and infill length both unchanged to
+/// the last digit at every margin tested).  An earlier attempt used a blanket
+/// morphological *opening* of the whole infill area; that cannot tell an
+/// artifact sliver from a real thin cavity and erased the caddy's lattice
+/// outright — its wall-zone void more than doubled (62 → 146 mm²) and 35 % of
+/// its infill vanished, which the slicing quality gate correctly caught.
+const SOLID_MARGIN_NOZZLE_MULT: f64 = 1.0;
 
 /// Calculate the interior region of a layer where solid surfaces and sparse
 /// infill should be printed (i.e. the area enclosed by the **innermost** wall
@@ -239,9 +244,48 @@ pub fn add_infill_to_layers(
         }
 
         let infill_area = if !layer.solid_regions.is_empty() {
+            // Subtract the solid surface **grown by half a bead**, not its raw
+            // outline.
+            //
+            // `solid_regions` is a nominal polygon, but the surface is actually
+            // printed as a rectilinear serpentine whose stepped extent only
+            // approximates it, and it was already trimmed back off the wall band
+            // by the surface pass.  Subtracting the raw outline therefore leaves
+            // a thin crescent **sliver** between the solid region and the wall
+            // all along a curved perimeter.  The scanline shatters that sliver
+            // into a swarm of sub-millimetre dashes (31 on 3DBenchy layer 41
+            // alone), each an isolated dab costing a full retract → travel →
+            // un-retract for no structural gain — the "infill produces tiny
+            // extrudes" defect.  The space is already flanked by the solid
+            // surface on one side and a wall bead on the other.
+            //
+            // Growing the subtracted region by `SOLID_MARGIN_NOZZLE_MULT × d`
+            // absorbs that sliver into the (already solid-filled) surface.  It
+            // is deliberately keyed to `solid_regions`, so it is an exact
+            // **no-op on layers that have no solid surface** — a genuinely thin
+            // wall-to-wall cavity, such as the hollow-box mid-height layers of
+            // the filament caddy, keeps its full sparse lattice.  A blanket
+            // morphological opening of the infill area cannot make that
+            // distinction and erases those legitimate lattices.
+            let margin = SOLID_MARGIN_NOZZLE_MULT * nozzle_diameter_mm;
+            let blocked = if margin > 1e-9 {
+                clipper2::inflate(
+                    layer.solid_regions.clone(),
+                    margin,
+                    clipper2::JoinType::Round,
+                    clipper2::EndType::Polygon,
+                    2.0,
+                )
+            } else {
+                layer.solid_regions.clone()
+            };
+            let blocked = if blocked.is_empty() {
+                layer.solid_regions.clone()
+            } else {
+                blocked
+            };
             let remaining =
-                difference(infill_area, layer.solid_regions.clone(), FillRule::Positive)
-                    .unwrap_or_default();
+                difference(infill_area, blocked, FillRule::Positive).unwrap_or_default();
             if remaining.is_empty() {
                 return None;
             }
@@ -301,40 +345,6 @@ pub fn add_infill_to_layers(
                 return None;
             }
             remaining
-        };
-
-        // Erase infill-area channels too narrow to host a meaningful bead.
-        //
-        // The area above is `interior − solid_regions − gap_fill − wall_band`.
-        // Each of those boundaries is jagged in its own way — most of all the
-        // solid surface, whose edge follows its rectilinear fill's stepped
-        // serpentine extent — so a **thin crescent sliver** survives between the
-        // solid region and the wall band all along a curved perimeter (clearly
-        // visible on the 3DBenchy hull, e.g. layers 40–42).  The sparse scanline
-        // clips that sliver into a swarm of sub-millimetre dashes, each an
-        // isolated dab of material costing a full retract → travel → un-retract
-        // to reach: the "infill produces tiny extrudes" defect.  They are pure
-        // waste — the sliver is already flanked by the solid surface on one side
-        // and the wall bead on the other, both of which deposit material there.
-        //
-        // Opening (erode → dilate) removes channels narrower than
-        // `INFILL_MIN_CHANNEL_WIDTH_NOZZLE_MULT × nozzle` while leaving genuine
-        // infill areas at full extent (only their convex corners, which sit
-        // against the walls, are rounded).  This attacks the **cause** — the
-        // sliver region — rather than the symptom, so it also removes the
-        // *longer* useless dashes inside the same sliver that a plain
-        // minimum-length filter would keep.  `min_infill_extrusion_mm` still
-        // guards the residual sub-threshold segments a legitimate region's
-        // tapering corners produce.
-        let open_radius = INFILL_MIN_CHANNEL_WIDTH_NOZZLE_MULT * nozzle_diameter_mm * 0.5;
-        let infill_area = if open_radius > 1e-9 {
-            let opened = super::surfaces::morphological_open(infill_area, open_radius);
-            if opened.is_empty() {
-                return None;
-            }
-            opened
-        } else {
-            infill_area
         };
 
         let base_angle_rad = infill_base_angle.to_radians();

--- a/src/core/infill.rs
+++ b/src/core/infill.rs
@@ -2,6 +2,36 @@ use clipper2::*;
 
 use super::types::{ExtrusionRole, SliceLayer};
 
+/// Minimum width — as a multiple of the nozzle diameter — a **sparse-infill
+/// area** channel must reach before infill lines are generated inside it.
+///
+/// The infill area is `interior − solid_regions − gap_fill − wall_band`.  Every
+/// one of those boundaries is jagged in its own way (most of all the solid
+/// surface, whose edge follows its rectilinear fill's stepped serpentine
+/// extent), so a **thin crescent sliver** survives between the solid region and
+/// the wall band all along a curved perimeter.  The scanline shatters that
+/// sliver into a swarm of sub-millimetre dashes — each an isolated dab costing a
+/// full retract → travel → un-retract, churning far more filament through the
+/// nozzle than it deposits (the jam risk), for no structural gain: the sliver is
+/// already flanked by solid surface on one side and a wall bead on the other.
+///
+/// A morphological opening at `MULT × nozzle / 2` erases channels narrower than
+/// `MULT × nozzle`.  `2.5` deliberately matches
+/// [`SURFACE_MIN_INTERIOR_WIDTH_NOZZLE_MULT`](super::surfaces): that constant is
+/// already the minimum width an interior region must reach to host a
+/// *rectilinear top/bottom surface fill*, and sparse infill is the same
+/// rectilinear-fill-in-a-thin-channel problem — only less critical, since it is
+/// a sparse lattice rather than a solid skin.  Genuine infill regions keep their
+/// full extent (only their convex corners, which sit against the walls, are
+/// rounded).
+///
+/// Measured across the corpus (0.4 mm nozzle): isolated sparse dashes drop
+/// 114 → 21 on the 3DBenchy, 45 → 23 on the Voron cube, 2 → 0 on the filament
+/// caddy, and never increase — for **0.28 %** of total infill length. Wall-zone
+/// void stays less than half the `classic` reference (34 vs 72 mm² over the
+/// sampled layers), confirming nothing printable was lost.
+const INFILL_MIN_CHANNEL_WIDTH_NOZZLE_MULT: f64 = 2.5;
+
 /// Calculate the interior region of a layer where solid surfaces and sparse
 /// infill should be printed (i.e. the area enclosed by the **innermost** wall
 /// of every island, optionally shrunk by a configured overlap).
@@ -271,6 +301,40 @@ pub fn add_infill_to_layers(
                 return None;
             }
             remaining
+        };
+
+        // Erase infill-area channels too narrow to host a meaningful bead.
+        //
+        // The area above is `interior − solid_regions − gap_fill − wall_band`.
+        // Each of those boundaries is jagged in its own way — most of all the
+        // solid surface, whose edge follows its rectilinear fill's stepped
+        // serpentine extent — so a **thin crescent sliver** survives between the
+        // solid region and the wall band all along a curved perimeter (clearly
+        // visible on the 3DBenchy hull, e.g. layers 40–42).  The sparse scanline
+        // clips that sliver into a swarm of sub-millimetre dashes, each an
+        // isolated dab of material costing a full retract → travel → un-retract
+        // to reach: the "infill produces tiny extrudes" defect.  They are pure
+        // waste — the sliver is already flanked by the solid surface on one side
+        // and the wall bead on the other, both of which deposit material there.
+        //
+        // Opening (erode → dilate) removes channels narrower than
+        // `INFILL_MIN_CHANNEL_WIDTH_NOZZLE_MULT × nozzle` while leaving genuine
+        // infill areas at full extent (only their convex corners, which sit
+        // against the walls, are rounded).  This attacks the **cause** — the
+        // sliver region — rather than the symptom, so it also removes the
+        // *longer* useless dashes inside the same sliver that a plain
+        // minimum-length filter would keep.  `min_infill_extrusion_mm` still
+        // guards the residual sub-threshold segments a legitimate region's
+        // tapering corners produce.
+        let open_radius = INFILL_MIN_CHANNEL_WIDTH_NOZZLE_MULT * nozzle_diameter_mm * 0.5;
+        let infill_area = if open_radius > 1e-9 {
+            let opened = super::surfaces::morphological_open(infill_area, open_radius);
+            if opened.is_empty() {
+                return None;
+            }
+            opened
+        } else {
+            infill_area
         };
 
         let base_angle_rad = infill_base_angle.to_radians();

--- a/src/core/infill.rs
+++ b/src/core/infill.rs
@@ -117,6 +117,10 @@ pub(crate) fn calculate_interior_region(
 /// * `nozzle_diameter_mm` - Nozzle diameter used when computing infill regions on the fly
 /// * `infill_perimeter_gap_mm` - Gap in mm between the innermost wall and the infill boundary.
 ///   A positive value leaves a gap; `0.0` means infill starts exactly at the inner wall edge.
+/// * `min_infill_extrusion_mm` - Isolated sparse-infill segments shorter than this are dropped
+///   as splats: a sub-threshold dash in a narrow corner deposits a mechanically-insignificant
+///   amount of material yet still costs a full retract → travel → un-retract to reach.  `0`
+///   disables the filter.  Mirrors the identical guard on solid-surface infill.
 /// * `precomputed_infill_regions` - Optional per-layer interior regions computed **before**
 ///   any single-wall restrictions were applied.  When provided, these regions are used
 ///   instead of calling [`calculate_interior_region`] on each layer, which prevents
@@ -134,8 +138,9 @@ pub(crate) fn calculate_interior_region(
 /// # let mesh = Mesh::new();
 ///
 /// let mut layers = slice_mesh(&mesh, 0.2);
-/// add_infill_to_layers(&mut layers, 0.2, InfillPattern::Rectilinear, 45.0, 0.4, 0.0, None);
+/// add_infill_to_layers(&mut layers, 0.2, InfillPattern::Rectilinear, 45.0, 0.4, 0.0, 0.4, None);
 /// ```
+#[allow(clippy::too_many_arguments)]
 pub fn add_infill_to_layers(
     layers: &mut [SliceLayer],
     infill_density: f64,
@@ -143,6 +148,7 @@ pub fn add_infill_to_layers(
     infill_base_angle: f64,
     nozzle_diameter_mm: f64,
     infill_perimeter_gap_mm: f64,
+    min_infill_extrusion_mm: f64,
     precomputed_infill_regions: Option<&[Paths]>,
 ) {
     use crate::infill::generate_infill;
@@ -292,10 +298,38 @@ pub fn add_infill_to_layers(
     let results: Vec<Option<Paths>> = (0..layers.len()).map(compute).collect();
 
     // ── Serial apply pass ─────────────────────────────────────────────────────
+    //
+    // Drop isolated sparse-infill segments shorter than `min_infill_extrusion_mm`:
+    // a sub-threshold dash in a narrow corner deposits a mechanically-
+    // insignificant amount of material yet still costs a full retract → travel →
+    // un-retract to reach — the "tiny inner-body splat".  This mirrors the guard
+    // solid-surface infill already applies in `generate_rectilinear_infill`.
+    let min_len_sq = if min_infill_extrusion_mm > 0.0 {
+        min_infill_extrusion_mm * min_infill_extrusion_mm
+    } else {
+        0.0
+    };
+    let polyline_len_sq_ge = |path: &clipper2::Path, min_sq: f64| -> bool {
+        if min_sq <= 0.0 {
+            return true;
+        }
+        let pts: Vec<(f64, f64)> = path.iter().map(|p| (p.x(), p.y())).collect();
+        let mut len = 0.0;
+        for w in pts.windows(2) {
+            len += ((w[1].0 - w[0].0).powi(2) + (w[1].1 - w[0].1).powi(2)).sqrt();
+            if len * len >= min_sq {
+                return true;
+            }
+        }
+        len * len >= min_sq
+    };
     for (layer_idx, infill_paths) in results.into_iter().enumerate() {
         if let Some(paths) = infill_paths {
             let layer = &mut layers[layer_idx];
             for infill_path in paths.iter() {
+                if !polyline_len_sq_ge(infill_path, min_len_sq) {
+                    continue;
+                }
                 layer.paths.push(infill_path.clone());
                 layer.path_roles.push(ExtrusionRole::Infill);
             }

--- a/src/core/mod.rs
+++ b/src/core/mod.rs
@@ -1563,13 +1563,17 @@ mod tests {
         );
     }
 
-    /// A sparse-infill area that is a **thin crescent channel** (narrower than
-    /// `INFILL_MIN_CHANNEL_WIDTH_NOZZLE_MULT × nozzle`) must produce **no**
-    /// infill at all — the morphological opening erases it — instead of a swarm
-    /// of sub-millimetre dashes each costing a retract/travel cycle.  A wide
-    /// region on the same layer must still fill normally.
+    /// A thin wall-to-wall cavity with **no solid surface** on the layer must
+    /// keep its full sparse lattice: the solid-region margin is keyed to
+    /// `solid_regions`, so it must be an exact no-op here.
+    ///
+    /// This is the hollow-box case (filament-caddy mid-height layers). An
+    /// earlier implementation morphologically *opened* the whole infill area and
+    /// erased this lattice outright — its wall-zone void more than doubled —
+    /// which the slicing quality gate caught. This test pins that behaviour so
+    /// the mistake cannot come back.
     #[test]
-    fn test_thin_infill_channel_yields_no_sparse_dashes() {
+    fn test_thin_cavity_without_solid_surface_keeps_its_infill() {
         use crate::infill::InfillPattern;
         use clipper2::Path;
 
@@ -1581,41 +1585,20 @@ mod tests {
                 .count()
         };
 
-        // A long, 0.6 mm-wide channel (below 2.5 × 0.4 = 1.0 mm): the wall band
-        // already fills it, so no sparse infill may be generated inside.
-        let mut thin = SliceLayer::new(0.2);
-        let strip: Path = vec![(-15.0, -0.3), (15.0, -0.3), (15.0, 0.3), (-15.0, 0.3)].into();
-        thin.paths.push(strip);
-        thin.path_roles.push(ExtrusionRole::OuterWall);
-        thin.path_widths.push(Some(0.4));
-        let mut thin_layers = vec![thin];
-        add_infill_to_layers(
-            &mut thin_layers,
-            0.2,
-            InfillPattern::Rectilinear,
-            45.0,
-            0.4,
-            0.0,
-            0.0, // length filter off — the opening alone must do the work
-            None,
-        );
-        assert_eq!(
-            count_infill(&thin_layers),
-            0,
-            "a sub-1 mm infill channel must yield no sparse dashes"
-        );
+        // A tall, narrow cavity between two walls — thin, but genuine: nothing
+        // else on the layer covers it, so it must still be filled.
+        let mut layer = SliceLayer::new(0.2);
+        let outer: Path = vec![(-20.0, -1.2), (20.0, -1.2), (20.0, 1.2), (-20.0, 1.2)].into();
+        layer.paths.push(outer);
+        layer.path_roles.push(ExtrusionRole::OuterWall);
+        layer.path_widths.push(Some(0.4));
+        // Deliberately no solid_regions on this layer.
+        assert!(layer.solid_regions.is_empty());
 
-        // A generous 30×30 mm square must still be filled normally, proving the
-        // opening does not suppress genuine infill.
-        let mut wide = SliceLayer::new(0.2);
-        let sq: Path = vec![(-15.0, -15.0), (15.0, -15.0), (15.0, 15.0), (-15.0, 15.0)].into();
-        wide.paths.push(sq);
-        wide.path_roles.push(ExtrusionRole::OuterWall);
-        wide.path_widths.push(Some(0.4));
-        let mut wide_layers = vec![wide];
+        let mut layers = vec![layer];
         add_infill_to_layers(
-            &mut wide_layers,
-            0.2,
+            &mut layers,
+            0.4,
             InfillPattern::Rectilinear,
             45.0,
             0.4,
@@ -1624,8 +1607,72 @@ mod tests {
             None,
         );
         assert!(
-            count_infill(&wide_layers) > 0,
-            "a wide region must still receive sparse infill"
+            count_infill(&layers) > 0,
+            "a thin cavity with no solid surface must keep its sparse lattice"
+        );
+    }
+
+    /// Sparse infill must not be laid in the sub-bead sliver between a solid
+    /// surface and the wall: `solid_regions` is grown by
+    /// `SOLID_MARGIN_NOZZLE_MULT × nozzle` before being subtracted, so infill
+    /// generated against a solid region keeps clear of it.
+    #[test]
+    fn test_solid_margin_keeps_infill_off_the_surface_sliver() {
+        use crate::infill::InfillPattern;
+        use clipper2::Path;
+
+        let infill_area_mm = |layers: &[SliceLayer]| -> f64 {
+            let mut total = 0.0;
+            for l in layers {
+                for (i, p) in l.paths.iter().enumerate() {
+                    if l.role_for_path(i) != ExtrusionRole::Infill {
+                        continue;
+                    }
+                    let pts: Vec<(f64, f64)> = p.iter().map(|q| (q.x(), q.y())).collect();
+                    total += pts
+                        .windows(2)
+                        .map(|w| ((w[1].0 - w[0].0).powi(2) + (w[1].1 - w[0].1).powi(2)).sqrt())
+                        .sum::<f64>();
+                }
+            }
+            total
+        };
+
+        // A 30 mm square whose interior is almost entirely solid surface, save a
+        // thin ring left over against the wall — the sliver.
+        let build = |with_solid: bool| {
+            let mut layer = SliceLayer::new(0.2);
+            let sq: Path = vec![(-15.0, -15.0), (15.0, -15.0), (15.0, 15.0), (-15.0, 15.0)].into();
+            layer.paths.push(sq);
+            layer.path_roles.push(ExtrusionRole::OuterWall);
+            layer.path_widths.push(Some(0.4));
+            if with_solid {
+                let solid: Path =
+                    vec![(-13.0, -13.0), (13.0, -13.0), (13.0, 13.0), (-13.0, 13.0)].into();
+                layer.solid_regions = Paths::new(vec![solid]);
+            }
+            let mut layers = vec![layer];
+            add_infill_to_layers(
+                &mut layers,
+                0.4,
+                InfillPattern::Rectilinear,
+                45.0,
+                0.4,
+                0.0,
+                0.0,
+                None,
+            );
+            layers
+        };
+
+        // With a solid region covering the middle, only the ring outside it can
+        // host infill — and the margin must shrink that ring further, so the
+        // total is strictly less than the un-margined solid outline would allow.
+        let with_solid = infill_area_mm(&build(true));
+        let without_solid = infill_area_mm(&build(false));
+        assert!(
+            with_solid < without_solid,
+            "solid region must reduce infill ({with_solid:.1} !< {without_solid:.1})"
         );
     }
 

--- a/src/core/mod.rs
+++ b/src/core/mod.rs
@@ -1563,6 +1563,72 @@ mod tests {
         );
     }
 
+    /// A sparse-infill area that is a **thin crescent channel** (narrower than
+    /// `INFILL_MIN_CHANNEL_WIDTH_NOZZLE_MULT × nozzle`) must produce **no**
+    /// infill at all — the morphological opening erases it — instead of a swarm
+    /// of sub-millimetre dashes each costing a retract/travel cycle.  A wide
+    /// region on the same layer must still fill normally.
+    #[test]
+    fn test_thin_infill_channel_yields_no_sparse_dashes() {
+        use crate::infill::InfillPattern;
+        use clipper2::Path;
+
+        let count_infill = |layers: &[SliceLayer]| -> usize {
+            layers
+                .iter()
+                .flat_map(|l| l.path_roles.iter())
+                .filter(|&&r| r == ExtrusionRole::Infill)
+                .count()
+        };
+
+        // A long, 0.6 mm-wide channel (below 2.5 × 0.4 = 1.0 mm): the wall band
+        // already fills it, so no sparse infill may be generated inside.
+        let mut thin = SliceLayer::new(0.2);
+        let strip: Path = vec![(-15.0, -0.3), (15.0, -0.3), (15.0, 0.3), (-15.0, 0.3)].into();
+        thin.paths.push(strip);
+        thin.path_roles.push(ExtrusionRole::OuterWall);
+        thin.path_widths.push(Some(0.4));
+        let mut thin_layers = vec![thin];
+        add_infill_to_layers(
+            &mut thin_layers,
+            0.2,
+            InfillPattern::Rectilinear,
+            45.0,
+            0.4,
+            0.0,
+            0.0, // length filter off — the opening alone must do the work
+            None,
+        );
+        assert_eq!(
+            count_infill(&thin_layers),
+            0,
+            "a sub-1 mm infill channel must yield no sparse dashes"
+        );
+
+        // A generous 30×30 mm square must still be filled normally, proving the
+        // opening does not suppress genuine infill.
+        let mut wide = SliceLayer::new(0.2);
+        let sq: Path = vec![(-15.0, -15.0), (15.0, -15.0), (15.0, 15.0), (-15.0, 15.0)].into();
+        wide.paths.push(sq);
+        wide.path_roles.push(ExtrusionRole::OuterWall);
+        wide.path_widths.push(Some(0.4));
+        let mut wide_layers = vec![wide];
+        add_infill_to_layers(
+            &mut wide_layers,
+            0.2,
+            InfillPattern::Rectilinear,
+            45.0,
+            0.4,
+            0.0,
+            0.0,
+            None,
+        );
+        assert!(
+            count_infill(&wide_layers) > 0,
+            "a wide region must still receive sparse infill"
+        );
+    }
+
     // ── Bridge filter pipeline (issue: noisy bridges & overhang walls) ──────
 
     /// A tiny sliver of unsupported area (sub-mm) must be reclassified as

--- a/src/core/mod.rs
+++ b/src/core/mod.rs
@@ -327,6 +327,7 @@ mod tests {
             45.0,
             0.4,
             0.0,
+            0.0,
             None,
         );
 
@@ -358,6 +359,7 @@ mod tests {
             45.0,
             0.4,
             0.0,
+            0.0,
             None,
         );
 
@@ -376,7 +378,16 @@ mod tests {
         let mut layers = slice_mesh(&mesh, 2.0);
 
         // Add grid infill
-        add_infill_to_layers(&mut layers, 0.3, InfillPattern::Grid, 45.0, 0.4, 0.0, None);
+        add_infill_to_layers(
+            &mut layers,
+            0.3,
+            InfillPattern::Grid,
+            45.0,
+            0.4,
+            0.0,
+            0.0,
+            None,
+        );
 
         // Grid pattern should produce more infill paths than rectilinear
         for layer in &layers {
@@ -436,6 +447,7 @@ mod tests {
             InfillPattern::Rectilinear,
             45.0,
             0.4,
+            0.0,
             0.0,
             None,
         );
@@ -1431,6 +1443,7 @@ mod tests {
             45.0,
             0.4,
             0.0,
+            0.0,
             None,
         );
 
@@ -1442,6 +1455,7 @@ mod tests {
             45.0,
             0.4,
             0.2, // 0.2 mm gap from walls
+            0.0,
             None,
         );
 
@@ -1462,6 +1476,90 @@ mod tests {
             "Infill with gap ({} paths) should not have more paths than no-gap ({} paths)",
             gap_count,
             no_gap_count
+        );
+    }
+
+    /// Isolated sparse-infill dashes shorter than `min_infill_extrusion_mm` are
+    /// dropped as splats, while the same scene with the filter disabled keeps
+    /// them — the "tiny inner-body splat" cleanup.
+    #[test]
+    fn test_min_infill_extrusion_drops_sparse_splats() {
+        use crate::infill::InfillPattern;
+
+        // Build a layer with a large interior so rectilinear infill generates a
+        // mix of long lines and — at the rounded corners of the region — short
+        // dashes.  A disc gives the diagonal boundary that yields sub-mm crossings.
+        let make_disc_layer = || {
+            let mut layer = SliceLayer::new(0.2);
+            let mut ring: Vec<(f64, f64)> = Vec::new();
+            let r = 8.0;
+            for k in 0..64 {
+                let a = std::f64::consts::TAU * (k as f64) / 64.0;
+                ring.push((r * a.cos(), r * a.sin()));
+            }
+            let disc: clipper2::Path = ring.into();
+            layer.paths.push(disc);
+            layer.path_roles.push(ExtrusionRole::OuterWall);
+            layer.path_widths.push(Some(0.4));
+            layer
+        };
+
+        let count_short = |layers: &[SliceLayer], max_len: f64| -> usize {
+            let mut n = 0;
+            for l in layers {
+                for (i, p) in l.paths.iter().enumerate() {
+                    if l.role_for_path(i) != ExtrusionRole::Infill {
+                        continue;
+                    }
+                    let pts: Vec<(f64, f64)> = p.iter().map(|q| (q.x(), q.y())).collect();
+                    let len: f64 = pts
+                        .windows(2)
+                        .map(|w| ((w[1].0 - w[0].0).powi(2) + (w[1].1 - w[0].1).powi(2)).sqrt())
+                        .sum();
+                    if len < max_len {
+                        n += 1;
+                    }
+                }
+            }
+            n
+        };
+
+        let mut unfiltered = vec![make_disc_layer()];
+        add_infill_to_layers(
+            &mut unfiltered,
+            0.15,
+            InfillPattern::Rectilinear,
+            45.0,
+            0.4,
+            0.0,
+            0.0, // filter disabled
+            None,
+        );
+
+        let mut filtered = vec![make_disc_layer()];
+        add_infill_to_layers(
+            &mut filtered,
+            0.15,
+            InfillPattern::Rectilinear,
+            45.0,
+            0.4,
+            0.0,
+            0.4, // drop sub-0.4 mm dashes
+            None,
+        );
+
+        // The filter must leave no sub-0.4 mm infill dash …
+        assert_eq!(
+            count_short(&filtered, 0.4),
+            0,
+            "no sub-threshold sparse dash should survive the filter"
+        );
+        // … and must not add paths; it only ever removes.
+        let n_unfiltered: usize = unfiltered.iter().map(|l| l.paths.len()).sum();
+        let n_filtered: usize = filtered.iter().map(|l| l.paths.len()).sum();
+        assert!(
+            n_filtered <= n_unfiltered,
+            "filter must not add paths ({n_filtered} > {n_unfiltered})"
         );
     }
 

--- a/src/core/pipeline.rs
+++ b/src/core/pipeline.rs
@@ -227,7 +227,7 @@ pub fn process_mesh(
         // islands on the uniform surface.  Genuine gap fill in sparse zones and
         // thin ribs (outside solid_regions) is preserved.
         logger.log_debug("pruning redundant gap fill inside solid surfaces");
-        prune_redundant_gap_fill(&mut layers);
+        prune_redundant_gap_fill(&mut layers, params.nozzle_diameter_mm);
     }
 
     // Add infill
@@ -249,6 +249,7 @@ pub fn process_mesh(
             params.infill_base_angle,
             params.nozzle_diameter_mm,
             params.infill_perimeter_gap_mm,
+            params.min_infill_extrusion_mm,
             pre_strip_infill_regions.as_deref(),
         );
         t_infill.finish();
@@ -609,6 +610,7 @@ pub fn process_mesh_debug(
             params.infill_base_angle,
             params.nozzle_diameter_mm,
             params.infill_perimeter_gap_mm,
+            params.min_infill_extrusion_mm,
             pre_strip_infill_regions.as_deref(),
         );
 

--- a/src/core/surfaces.rs
+++ b/src/core/surfaces.rs
@@ -167,6 +167,30 @@ const SURFACE_MIN_ISLAND_MM2: f64 = 2.0;
 /// keeps the latter with wide margin.
 const SURFACE_MIN_INTERIOR_WIDTH_NOZZLE_MULT: f64 = 2.5;
 
+/// Opening radius, as a fraction of the **solid-surface extrusion width**, used
+/// to erase sub-bead slivers left on a surface region by the wall-band trim.
+///
+/// A value of 0.5 makes the erosion diameter exactly one extrusion width, which
+/// is the physically meaningful threshold: a strip narrower than one bead cannot
+/// hold a bead, so filling it is impossible by construction and the flanking
+/// wall already covers it.  See [`open_surface_region_for_fill`].
+const SURFACE_FILL_MIN_WIDTH_FRACTION: f64 = 0.5;
+
+/// How far the surviving core is re-grown, as a multiple of the erosion radius,
+/// before being clipped back to the original region.
+///
+/// Re-growing by *more* than the erosion radius restores sharp convex corners
+/// exactly (the clip to the original region bounds the result), instead of
+/// leaving them rounded as a plain morphological opening would.  Corner rounding
+/// is not a coverage problem — it is a *stub* problem: the scanline crossing a
+/// rounded corner emits a couple of extra sub-millimetre spans, which is the
+/// very artifact this filter exists to remove.
+///
+/// 2.0 recovers every corner while staying well below the wall-band width that
+/// separates a sliver from the nearest genuine surface, so a dropped sliver is
+/// never re-attached.
+const SURFACE_FILL_REGROW_FACTOR: f64 = 2.0;
+
 /// Maximum horizontal gap (as a multiple of `line_spacing`) allowed when
 /// connecting the end of one scan-line segment to the nearest end of the next
 /// scan-line segment in the serpentine chaining pass.
@@ -724,6 +748,60 @@ fn open_interior_for_surface(interior: &Paths, nozzle_diameter_mm: f64) -> Paths
         return interior.clone();
     }
     morphological_open(interior.clone(), radius)
+}
+
+/// Erase residual **sub-bead slivers** from a solid top/bottom surface region so
+/// the scanline never fills a strip too narrow to hold a bead.
+///
+/// The wall-band trim subtracts the eroded wall-bead footprint from a surface
+/// region whose outline does not follow that footprint exactly.  Where the two
+/// boundaries meet at a **grazing angle** the subtraction leaves a long crescent
+/// far narrower than one extrusion.  The scanline happily fills such a crescent,
+/// but since the fill direction is then near-parallel to it *every* span is a
+/// stub: the observed artifact is a dense `≈0.8 mm line / ≈0.6 mm connector`
+/// micro-serpentine hugging the wall — a burst of retract-free but pointless
+/// sub-millimetre moves whose material is overwhelmingly already laid down by
+/// the flanking wall bead.
+///
+/// Opening by half the extrusion width erases every feature narrower than one
+/// full bead.  Unlike a plain morphological opening this preserves **sharp
+/// convex corners**: the surviving core is re-grown by
+/// `SURFACE_FILL_REGROW_FACTOR × radius` and then clipped back to the original
+/// region, so thicker geometry is recovered at its exact original shape.  That
+/// matters because a rounded corner makes the scanline emit extra stub spans —
+/// the very artifact being removed.  This is a **width** filter, not an area
+/// filter, so genuinely small *but printable* surfaces are untouched.
+fn open_surface_region_for_fill(region: Paths, surface_width_mm: f64) -> Paths {
+    let radius = surface_width_mm * SURFACE_FILL_MIN_WIDTH_FRACTION;
+    if radius <= 1e-6 || region.is_empty() {
+        return region;
+    }
+
+    // Erode to the printable-width core; a sub-bead sliver contributes nothing.
+    let core = clipper2::inflate(
+        region.clone(),
+        -radius,
+        JoinType::Round,
+        EndType::Polygon,
+        2.0,
+    );
+    if core.is_empty() {
+        return Paths::new(vec![]);
+    }
+
+    // Re-grow past the erosion radius, then clip to the original so corners come
+    // back sharp.  `NonZero` keeps CW hole sub-paths as holes.
+    let grown = clipper2::inflate(
+        core,
+        radius * SURFACE_FILL_REGROW_FACTOR,
+        JoinType::Round,
+        EndType::Polygon,
+        2.0,
+    );
+    if grown.is_empty() {
+        return Paths::new(vec![]);
+    }
+    intersect(region, grown, FillRule::NonZero).unwrap_or_default()
 }
 
 /// Anchor expansion: dilate `unsupported` by `anchor_mm` (clipped to the
@@ -2162,6 +2240,15 @@ pub fn generate_top_bottom_surfaces_with_interior(
         };
         let solid_line_spacing = solid_surface_line_spacing(surface_width, layer_height);
 
+        // Drop sub-bead slivers the wall-band trim above may have left behind,
+        // so the scanline never fills a strip too narrow to hold a bead (that
+        // produces a micro-serpentine of stub segments against the wall).
+        // See `open_surface_region_for_fill` for the full rationale.
+        let (bottom_region, top_region) = (
+            open_surface_region_for_fill(bottom_region, surface_width),
+            open_surface_region_for_fill(top_region, surface_width),
+        );
+
         if !bottom_region.is_empty() {
             #[cfg(not(target_arch = "wasm32"))]
             let t = Instant::now();
@@ -2702,8 +2789,67 @@ mod tests {
         );
     }
 
-    /// **Regression** — a top surface detected over a locally-thin cross-section
-    /// (a thin wall-band channel whose aft end steps back a layer) must NOT be
+    /// **Regression** — the sub-bead sliver the wall-band trim leaves along a
+    /// boundary it meets at a grazing angle must be erased, so the scanline
+    /// never fills it with a micro-serpentine of stub segments.
+    ///
+    /// Measured on the Filament Card Caddy's hexagon logo (0.44 mm extrusion):
+    /// the trim left ≈0.22 mm-wide crescents of ≈4.5 mm² along the two hexagon
+    /// edges lying only 15° off the fill direction, which the scanline filled
+    /// with a repeating 0.8 mm-line / 0.6 mm-connector zig-zag.
+    #[test]
+    fn test_open_surface_region_drops_sub_bead_sliver() {
+        // 0.22 mm-wide crescent — half of the 0.44 mm extrusion width.
+        let sliver: Path = vec![(0.0, 0.0), (20.0, 0.0), (20.0, 0.22), (0.0, 0.22)].into();
+        let region = Paths::new(vec![sliver]);
+
+        let opened = open_surface_region_for_fill(region, 0.44);
+
+        assert!(
+            opened.is_empty(),
+            "a sub-bead sliver must be erased, got {} sub-path(s)",
+            opened.len()
+        );
+    }
+
+    /// A strip exactly one bead wide *can* hold a bead, and anything thicker
+    /// must survive the filter at its **exact original shape** — including
+    /// sharp convex corners, which a plain morphological opening would round
+    /// (and a rounded corner makes the scanline emit extra stub spans).
+    #[test]
+    fn test_open_surface_region_keeps_printable_regions() {
+        // 3×3 mm surface — small in area but far wider than one 0.44 mm bead.
+        let small: Path = vec![(0.0, 0.0), (3.0, 0.0), (3.0, 3.0), (0.0, 3.0)].into();
+        let opened = open_surface_region_for_fill(Paths::new(vec![small]), 0.44);
+        let area: f64 = opened.iter().map(|p| p.signed_area().abs()).sum();
+        assert!(
+            area >= 8.95,
+            "a printable surface must keep its sharp corners (area {area:.3} mm², expected ≈ 9.0)"
+        );
+
+        // A 1.0 mm-wide rib is over two beads wide and must also survive.
+        let rib: Path = vec![(0.0, 0.0), (12.0, 0.0), (12.0, 1.0), (0.0, 1.0)].into();
+        let opened = open_surface_region_for_fill(Paths::new(vec![rib]), 0.44);
+        assert!(
+            !opened.is_empty(),
+            "a 1 mm rib is wider than one bead and must be kept"
+        );
+    }
+
+    /// A zero/negative width must be a no-op rather than erasing the region.
+    #[test]
+    fn test_open_surface_region_degenerate_width_is_noop() {
+        let square: Path = vec![(0.0, 0.0), (5.0, 0.0), (5.0, 5.0), (0.0, 5.0)].into();
+        let region = Paths::new(vec![square]);
+        let opened = open_surface_region_for_fill(region.clone(), 0.0);
+        assert_eq!(
+            opened.len(),
+            region.len(),
+            "a degenerate width must leave the region untouched"
+        );
+    }
+
+    /// **Regression** — a top surface detected over a locally-thin cross-section    /// (a thin wall-band channel whose aft end steps back a layer) must NOT be
     /// filled: the opened interior is empty there, so the surface is dropped,
     /// matching the `classic` generator.  Guards the "tiny top-surface extrudes
     /// in a thin wall channel" defect (Benchy hull sides / funnel transitions).

--- a/src/core/surfaces.rs
+++ b/src/core/surfaces.rs
@@ -307,7 +307,7 @@ fn principal_axis_angle_deg(paths: &Paths) -> Option<f64> {
 /// Removes thin features (slivers, hair-thin connecting strands) narrower
 /// than `2 × radius_mm` while preserving larger regions almost unchanged.
 /// A no-op when `radius_mm <= 0`.
-pub(super) fn morphological_open(paths: Paths, radius_mm: f64) -> Paths {
+fn morphological_open(paths: Paths, radius_mm: f64) -> Paths {
     // 1e-6 mm = 1 nm — well below any real geometry and below Clipper2's
     // Centi quantisation (10 µm).  Anything smaller is rounding noise and
     // a no-op is the right behaviour.

--- a/src/core/surfaces.rs
+++ b/src/core/surfaces.rs
@@ -451,21 +451,113 @@ pub(super) fn compute_gap_fill_footprint(layer: &SliceLayer, nozzle_diameter_mm:
     acc
 }
 
-/// Remove `GapFill` beads that fall inside a solid-surface region.
+/// Perpendicular over-reach, as a multiple of the nozzle diameter, added to a
+/// gap-fill bead's own half-width when probing for solid surface on either side
+/// (see [`gap_fill_sandwiched_by_surface`]).  The probe point must clear the
+/// gap-fill footprint band that `blocked_for_surface` carved out of the surface
+/// (exactly the bead's half-width) and land a nozzle-fraction *into* the
+/// surface fill beyond it; `0.5·d` (0.2 mm at a 0.4 mm nozzle) clears the band
+/// edge without reaching across a genuine one-sided neck to the surface on its
+/// far flank.
+const GAP_FILL_SURFACE_PROBE_OVERREACH_NOZZLE_MULT: f64 = 0.5;
+
+/// Fraction of a gap-fill bead's vertices that must be flanked by solid surface
+/// on **both** sides for the bead to count as redundant with that surface.
+const GAP_FILL_SANDWICH_MAJORITY: f64 = 0.5;
+
+/// True when a gap-fill `bead` runs *through* a solid-surface region — the
+/// surface abuts it on **both** perpendicular sides — so filling it as gap fill
+/// merely double-extrudes over the surface the pipeline already lays down.
+///
+/// ## Why the plain "inside `solid_regions`" test misses this
+///
+/// `blocked_for_surface` unions the gap-fill footprint out of the surface region
+/// so the surface fill *abuts* rather than welds onto genuine thin necks.  That
+/// leaves a bead-wide corridor in `solid_regions` exactly where each gap-fill
+/// bead sits, so a bead centred in a solid strip is never "inside" the surface —
+/// yet the surface's rectilinear zig-zag, laid at full extrusion width, still
+/// deposits straight over it (measured on the 3DBenchy rear rail, ≈ layer 200:
+/// 6 mm² of GapFill∩TopSurface double-extrusion that a footprint-erosion overlap
+/// scan hides because the bead is thin).
+///
+/// ## The discriminator
+///
+/// Probe each bead vertex a short distance to either perpendicular side
+/// (`half-width + `[`GAP_FILL_SURFACE_PROBE_OVERREACH_NOZZLE_MULT`]`·d`), just
+/// past the carved-out corridor.  A bead the surface *surrounds* (rear rail,
+/// embossed-logo channel) has surface on both probes; a genuine thin neck that
+/// merely *abuts* a surface edge has it on at most one.  Requiring both sides on
+/// a majority of vertices ([`GAP_FILL_SANDWICH_MAJORITY`]) drops the redundant
+/// centre-of-strip beads while keeping every load-bearing thin-neck bead.
+fn gap_fill_sandwiched_by_surface(
+    bead: &clipper2::Path,
+    vertex_widths: Option<&[f64]>,
+    scalar_width: Option<f64>,
+    nozzle_diameter_mm: f64,
+    solid_regions: &Paths,
+) -> bool {
+    let pts: Vec<(f64, f64)> = bead.iter().map(|p| (p.x(), p.y())).collect();
+    if pts.len() < 2 {
+        return false;
+    }
+    let overreach = GAP_FILL_SURFACE_PROBE_OVERREACH_NOZZLE_MULT * nozzle_diameter_mm;
+    let default_half = 0.5 * nozzle_diameter_mm;
+    let mut total = 0_usize;
+    let mut sandwiched = 0_usize;
+    for j in 0..pts.len() {
+        // Tangent from the neighbours (forward/back difference at the ends).
+        let prev = pts[j.saturating_sub(1)];
+        let next = pts[(j + 1).min(pts.len() - 1)];
+        let (tx, ty) = (next.0 - prev.0, next.1 - prev.1);
+        let len = (tx * tx + ty * ty).sqrt();
+        if len <= 1e-9 {
+            continue;
+        }
+        // Perpendicular unit vector.
+        let (px, py) = (-ty / len, tx / len);
+        let half_w = vertex_widths
+            .and_then(|w| w.get(j).copied())
+            .or(scalar_width)
+            .map(|w| 0.5 * w)
+            .unwrap_or(default_half);
+        let reach = half_w + overreach;
+        let (vx, vy) = pts[j];
+        let side_a = vertex_inside_or_on_paths_eo(vx + px * reach, vy + py * reach, solid_regions);
+        let side_b = vertex_inside_or_on_paths_eo(vx - px * reach, vy - py * reach, solid_regions);
+        total += 1;
+        if side_a && side_b {
+            sandwiched += 1;
+        }
+    }
+    total > 0 && (sandwiched as f64) > GAP_FILL_SANDWICH_MAJORITY * (total as f64)
+}
+
+/// Remove `GapFill` beads that are already covered by a solid-surface region.
 ///
 /// Arachne emits medial gap fill over *every* thin residual its offset loops
 /// leave — including thin necks deep inside the solid interior.  On a solid
 /// layer the top/bottom surface fills that interior densely, so a gap bead
 /// there is redundant; since the surface is generated in full first, the bead
 /// would otherwise sit as a scattered variable-width island on the uniform
-/// surface (the isolated dashes visible across the Benchy first layer).
+/// surface (the isolated dashes visible across the Benchy first layer), or —
+/// where it runs down the centre of a thin solid strip — double-extrude
+/// straight under the surface's zig-zag (the Benchy rear-rail "unexplained gap
+/// bead under a top surface" defect).
 ///
-/// Fill priority is **solid surface > gap fill > sparse infill**: a bead whose
-/// majority of vertices lie inside `solid_regions` (even-odd test) loses to the
-/// surface and is dropped; gap fill in sparse zones and thin ribs (outside
-/// `solid_regions`) is kept, because sparse infill would skip those sub-nozzle
-/// channels.  Runs after surface generation, before sparse infill.
-pub(super) fn prune_redundant_gap_fill(layers: &mut [SliceLayer]) {
+/// Fill priority is **solid surface > gap fill > sparse infill**.  A bead is
+/// dropped when either
+///
+/// 1. a majority of its vertices lie **inside** `solid_regions` (the bead sits
+///    in a filled surface), or
+/// 2. it is **sandwiched** by surface on both perpendicular sides
+///    ([`gap_fill_sandwiched_by_surface`]) — the surface surrounds it even
+///    though `blocked_for_surface` carved a bead-wide corridor out of
+///    `solid_regions` so the plain inside-test would miss it.
+///
+/// Gap fill in sparse zones and genuine thin ribs (surface on at most one side)
+/// is kept, because sparse infill would skip those sub-nozzle channels.  Runs
+/// after surface generation, before sparse infill.
+pub(super) fn prune_redundant_gap_fill(layers: &mut [SliceLayer], nozzle_diameter_mm: f64) {
     for layer in layers.iter_mut() {
         if layer.solid_regions.is_empty() || !layer.path_roles.contains(&ExtrusionRole::GapFill) {
             continue;
@@ -488,7 +580,14 @@ pub(super) fn prune_redundant_gap_fill(layers: &mut [SliceLayer]) {
                         inside += 1;
                     }
                 }
-                total > 0 && inside * 2 > total
+                (total > 0 && inside * 2 > total)
+                    || gap_fill_sandwiched_by_surface(
+                        path,
+                        layer.vertex_widths_for_path(i).as_deref(),
+                        layer.width_for_path(i),
+                        nozzle_diameter_mm,
+                        &layer.solid_regions,
+                    )
             };
             if redundant {
                 continue;
@@ -2562,6 +2661,64 @@ mod tests {
         assert!(
             !layers[0].path_roles.contains(&ExtrusionRole::TopSurface),
             "a top surface over a thin wall-band channel must be dropped"
+        );
+    }
+
+    /// A gap-fill bead running down the centre of a solid-surface strip (surface
+    /// on both perpendicular sides) is redundant with the surface and must be
+    /// pruned — the Benchy rear-rail "gap bead under a top surface" defect.
+    #[test]
+    fn test_prune_gap_fill_sandwiched_by_surface() {
+        let mut layer = SliceLayer::new(0.2);
+        // Gap-fill bead: a horizontal 0.56 mm-wide centreline at y = 0.
+        let bead: Path = vec![(-8.0, 0.0), (8.0, 0.0)].into();
+        layer.paths.push(bead);
+        layer.path_roles.push(ExtrusionRole::GapFill);
+        layer.path_widths.push(Some(0.56));
+        layer.path_vertex_widths.push(Some(vec![0.56, 0.56]));
+        layer.path_is_open.push(true);
+
+        // solid_regions: two surface bands flanking the bead with a bead-wide
+        // corridor carved out (as `blocked_for_surface` does): the corridor is
+        // the bead's half-width (0.28 mm), so the surface starts at y = ±0.3 —
+        // present on BOTH sides.
+        let top_band: Path = vec![(-8.0, 0.3), (8.0, 0.3), (8.0, 1.3), (-8.0, 1.3)].into();
+        let bot_band: Path = vec![(-8.0, -1.3), (8.0, -1.3), (8.0, -0.3), (-8.0, -0.3)].into();
+        layer.solid_regions = Paths::new(vec![top_band, bot_band]);
+
+        let mut layers = vec![layer];
+        prune_redundant_gap_fill(&mut layers, 0.4);
+
+        assert!(
+            !layers[0].path_roles.contains(&ExtrusionRole::GapFill),
+            "a gap bead flanked by surface on both sides must be pruned"
+        );
+    }
+
+    /// A gap-fill bead that a solid surface only abuts on **one** side is a
+    /// genuine thin neck (sparse infill would skip it) and must be kept.
+    #[test]
+    fn test_keep_gap_fill_abutting_surface_one_side() {
+        let mut layer = SliceLayer::new(0.2);
+        let bead: Path = vec![(-8.0, 0.0), (8.0, 0.0)].into();
+        layer.paths.push(bead);
+        layer.path_roles.push(ExtrusionRole::GapFill);
+        layer.path_widths.push(Some(0.56));
+        layer.path_vertex_widths.push(Some(vec![0.56, 0.56]));
+        layer.path_is_open.push(true);
+
+        // Surface present on ONE side only (y ∈ [0.3, 1.3], reachable by the
+        // probe); the other side is open (a wall band the sparse infill can't
+        // reach).
+        let top_band: Path = vec![(-8.0, 0.3), (8.0, 0.3), (8.0, 1.3), (-8.0, 1.3)].into();
+        layer.solid_regions = Paths::new(vec![top_band]);
+
+        let mut layers = vec![layer];
+        prune_redundant_gap_fill(&mut layers, 0.4);
+
+        assert!(
+            layers[0].path_roles.contains(&ExtrusionRole::GapFill),
+            "a gap bead with surface on only one side is a real neck — keep it"
         );
     }
 }

--- a/src/core/surfaces.rs
+++ b/src/core/surfaces.rs
@@ -43,6 +43,25 @@ fn union_or_first(a: Paths, b: Paths) -> Paths {
     }
 }
 
+/// Union of a layer's detected `bridge`, `bottom`, and `top` surface regions —
+/// the full area that will be solid-filled — for the gap-fill sandwich test in
+/// [`compute_gap_fill_footprint_excluding_sandwiched`].  Borrows its inputs
+/// (unlike [`union_or_first`]) so the detection tuple is left intact.
+fn combined_surface_region(bridge: &Paths, bottom: &Paths, top: &Paths) -> Paths {
+    let mut acc = Paths::new(vec![]);
+    for part in [bridge, bottom, top] {
+        if part.is_empty() {
+            continue;
+        }
+        acc = if acc.is_empty() {
+            part.clone()
+        } else {
+            union(acc, part.clone(), FillRule::EvenOdd).unwrap_or_default()
+        };
+    }
+    acc
+}
+
 /// Center-to-center spacing (mm) for solid top/bottom **surface** fill lines.
 ///
 /// Uses the libslic3r/Orca/PrusaSlicer **extrusion-spacing** relation so that
@@ -321,6 +340,23 @@ fn morphological_open(paths: Paths, radius_mm: f64) -> Paths {
 /// Bridge detection and solid top/bottom surfaces subtract this so nothing is
 /// deposited on top of an existing wall or gap-fill bead.
 pub(super) fn compute_wall_bead_footprint(layer: &SliceLayer, nozzle_diameter_mm: f64) -> Paths {
+    compute_wall_bead_footprint_filtered(layer, nozzle_diameter_mm, true)
+}
+
+/// Like [`compute_wall_bead_footprint`] but, when `include_gap_fill` is `false`,
+/// omits `GapFill` beads from the footprint.
+///
+/// The solid top/bottom surface trim uses the walls-only footprint because it
+/// carves the gap-fill footprint separately via
+/// [`compute_gap_fill_footprint_excluding_sandwiched`], which drops beads that
+/// are redundant with the surface.  Including gap fill here as well would
+/// re-add those redundant beads and punch the same bead-wide hole back into the
+/// surface (the 3DBenchy rear-rail defect this exclusion targets).
+pub(super) fn compute_wall_bead_footprint_filtered(
+    layer: &SliceLayer,
+    nozzle_diameter_mm: f64,
+    include_gap_fill: bool,
+) -> Paths {
     // Group wall paths by (is_open, radius-bucket) so we can run **one**
     // `inflate` call per group instead of one per path.  Clipper2's `inflate`
     // takes a `Paths` and offsets every contained sub-path together — there
@@ -343,14 +379,14 @@ pub(super) fn compute_wall_bead_footprint(layer: &SliceLayer, nozzle_diameter_mm
         // bridge over.  `OverhangPerimeter` is included because the
         // overhang post-pass relabels in-air wall arcs, and bridges still
         // must not overlap them; `GapFill` deposits material inside the wall
-        // band and must likewise not be bridged over.
-        if !matches!(
+        // band and must likewise not be bridged over — but the surface trim
+        // passes `include_gap_fill = false` because it accounts for gap fill
+        // separately (and drops beads redundant with the surface).
+        let role_included = matches!(
             role,
-            ExtrusionRole::OuterWall
-                | ExtrusionRole::InnerWall
-                | ExtrusionRole::OverhangPerimeter
-                | ExtrusionRole::GapFill
-        ) {
+            ExtrusionRole::OuterWall | ExtrusionRole::InnerWall | ExtrusionRole::OverhangPerimeter
+        ) || (include_gap_fill && role == ExtrusionRole::GapFill);
+        if !role_included {
             continue;
         }
 
@@ -413,11 +449,56 @@ pub(super) fn compute_wall_bead_footprint(layer: &SliceLayer, nozzle_diameter_mm
 /// otherwise account for).  Gap-fill beads number in the tens per layer, so a
 /// per-path inflate + union is ample.
 pub(super) fn compute_gap_fill_footprint(layer: &SliceLayer, nozzle_diameter_mm: f64) -> Paths {
+    compute_gap_fill_footprint_filtered(layer, nozzle_diameter_mm, None)
+}
+
+/// Physical bead footprint of the layer's gap-fill beads, **excluding** any bead
+/// that is sandwiched by (redundant with) `surface_region`.
+///
+/// Used when trimming a solid top/bottom surface: a gap-fill bead running down
+/// the centre of the surface strip is sandwiched by the surface on both sides,
+/// so [`prune_redundant_gap_fill`] deletes it later — and carving its footprint
+/// out of the surface (as the plain [`compute_gap_fill_footprint`] would) leaves
+/// a bead-wide **hole** in the surface region.  On a thin roof (the 3DBenchy
+/// rear rail, ≈ layer 200) that hole both splits the surface serpentine into two
+/// disconnected bands *and* is then re-filled with sparse-infill dashes over the
+/// void the pruned bead left — the "two infill surfaces plus tiny blobs" defect.
+/// Excluding sandwiched beads lets the surface cover the whole strip as one
+/// region; genuine thin necks (surface on only one side) are still carved so the
+/// surface abuts, never welds onto, them.
+fn compute_gap_fill_footprint_excluding_sandwiched(
+    layer: &SliceLayer,
+    nozzle_diameter_mm: f64,
+    surface_region: &Paths,
+) -> Paths {
+    compute_gap_fill_footprint_filtered(layer, nozzle_diameter_mm, Some(surface_region))
+}
+
+/// Shared implementation for [`compute_gap_fill_footprint`] and
+/// [`compute_gap_fill_footprint_excluding_sandwiched`].  When `skip_sandwiched`
+/// is `Some(region)`, a gap-fill bead flanked by that region on both sides is
+/// omitted from the footprint.
+fn compute_gap_fill_footprint_filtered(
+    layer: &SliceLayer,
+    nozzle_diameter_mm: f64,
+    skip_sandwiched: Option<&Paths>,
+) -> Paths {
     let default_radius = nozzle_diameter_mm * 0.5;
     let mut acc = Paths::new(vec![]);
     for (i, path) in layer.paths.iter().enumerate() {
         if layer.role_for_path(i) != ExtrusionRole::GapFill {
             continue;
+        }
+        if let Some(region) = skip_sandwiched {
+            if gap_fill_sandwiched_by_surface(
+                path,
+                layer.vertex_widths_for_path(i).as_deref(),
+                layer.width_for_path(i),
+                nozzle_diameter_mm,
+                region,
+            ) {
+                continue;
+            }
         }
         let radius = layer
             .width_for_path(i)
@@ -1435,9 +1516,17 @@ pub fn generate_top_bottom_surfaces_with_interior(
     // top/bottom surface trim (see the gated parallel pass after detection for
     // the full rationale and why it is now computed lazily).  Defined here as a
     // closure so both that pass and the wasm fallback share it.
+    //
+    // `surface_region` is the layer's combined (bottom ∪ top ∪ bridge) detected
+    // surface *before* this trim.  It is used to skip gap-fill beads that are
+    // sandwiched by (redundant with) the surface: those beads are pruned by
+    // `prune_redundant_gap_fill`, so carving their footprint out here would
+    // leave a bead-wide hole the surface serpentine has to route around (two
+    // bands) and sparse infill then leaks into.  Genuine one-sided necks are
+    // still carved so the surface abuts them.
     let surface_bond = (config.infill_overlap_percent * nozzle_diameter_mm).max(0.0);
-    let blocked_for_surface = |l: &SliceLayer| -> Paths {
-        let wall_fp = compute_wall_bead_footprint(l, nozzle_diameter_mm);
+    let blocked_for_surface = |l: &SliceLayer, surface_region: &Paths| -> Paths {
+        let wall_fp = compute_wall_bead_footprint_filtered(l, nozzle_diameter_mm, false);
         if wall_fp.is_empty() {
             return Paths::new(vec![]);
         }
@@ -1452,7 +1541,8 @@ pub fn generate_top_bottom_surfaces_with_interior(
         } else {
             wall_fp
         };
-        let gap_fp = compute_gap_fill_footprint(l, nozzle_diameter_mm);
+        let gap_fp =
+            compute_gap_fill_footprint_excluding_sandwiched(l, nozzle_diameter_mm, surface_region);
         if gap_fp.is_empty() {
             eroded
         } else if eroded.is_empty() {
@@ -1968,11 +2058,12 @@ pub fn generate_top_bottom_surfaces_with_interior(
         (0..total)
             .into_par_iter()
             .map(|i| {
-                let (_, bottom, top, _) = &regions[i];
+                let (bridge, bottom, top, _) = &regions[i];
                 if bottom.is_empty() && top.is_empty() {
                     Paths::new(vec![])
                 } else {
-                    blocked_for_surface(&layers[i])
+                    let surface_region = combined_surface_region(bridge, bottom, top);
+                    blocked_for_surface(&layers[i], &surface_region)
                 }
             })
             .collect()
@@ -1980,11 +2071,12 @@ pub fn generate_top_bottom_surfaces_with_interior(
     #[cfg(target_arch = "wasm32")]
     let surface_blocked: Vec<Paths> = (0..total)
         .map(|i| {
-            let (_, bottom, top, _) = &regions[i];
+            let (bridge, bottom, top, _) = &regions[i];
             if bottom.is_empty() && top.is_empty() {
                 Paths::new(vec![])
             } else {
-                blocked_for_surface(&layers[i])
+                let surface_region = combined_surface_region(bridge, bottom, top);
+                blocked_for_surface(&layers[i], &surface_region)
             }
         })
         .collect();
@@ -2719,6 +2811,83 @@ mod tests {
         assert!(
             layers[0].path_roles.contains(&ExtrusionRole::GapFill),
             "a gap bead with surface on only one side is a real neck — keep it"
+        );
+    }
+
+    /// The walls-only wall-bead footprint (`include_gap_fill = false`) must omit
+    /// gap-fill beads, so the solid-surface trim does not re-carve a gap bead it
+    /// accounts for separately — the fix for the 3DBenchy rear-rail hole that
+    /// split the surface into two bands and leaked sparse infill.
+    #[test]
+    fn test_wall_footprint_excludes_gap_fill_when_requested() {
+        let mut layer = SliceLayer::new(0.2);
+        // An outer wall loop around a thin strip.
+        let wall: Path = vec![(-8.0, -0.9), (8.0, -0.9), (8.0, 0.9), (-8.0, 0.9)].into();
+        layer.paths.push(wall);
+        layer.path_roles.push(ExtrusionRole::OuterWall);
+        layer.path_widths.push(Some(0.4));
+        layer.path_vertex_widths.push(None);
+        layer.path_is_open.push(false);
+        // A gap-fill bead down the centre.
+        let bead: Path = vec![(-7.0, 0.0), (7.0, 0.0)].into();
+        layer.paths.push(bead);
+        layer.path_roles.push(ExtrusionRole::GapFill);
+        layer.path_widths.push(Some(0.56));
+        layer.path_vertex_widths.push(Some(vec![0.56, 0.56]));
+        layer.path_is_open.push(true);
+
+        let with_gap = compute_wall_bead_footprint_filtered(&layer, 0.4, true);
+        let without_gap = compute_wall_bead_footprint_filtered(&layer, 0.4, false);
+        let area = |p: &Paths| p.iter().map(|q| q.signed_area().abs()).sum::<f64>();
+        assert!(
+            area(&with_gap) > area(&without_gap) + 1.0,
+            "including gap fill must add the centre bead's area ({:.2} vs {:.2})",
+            area(&with_gap),
+            area(&without_gap)
+        );
+    }
+
+    /// The surface-carve gap footprint must exclude a bead sandwiched by the
+    /// surface (it is pruned, so carving it would hole the surface) while still
+    /// carving a genuine one-sided neck (so the surface abuts it).
+    #[test]
+    fn test_gap_footprint_excludes_sandwiched_only() {
+        let mut layer = SliceLayer::new(0.2);
+        // Sandwiched centre bead.
+        let mid: Path = vec![(-7.0, 0.0), (7.0, 0.0)].into();
+        layer.paths.push(mid);
+        layer.path_roles.push(ExtrusionRole::GapFill);
+        layer.path_widths.push(Some(0.56));
+        layer.path_vertex_widths.push(Some(vec![0.56, 0.56]));
+        layer.path_is_open.push(true);
+        // Genuine neck poking out below the surface (surface only above it).
+        let neck: Path = vec![(-7.0, -3.0), (7.0, -3.0)].into();
+        layer.paths.push(neck);
+        layer.path_roles.push(ExtrusionRole::GapFill);
+        layer.path_widths.push(Some(0.56));
+        layer.path_vertex_widths.push(Some(vec![0.56, 0.56]));
+        layer.path_is_open.push(true);
+
+        // Surface flanks the centre bead on both sides (y ∈ ±[0.3,1.3]); the neck
+        // at y=-3 has surface on neither side.
+        let top: Path = vec![(-8.0, 0.3), (8.0, 0.3), (8.0, 1.3), (-8.0, 1.3)].into();
+        let bot: Path = vec![(-8.0, -1.3), (8.0, -1.3), (8.0, -0.3), (-8.0, -0.3)].into();
+        let surface = Paths::new(vec![top, bot]);
+
+        let all = compute_gap_fill_footprint(&layer, 0.4);
+        let excl = compute_gap_fill_footprint_excluding_sandwiched(&layer, 0.4, &surface);
+        let area = |p: &Paths| p.iter().map(|q| q.signed_area().abs()).sum::<f64>();
+        // The excluding footprint keeps the neck but drops the sandwiched centre
+        // bead, so it is strictly smaller than the all-beads footprint.
+        assert!(
+            area(&excl) > 1.0,
+            "the genuine neck must remain in the footprint"
+        );
+        assert!(
+            area(&excl) < area(&all) - 1.0,
+            "the sandwiched centre bead must be dropped ({:.2} vs {:.2})",
+            area(&excl),
+            area(&all)
         );
     }
 }

--- a/src/core/surfaces.rs
+++ b/src/core/surfaces.rs
@@ -307,7 +307,7 @@ fn principal_axis_angle_deg(paths: &Paths) -> Option<f64> {
 /// Removes thin features (slivers, hair-thin connecting strands) narrower
 /// than `2 × radius_mm` while preserving larger regions almost unchanged.
 /// A no-op when `radius_mm <= 0`.
-fn morphological_open(paths: Paths, radius_mm: f64) -> Paths {
+pub(super) fn morphological_open(paths: Paths, radius_mm: f64) -> Paths {
     // 1e-6 mm = 1 nm — well below any real geometry and below Clipper2's
     // Centi quantisation (10 µm).  Anything smaller is rounding noise and
     // a no-op is the right behaviour.

--- a/src/settings/README.md
+++ b/src/settings/README.md
@@ -15,7 +15,7 @@ Configuration for slicing behavior and printer control. All values stored as JSO
 | `nozzle_temp`             | °C   | 210       | 180–250                             | Heat level (material-dependent)                               |
 | `bed_temp`                | °C   | 60        | 20–100                              | Bed heat (material-dependent)                                 |
 | `seam_position`           | enum | `nearest` | see [Seam Position](#seam-position) | Where each closed-loop seam sits                              |
-| `min_infill_extrusion_mm` | mm   | 0.4       | 0.0–nozzle                          | Drops sub-threshold solid-infill segments to cut tiny travels |
+| `min_infill_extrusion_mm` | mm   | 0.4       | 0.0–nozzle                          | Drops sub-threshold solid-surface and sparse-infill segments to cut tiny travels |
 | `coasting_distance_mm`    | mm   | 0.2       | 0.0–1.0                             | Length of un-extruded tail at the end of each path            |
 | `thumbnail_enabled`       | bool | `true`    | true/false                          | Embed a PNG thumbnail comment block in output G-code (Thumbnail group) |
 | `thumbnail_size_px`       | px   | 320       | 64–1024                             | Square thumbnail resolution (the quality knob)                 |

--- a/src/settings/params.rs
+++ b/src/settings/params.rs
@@ -764,8 +764,12 @@ Set to `0` to fall back to `perimeter_speed` (then `print_speed`).
         description = "Minimum length in mm for a gap-fill bead to be kept.
 
 Gap-fill beads shorter than this are dropped to avoid stringy sub-millimetre
-dribbles the medial pass finds along faceted boundaries.  Set to `0` to use the
-automatic default (one nozzle diameter).
+dribbles the medial pass finds along faceted boundaries — the isolated \"splat\"
+beads that waste print time on a retract/travel/un-retract cycle and risk
+filament grinding for a mechanically-insignificant dab.  Set to `0` to use the
+automatic default (twice the nozzle diameter), which matches the faceting-noise
+floor used when de-noising the medial skeleton; the residual such short beads
+would have filled is bridged by the squish of the flanking wall beads.
 **Typical:** 0.4–1.0 mm.",
         extend("x-group" = "Walls")
     )]
@@ -996,12 +1000,14 @@ where the infill pattern shows through the outer wall.
     pub infill_perimeter_gap_mm: f64,
 
     #[schemars(
-        description = "Minimum solid infill line length in mm.
+        description = "Minimum infill line length in mm.
 
 Scan-line segments shorter than this threshold are discarded instead of being
-printed. Tiny slivers at curved or diagonal surface boundaries waste printhead
-motion without meaningfully improving coverage — adjacent lines overlap to fill
-the gap naturally.
+printed, for **both** solid top/bottom surface fill and sparse infill. Tiny
+slivers at curved or diagonal boundaries — and isolated sparse-infill dashes in
+narrow corners — waste printhead motion (a full retract/travel/un-retract for a
+mechanically-insignificant dab) without meaningfully improving coverage;
+adjacent lines and the flanking walls fill the space naturally.
 
 Set to the nozzle diameter for best results (e.g. `0.4` for a 0.4 mm nozzle).
 Set to `0.0` to disable the filter entirely.

--- a/src/walls/arachne/generate.rs
+++ b/src/walls/arachne/generate.rs
@@ -301,11 +301,7 @@ fn emit_residual_medial_fill(
     // ≥ `min_len · min_w`.  A residual sub-region below that bound can never
     // host a printable bead, so skip its (expensive) Voronoi/skeleton build.
     // 97 % of Benchy residual slivers fall here; the skip is loss-free.
-    let min_len = if params.gap_fill_min_length_mm > 0.0 {
-        params.gap_fill_min_length_mm
-    } else {
-        d
-    };
+    let min_len = gap_fill_min_run_len_mm(params);
     let min_area = params.wall_line_width_min_mm * min_len;
     for sub in split_islands(&uncovered) {
         let area = sub.iter().map(|p| p.signed_area()).sum::<f64>().abs();
@@ -385,6 +381,41 @@ const GAP_SPUR_PRUNE_RATIO: f64 = 0.6;
 /// unchanged (a larger floor starts nibbling fine embossed-logo detail); the
 /// coincidence-free wall property is untouched because walls are not modified.
 const GAP_SPUR_MIN_LEN_FACTOR: f64 = 2.0;
+
+/// Minimum emitted gap-fill **run** length, as a multiple of the nozzle
+/// diameter, used when the caller leaves `gap_fill_min_length_mm` at its `0`
+/// "auto" default.
+///
+/// A run shorter than this deposits a mechanically-insignificant dab of
+/// material (below `2·d × min_width` ≈ 0.3 mm² at a 0.4 mm nozzle) yet still
+/// costs a full retract → travel → un-retract cycle to reach — the "tiny
+/// inner-body splat" that wastes print time and invites filament grinding.  The
+/// sub-`2·d` residual such a run would have filled is already bridged by the
+/// squish of the wall beads flanking it: the `classic` generator leaves the
+/// identical curved/tapering wall-band corners bead-free with no measurable
+/// wall-zone void (verified with [`tools/gcode-analysis/voids.py`]).  Dropping
+/// them clears the splat swarm (~270 isolated beads on the 3DBenchy) with no
+/// change in void coverage.
+///
+/// It matches [`GAP_SPUR_MIN_LEN_FACTOR`] on purpose: a run below the same `2·d`
+/// floor that separates a real gap spine from facet-noise spurs is itself facet
+/// noise once isolated as its own bead.  A user who wants the old, denser
+/// behaviour can set an explicit smaller `gap_fill_min_length_mm`.
+const GAP_FILL_MIN_RUN_LEN_FACTOR: f64 = 2.0;
+
+/// Resolve the effective minimum gap-fill run length (mm): the explicit
+/// `gap_fill_min_length_mm` when the user set one (`> 0`), else
+/// [`GAP_FILL_MIN_RUN_LEN_FACTOR`] × nozzle diameter.  Shared by the residual
+/// pre-filter ([`emit_residual_medial_fill`]) and the per-run emit filter
+/// ([`emit_medial_beads`]) so the two never disagree on what counts as a
+/// printable run.
+fn gap_fill_min_run_len_mm(params: &WallParams) -> f64 {
+    if params.gap_fill_min_length_mm > 0.0 {
+        params.gap_fill_min_length_mm
+    } else {
+        GAP_FILL_MIN_RUN_LEN_FACTOR * params.nozzle_diameter_mm
+    }
+}
 
 /// Medial-fill a (thin) region: emit variable-width open beads along its medial
 /// axis wherever the local thickness (2·radius) is a printable `[min, max]`
@@ -473,11 +504,7 @@ fn emit_medial_beads(
     // user asked for (visible as blobs / dimensional bulge, especially layer 1).
     let max_w = params.wall_line_width_max_mm;
     let gap_max = 2.5 * params.nozzle_diameter_mm;
-    let min_len = if params.gap_fill_min_length_mm > 0.0 {
-        params.gap_fill_min_length_mm
-    } else {
-        params.nozzle_diameter_mm
-    };
+    let min_len = gap_fill_min_run_len_mm(params);
     let mut run: Vec<(f64, f64)> = Vec::new();
     let mut run_w: Vec<f64> = Vec::new();
 
@@ -658,6 +685,42 @@ mod tests {
         assert_eq!(
             closed_loops, 0,
             "a nozzle-thick rib should NOT get a degenerate closed loop"
+        );
+    }
+
+    #[test]
+    fn gap_fill_min_run_len_auto_default_is_two_nozzle() {
+        // With the param left at its 0 "auto" default, the floor is 2·d — the
+        // faceting-noise floor that keeps sub-2·d splat beads out.
+        let mut p = wall_params();
+        p.gap_fill_min_length_mm = 0.0;
+        p.nozzle_diameter_mm = 0.4;
+        assert!((gap_fill_min_run_len_mm(&p) - 0.8).abs() < 1e-9);
+
+        // An explicit value overrides the auto default verbatim.
+        p.gap_fill_min_length_mm = 0.3;
+        assert!((gap_fill_min_run_len_mm(&p) - 0.3).abs() < 1e-9);
+    }
+
+    #[test]
+    fn short_residual_gap_yields_no_splat_bead() {
+        // A 0.6 mm-long, ~0.5 mm-thick residual pocket is below the 2·d = 0.8 mm
+        // auto floor, so it must NOT emit an isolated gap-fill "splat" bead.
+        let mut layer = SliceLayer::new(0.2);
+        // A short thin rib: 0.6 mm long (x), 0.5 mm thick (y).
+        let rib: Path = vec![(-0.3, -0.25), (0.3, -0.25), (0.3, 0.25), (-0.3, 0.25)].into();
+        layer.paths.push(rib);
+        layer.path_roles.push(ExtrusionRole::OuterWall);
+        layer.path_widths.push(None);
+
+        generate_arachne_walls_for_layer(&mut layer, &wall_params());
+
+        let open_beads = (0..layer.paths.len())
+            .filter(|&i| layer.is_path_open(i))
+            .count();
+        assert_eq!(
+            open_beads, 0,
+            "a sub-2·d residual must not emit a gap-fill splat bead, got {open_beads}"
         );
     }
 }

--- a/tests/qa/baselines/benchy_arachne.json
+++ b/tests/qa/baselines/benchy_arachne.json
@@ -5,15 +5,15 @@
   "z_max": 47.9,
   "bbox_x_mm": 30.6,
   "bbox_y_mm": 59.6,
-  "total_extrusion_mm": 115693.2,
+  "total_extrusion_mm": 115207.1,
   "role_extrusion_mm": {
     "bottom_surface": 5393.4,
     "bridge": 636.0,
-    "gap_fill": 7589.5,
-    "infill": 18617.9,
-    "inner_wall": 41154.3,
-    "outer_wall": 32331.1,
+    "gap_fill": 7403.5,
+    "infill": 18288.0,
+    "inner_wall": 41154.2,
+    "outer_wall": 32331.0,
     "overhang_wall": 370.8,
-    "top_surface": 9600.1
+    "top_surface": 9630.3
   }
 }

--- a/tests/qa/baselines/benchy_classic.json
+++ b/tests/qa/baselines/benchy_classic.json
@@ -5,11 +5,11 @@
   "z_max": 47.9,
   "bbox_x_mm": 30.6,
   "bbox_y_mm": 59.6,
-  "total_extrusion_mm": 118575.2,
+  "total_extrusion_mm": 118216.6,
   "role_extrusion_mm": {
     "bottom_surface": 5395.0,
     "bridge": 637.5,
-    "infill": 18737.6,
+    "infill": 18378.9,
     "inner_wall": 51543.0,
     "outer_wall": 32331.0,
     "overhang_wall": 394.7,

--- a/tests/qa/baselines/caddy_arachne.json
+++ b/tests/qa/baselines/caddy_arachne.json
@@ -5,14 +5,14 @@
   "z_max": 19.9,
   "bbox_x_mm": 67.1,
   "bbox_y_mm": 77.7,
-  "total_extrusion_mm": 286546.1,
+  "total_extrusion_mm": 286047.0,
   "role_extrusion_mm": {
     "bottom_surface": 42341.1,
-    "gap_fill": 38000.0,
-    "infill": 8507.6,
+    "gap_fill": 37723.1,
+    "infill": 8185.5,
     "inner_wall": 105300.4,
     "outer_wall": 54310.1,
     "overhang_wall": 11.1,
-    "top_surface": 38075.9
+    "top_surface": 38175.8
   }
 }

--- a/tests/qa/baselines/caddy_classic.json
+++ b/tests/qa/baselines/caddy_classic.json
@@ -5,10 +5,10 @@
   "z_max": 19.9,
   "bbox_x_mm": 67.1,
   "bbox_y_mm": 77.7,
-  "total_extrusion_mm": 253327.6,
+  "total_extrusion_mm": 252931.8,
   "role_extrusion_mm": {
     "bottom_surface": 42341.3,
-    "infill": 13170.1,
+    "infill": 12774.3,
     "inner_wall": 105315.8,
     "outer_wall": 54310.1,
     "overhang_wall": 11.1,

--- a/tests/qa/baselines/hinge_arachne.json
+++ b/tests/qa/baselines/hinge_arachne.json
@@ -5,15 +5,15 @@
   "z_max": 5.9,
   "bbox_x_mm": 39.6,
   "bbox_y_mm": 31.07,
-  "total_extrusion_mm": 36464.7,
+  "total_extrusion_mm": 36433.7,
   "role_extrusion_mm": {
-    "bottom_surface": 8025.5,
+    "bottom_surface": 8036.0,
     "bridge": 134.4,
-    "gap_fill": 524.1,
-    "infill": 3374.2,
+    "gap_fill": 482.9,
+    "infill": 3351.5,
     "inner_wall": 10701.7,
     "outer_wall": 6372.6,
     "overhang_wall": 240.6,
-    "top_surface": 7091.6
+    "top_surface": 7114.1
   }
 }

--- a/tests/qa/baselines/hinge_classic.json
+++ b/tests/qa/baselines/hinge_classic.json
@@ -5,11 +5,11 @@
   "z_max": 5.9,
   "bbox_x_mm": 39.6,
   "bbox_y_mm": 31.07,
-  "total_extrusion_mm": 36593.5,
+  "total_extrusion_mm": 36548.6,
   "role_extrusion_mm": {
     "bottom_surface": 8037.0,
     "bridge": 134.1,
-    "infill": 3416.9,
+    "infill": 3372.0,
     "inner_wall": 11222.4,
     "outer_wall": 6372.6,
     "overhang_wall": 287.0,

--- a/tests/qa/baselines/voron_arachne.json
+++ b/tests/qa/baselines/voron_arachne.json
@@ -5,15 +5,15 @@
   "z_max": 29.9,
   "bbox_x_mm": 29.6,
   "bbox_y_mm": 29.6,
-  "total_extrusion_mm": 124938.5,
+  "total_extrusion_mm": 124706.3,
   "role_extrusion_mm": {
-    "bottom_surface": 5513.1,
+    "bottom_surface": 5518.3,
     "bridge": 242.1,
-    "gap_fill": 513.6,
-    "infill": 31367.7,
-    "inner_wall": 53399.4,
+    "gap_fill": 435.6,
+    "infill": 31206.1,
+    "inner_wall": 53399.5,
     "outer_wall": 27695.0,
     "overhang_wall": 648.3,
-    "top_surface": 5559.3
+    "top_surface": 5561.5
   }
 }

--- a/tests/qa/baselines/voron_classic.json
+++ b/tests/qa/baselines/voron_classic.json
@@ -5,11 +5,11 @@
   "z_max": 29.9,
   "bbox_x_mm": 29.6,
   "bbox_y_mm": 29.6,
-  "total_extrusion_mm": 125184.6,
+  "total_extrusion_mm": 124985.7,
   "role_extrusion_mm": {
     "bottom_surface": 5524.8,
     "bridge": 242.7,
-    "infill": 31568.0,
+    "infill": 31369.2,
     "inner_wall": 53933.3,
     "outer_wall": 27695.1,
     "overhang_wall": 648.3,

--- a/tools/gcode-analysis/README.md
+++ b/tools/gcode-analysis/README.md
@@ -37,6 +37,7 @@ printf '[slicing]\nwall_generator = "classic"\n' > /tmp/classic.toml
 | `zoom.py` | Zoomed region drawing every bead as a filled capsule at its **actual `;WIDTH:`**, so you can see whether gap-fill beads truly span their gap. | `zoom.py <gcode> [layer] [cx] [cy] [half] [out.png]` |
 | `overlap.py` | **Cross-role double-extrusion**: pairwise footprint intersection between every role pair, with a ¼-nozzle-eroded **BODY** column that strips the expected boundary seam and leaves genuine bead-on-bead overlap (e.g. sparse infill re-extruding over a gap-fill bead). | `overlap.py <gcode> [layer\|all]` |
 | `beaddiff.py` | **Before/after visual diff** of one layer from two gcode files, every bead a capsule at its true `;WIDTH:`, role-coloured on a shared scale, with isolated short paths highlighted and counted. The image to attach to a PR. | `beaddiff.py <before> <after> [layer] [out.png] [cx cy half] [--short=0.8]` |
+| `wallbands.py` | **Wall-band anatomy of one island**: labels every island on a layer, then zooms one and draws its wall loops in print order (outer, inner-1, inner-2, …) as separate colours, so "between the two inner walls" is unambiguous. | `wallbands.py <gcode> <layer> [island] [out.png]` |
 
 ### Examples
 

--- a/tools/gcode-analysis/README.md
+++ b/tools/gcode-analysis/README.md
@@ -36,6 +36,7 @@ printf '[slicing]\nwall_generator = "classic"\n' > /tmp/classic.toml
 | `render.py` | Two generators side-by-side, red = wall-zone gap. Best for locating gaps. | `render.py <gcodeA> [layer=60] [gcodeB] [out.png]` |
 | `zoom.py` | Zoomed region drawing every bead as a filled capsule at its **actual `;WIDTH:`**, so you can see whether gap-fill beads truly span their gap. | `zoom.py <gcode> [layer] [cx] [cy] [half] [out.png]` |
 | `overlap.py` | **Cross-role double-extrusion**: pairwise footprint intersection between every role pair, with a ¼-nozzle-eroded **BODY** column that strips the expected boundary seam and leaves genuine bead-on-bead overlap (e.g. sparse infill re-extruding over a gap-fill bead). | `overlap.py <gcode> [layer\|all]` |
+| `beaddiff.py` | **Before/after visual diff** of one layer from two gcode files, every bead a capsule at its true `;WIDTH:`, role-coloured on a shared scale, with isolated short paths highlighted and counted. The image to attach to a PR. | `beaddiff.py <before> <after> [layer] [out.png] [cx cy half] [--short=0.8]` |
 
 ### Examples
 
@@ -57,7 +58,19 @@ python3 tools/gcode-analysis/zoom.py  /tmp/arachne.gcode 60 -11.5 -1 3.5 /tmp/hu
 # Which roles double-extrude over each other (e.g. infill over gap fill)? Compare to classic.
 python3 tools/gcode-analysis/overlap.py /tmp/arachne.gcode all
 python3 tools/gcode-analysis/overlap.py /tmp/classic.gcode all
+
+# Did my change actually fix the layer? Before/after, beads at true width —
+# this is the image to attach to the PR.
+python3 tools/gcode-analysis/beaddiff.py /tmp/before.gcode /tmp/after.gcode 41 /tmp/diff.png
+python3 tools/gcode-analysis/beaddiff.py /tmp/before.gcode /tmp/after.gcode 201 /tmp/rail.png 0.9 -12 2.2 --short=1.5
 ```
+
+> **Attach the picture to the PR.** Slicing changes are geometry; a diff and a
+> table do not let a reviewer see whether the toolpaths are right. See
+> [`.github/instructions/slicing-visual-verification.instructions.md`](../../.github/instructions/slicing-visual-verification.instructions.md)
+> for the full contract, including why a **centerline** plot must never be used
+> to verify one (two beads 0.3 mm apart look separate as lines and overlap as
+> material).
 
 > **Reading `overlap.py`.** Wall×surface and wall×infill body-overlap is largely
 > the *designed* `infill_overlap_percent` bond and shows up in **both**

--- a/tools/gcode-analysis/beaddiff.py
+++ b/tools/gcode-analysis/beaddiff.py
@@ -1,0 +1,224 @@
+#!/usr/bin/env python3
+"""Before/after bead diff: render one layer from TWO gcode files side by side,
+drawing every extrusion as a filled capsule at its ACTUAL ``;WIDTH:``.
+
+This is the "visual double check" for geometry changes. Centerline plots lie:
+two beads whose centerlines sit 0.3 mm apart look like tidy separate lines, but
+at their real 0.4-0.56 mm widths they are visibly *the same material laid twice*.
+Only a true-width capsule render makes double-extrusion, uncovered slivers and
+split/fragmented surfaces obvious to a human reviewer.
+
+Short isolated paths (the "tiny extrude / splat" defect class) are highlighted in
+magenta and counted in each title, because they are the single most common thing
+worth eyeballing after a fill/wall change.
+
+Usage
+-----
+    beaddiff.py <before.gcode> <after.gcode> [layer=60] [out.png]
+                [cx cy half] [--short=0.8] [--titles="Before|After"]
+
+``layer`` is a 1-based dense print-layer index (Z-bucketed, same convention as
+the other scripts here). Omit ``cx cy half`` to auto-fit both layers to a shared
+window; pass them to zoom on a feature. Both panels always share one scale so
+the comparison is honest.
+
+Examples
+--------
+    # whole layer, auto-fit
+    beaddiff.py /tmp/before.gcode /tmp/after.gcode 41 /tmp/diff.png
+
+    # zoom a 3 mm window on the rear rail, flag anything under 1.5 mm
+    beaddiff.py /tmp/before.gcode /tmp/after.gcode 201 /tmp/rail.png 0.9 -12 3 --short=1.5
+"""
+import sys
+import math
+
+import matplotlib
+
+matplotlib.use("Agg")
+import matplotlib.patches as mpatches
+import matplotlib.pyplot as plt
+from matplotlib.collections import PatchCollection
+from matplotlib.patches import Polygon as MPoly
+
+sys.path.insert(0, __file__.rsplit("/", 1)[0])
+from voids import parse_layers  # noqa: E402  (shared Z-bucketed parser)
+
+# Role -> (facecolor, alpha).  Walls are neutral greys so the *fills* — where
+# geometry bugs live — carry the colour.
+COLOR = {
+    "Outer wall": ((0.35, 0.35, 0.35), 0.55),
+    "Inner wall": ((0.25, 0.35, 0.85), 0.50),
+    "Overhang wall": ((0.00, 0.70, 0.80), 0.55),
+    "Gap infill": ((0.00, 0.70, 0.00), 0.60),
+    "Sparse infill": ((1.00, 0.60, 0.10), 0.60),
+    "Top surface": ((0.90, 0.30, 0.30), 0.45),
+    "Bottom surface": ((0.60, 0.20, 0.70), 0.45),
+    "Bridge": ((0.10, 0.45, 0.90), 0.55),
+}
+SHORT_COLOR = "magenta"
+DEFAULT_SHORT_MM = 0.8
+
+
+def capsule(x0, y0, x1, y1, w):
+    """Rectangle of width `w` about the segment (rounded caps are visually
+    irrelevant at these scales and cost a lot of patches)."""
+    dx, dy = x1 - x0, y1 - y0
+    L = math.hypot(dx, dy)
+    if L < 1e-9:
+        return None
+    r = w / 2.0
+    nx, ny = -dy / L * r, dx / L * r
+    return [(x0 + nx, y0 + ny), (x1 + nx, y1 + ny), (x1 - nx, y1 - ny), (x0 - nx, y0 - ny)]
+
+
+def group_paths(segs):
+    """Group a layer's ordered segments into contiguous extrusion *paths*.
+
+    `parse_layers` yields segments only; a path is a maximal run of segments
+    that share a role and are head-to-tail connected. Path length — not segment
+    length — is what determines whether an extrusion is an isolated "splat"
+    (a path is printed in one go; a segment is just one vertex-to-vertex hop).
+    """
+    paths = []
+    cur = None
+    for (x0, y0, x1, y1, w, typ) in segs:
+        if (
+            cur is not None
+            and cur["typ"] == typ
+            and abs(cur["end"][0] - x0) < 1e-6
+            and abs(cur["end"][1] - y0) < 1e-6
+        ):
+            cur["segs"].append((x0, y0, x1, y1, w))
+            cur["len"] += math.hypot(x1 - x0, y1 - y0)
+            cur["end"] = (x1, y1)
+        else:
+            if cur is not None:
+                paths.append(cur)
+            cur = {
+                "typ": typ,
+                "segs": [(x0, y0, x1, y1, w)],
+                "len": math.hypot(x1 - x0, y1 - y0),
+                "end": (x1, y1),
+            }
+    if cur is not None:
+        paths.append(cur)
+    return paths
+
+
+def layer_segs(path, layer_1based):
+    layers = parse_layers(path)
+    if not layers:
+        sys.exit(f"no layers parsed from {path}")
+    i = max(0, min(len(layers) - 1, layer_1based - 1))
+    if i != layer_1based - 1:
+        print(f"warning: {path} has {len(layers)} layers; clamped to {i + 1}")
+    return layers[i]
+
+
+def bounds(*segs_lists):
+    xs, ys = [], []
+    for segs in segs_lists:
+        for (x0, y0, x1, y1, _w, _t) in segs:
+            xs += [x0, x1]
+            ys += [y0, y1]
+    if not xs:
+        return (-10, 10, -10, 10)
+    return min(xs), max(xs), min(ys), max(ys)
+
+
+def draw(ax, segs, title, short_mm):
+    n_short = 0
+    patches, colors, alphas = [], [], []
+    for p in group_paths(segs):
+        is_short = p["len"] < short_mm
+        if is_short:
+            n_short += 1
+        face, alpha = COLOR.get(p["typ"], ((0.5, 0.5, 0.5), 0.5))
+        if is_short:
+            face, alpha = SHORT_COLOR, 0.95
+        for (x0, y0, x1, y1, w) in p["segs"]:
+            poly = capsule(x0, y0, x1, y1, w)
+            if poly:
+                patches.append(MPoly(poly))
+                colors.append(face)
+                alphas.append(alpha)
+        if is_short:
+            ax.plot(
+                p["segs"][0][0], p["segs"][0][1],
+                "o", mfc="none", mec=SHORT_COLOR, ms=13, mew=1.6, zorder=5,
+            )
+    # One PatchCollection per alpha bucket keeps rendering fast while still
+    # letting fills sit under the wall greys at their own transparency.
+    for a in sorted(set(alphas)):
+        sel = [p for p, al in zip(patches, alphas) if al == a]
+        col = [c for c, al in zip(colors, alphas) if al == a]
+        ax.add_collection(PatchCollection(sel, facecolor=col, edgecolor="none", alpha=a))
+    ax.set_title(f"{title}\n({n_short} isolated paths < {short_mm:g} mm)", fontsize=11)
+    ax.set_aspect("equal")
+    ax.grid(True, alpha=0.25)
+    return n_short
+
+
+def main():
+    args = [a for a in sys.argv[1:] if not a.startswith("--")]
+    opts = {a.split("=", 1)[0]: a.split("=", 1)[1] for a in sys.argv[1:] if a.startswith("--") and "=" in a}
+    if len(args) < 2:
+        sys.exit(__doc__)
+
+    before, after = args[0], args[1]
+    layer = int(args[2]) if len(args) > 2 else 60
+    out = args[3] if len(args) > 3 else "/tmp/beaddiff.png"
+    cx = float(args[4]) if len(args) > 4 else None
+    cy = float(args[5]) if len(args) > 5 else None
+    half = float(args[6]) if len(args) > 6 else None
+    short_mm = float(opts.get("--short", DEFAULT_SHORT_MM))
+    titles = opts.get("--titles", "BEFORE|AFTER").split("|")
+    t_before = titles[0]
+    t_after = titles[1] if len(titles) > 1 else "AFTER"
+
+    sa = layer_segs(before, layer)
+    sb = layer_segs(after, layer)
+
+    if cx is not None and cy is not None and half is not None:
+        # Explicit zoom: a square window, so the two panels read best side by side.
+        xlim = (cx - half, cx + half)
+        ylim = (cy - half, cy + half)
+    else:
+        # Auto-fit to the data with a small margin.  Deliberately *not* squared:
+        # a long flat feature (a rail roof, a deck edge) must render wide, or the
+        # detail the reviewer is meant to check collapses to a few pixels.
+        minx, maxx, miny, maxy = bounds(sa, sb)
+        mx = max(0.5, (maxx - minx) * 0.03)
+        my = max(0.5, (maxy - miny) * 0.03)
+        xlim = (minx - mx, maxx + mx)
+        ylim = (miny - my, maxy + my)
+
+    # Stack vertically for wide/flat windows, side by side otherwise — a wide
+    # part squeezed into a narrow column is unreadable in a PR.
+    wide = (xlim[1] - xlim[0]) > 2.0 * (ylim[1] - ylim[0])
+    if wide:
+        fig, axes = plt.subplots(2, 1, figsize=(17, 8))
+    else:
+        fig, axes = plt.subplots(1, 2, figsize=(19, 10))
+
+    n_b = draw(axes[0], sa, t_before, short_mm)
+    n_a = draw(axes[1], sb, t_after, short_mm)
+    for ax in axes:
+        ax.set_xlim(*xlim)
+        ax.set_ylim(*ylim)
+
+    roles = sorted({p["typ"] for p in group_paths(sa)} | {p["typ"] for p in group_paths(sb)})
+    handles = [
+        mpatches.Patch(color=COLOR[r][0], label=r) for r in roles if r in COLOR
+    ] + [mpatches.Patch(color=SHORT_COLOR, label=f"isolated path < {short_mm:g} mm")]
+    fig.legend(handles=handles, loc="lower center", ncol=min(6, len(handles)), frameon=False)
+    fig.suptitle(f"layer {layer} — beads drawn at their true ;WIDTH:", fontsize=12)
+    plt.tight_layout(rect=[0, 0.05, 1, 0.97])
+    plt.savefig(out, dpi=95, bbox_inches="tight")
+    print(f"layer {layer}: isolated paths < {short_mm:g} mm  {n_b} -> {n_a}")
+    print(f"wrote {out}")
+
+
+if __name__ == "__main__":
+    main()

--- a/tools/gcode-analysis/wallbands.py
+++ b/tools/gcode-analysis/wallbands.py
@@ -1,0 +1,219 @@
+#!/usr/bin/env python3
+"""Annotate one layer's islands and the wall band of a chosen island.
+
+Built to pin down "a wrong zig-zag between the two inner walls" reports: it
+labels every island, then zooms one of them and draws the wall loops in
+**print order** (outer, inner-1, inner-2, ...) as separate colours so "between
+the two inner walls" is unambiguous, with every bead at its true ``;WIDTH:``.
+
+Usage
+-----
+    wallbands.py <gcode> <layer> [island_index] [out.png]
+
+`island_index` selects which outer-wall loop to zoom (see the overview panel's
+labels); omit it to zoom the smallest island.
+"""
+import math
+import sys
+
+import matplotlib
+
+matplotlib.use("Agg")
+import matplotlib.patches as mpatches
+import matplotlib.pyplot as plt
+from matplotlib.collections import PatchCollection
+from matplotlib.patches import Polygon as MPoly
+
+sys.path.insert(0, __file__.rsplit("/", 1)[0])
+from voids import parse_layers  # noqa: E402
+
+FILL_ROLES = ("Top surface", "Bottom surface", "Sparse infill", "Bridge")
+# Wall loops are coloured by their depth in the shell, not by role, so the
+# "first inner" and "second inner" loop are visually distinct.
+DEPTH_COLOR = [(0.20, 0.20, 0.20), (0.20, 0.45, 0.90), (0.60, 0.25, 0.85), (0.0, 0.6, 0.6)]
+FILL_COLOR = {
+    "Top surface": (0.90, 0.30, 0.30),
+    "Bottom surface": (0.60, 0.20, 0.70),
+    "Sparse infill": (1.00, 0.60, 0.10),
+    "Gap infill": (0.00, 0.75, 0.00),
+    "Bridge": (0.10, 0.45, 0.90),
+}
+
+
+def paths_of(segs):
+    out, cur = [], None
+    for (x0, y0, x1, y1, w, t) in segs:
+        if (
+            cur
+            and cur["t"] == t
+            and abs(cur["e"][0] - x0) < 1e-6
+            and abs(cur["e"][1] - y0) < 1e-6
+        ):
+            cur["l"] += math.hypot(x1 - x0, y1 - y0)
+            cur["e"] = (x1, y1)
+            cur["pts"].append((x1, y1))
+        else:
+            if cur:
+                out.append(cur)
+            cur = {
+                "t": t,
+                "l": math.hypot(x1 - x0, y1 - y0),
+                "e": (x1, y1),
+                "w": w,
+                "pts": [(x0, y0), (x1, y1)],
+            }
+    if cur:
+        out.append(cur)
+    return out
+
+
+def bbox(pts):
+    xs = [p[0] for p in pts]
+    ys = [p[1] for p in pts]
+    return min(xs), max(xs), min(ys), max(ys)
+
+
+def contains(outer, inner, pad=0.0):
+    ox0, ox1, oy0, oy1 = bbox(outer)
+    ix0, ix1, iy0, iy1 = bbox(inner)
+    return ox0 - pad <= ix0 and ix1 <= ox1 + pad and oy0 - pad <= iy0 and iy1 <= oy1 + pad
+
+
+def capsule(x0, y0, x1, y1, w):
+    dx, dy = x1 - x0, y1 - y0
+    L = math.hypot(dx, dy)
+    if L < 1e-9:
+        return None
+    r = w / 2
+    nx, ny = -dy / L * r, dx / L * r
+    return [(x0 + nx, y0 + ny), (x1 + nx, y1 + ny), (x1 - nx, y1 - ny), (x0 - nx, y0 - ny)]
+
+
+def draw_paths(ax, paths, color_of, alpha=0.85):
+    pats, cols = [], []
+    for p in paths:
+        c = color_of(p)
+        if c is None:
+            continue
+        for i in range(len(p["pts"]) - 1):
+            poly = capsule(*p["pts"][i], *p["pts"][i + 1], p["w"])
+            if poly:
+                pats.append(MPoly(poly))
+                cols.append(c)
+    if pats:
+        ax.add_collection(PatchCollection(pats, facecolor=cols, edgecolor="none", alpha=alpha))
+
+
+def main():
+    if len(sys.argv) < 3:
+        sys.exit(__doc__)
+    path, layer = sys.argv[1], int(sys.argv[2])
+    island_idx = int(sys.argv[3]) if len(sys.argv) > 3 else None
+    out = sys.argv[4] if len(sys.argv) > 4 else "/tmp/wallbands.png"
+
+    layers = parse_layers(path)
+    ps = paths_of(layers[layer - 1])
+    z = None
+    outers = [p for p in ps if p["t"] == "Outer wall"]
+    inners = [p for p in ps if p["t"] == "Inner wall"]
+
+    # Group inner loops under the smallest outer loop that contains them, so a
+    # nested island doesn't steal the enclosing frame's walls.
+    groups = []
+    for oi, o in enumerate(outers):
+        kids = [
+            q
+            for q in inners
+            if contains(o["pts"], q["pts"], 0.05)
+            and not any(
+                contains(o2["pts"], q["pts"], 0.05)
+                and (bbox(o2["pts"])[1] - bbox(o2["pts"])[0])
+                < (bbox(o["pts"])[1] - bbox(o["pts"])[0])
+                for o2 in outers
+                if o2 is not o
+            )
+        ]
+        # Sort inner loops outward-in by bbox width: inner-1 then inner-2.
+        kids.sort(key=lambda q: -(bbox(q["pts"])[1] - bbox(q["pts"])[0]))
+        groups.append({"outer": o, "inners": kids, "idx": oi})
+
+    if island_idx is None:
+        island_idx = min(
+            range(len(groups)),
+            key=lambda i: bbox(groups[i]["outer"]["pts"])[1] - bbox(groups[i]["outer"]["pts"])[0],
+        )
+    g = groups[island_idx]
+
+    fig, axes = plt.subplots(1, 2, figsize=(19, 9.5))
+
+    # ── Panel A: whole layer, islands labelled ───────────────────────────────
+    ax = axes[0]
+    draw_paths(ax, [p for p in ps if p["t"] in FILL_COLOR and p["t"] != "Gap infill"],
+               lambda p: FILL_COLOR.get(p["t"]), alpha=0.35)
+    draw_paths(ax, [p for p in ps if p["t"] == "Gap infill"], lambda p: FILL_COLOR["Gap infill"], 0.6)
+    draw_paths(ax, outers, lambda p: DEPTH_COLOR[0], 0.9)
+    draw_paths(ax, inners, lambda p: DEPTH_COLOR[1], 0.7)
+    for gg in groups:
+        x0, x1, y0, y1 = bbox(gg["outer"]["pts"])
+        sel = gg["idx"] == island_idx
+        ax.add_patch(
+            mpatches.Rectangle(
+                (x0 - 0.6, y0 - 0.6), x1 - x0 + 1.2, y1 - y0 + 1.2,
+                fill=False, ec="red" if sel else "0.5",
+                lw=2.2 if sel else 1.0, ls="-" if sel else "--", zorder=6,
+            )
+        )
+        ax.text(x0, y1 + 1.2, f"island {gg['idx']} ({len(gg['inners'])} inner)",
+                color="red" if sel else "0.35", fontsize=9, fontweight="bold" if sel else "normal")
+    ax.set_title(f"A — layer {layer}: all islands (red = zoomed below)", fontsize=11)
+    ax.set_aspect("equal")
+    ax.grid(True, alpha=0.25)
+
+    # ── Panel B: the chosen island, wall loops by depth ──────────────────────
+    ax = axes[1]
+    x0, x1, y0, y1 = bbox(g["outer"]["pts"])
+    pad = max(1.5, 0.08 * max(x1 - x0, y1 - y0))
+    loops = [g["outer"]] + g["inners"]
+    inzoom = lambda p: any(x0 - pad <= a[0] <= x1 + pad and y0 - pad <= a[1] <= y1 + pad
+                           for a in p["pts"])
+    fills = [p for p in ps if p["t"] in FILL_COLOR and inzoom(p)]
+    draw_paths(ax, fills, lambda p: FILL_COLOR.get(p["t"]), 0.9)
+    for d, loop in enumerate(loops):
+        draw_paths(ax, [loop], lambda p, d=d: DEPTH_COLOR[min(d, len(DEPTH_COLOR) - 1)], 0.85)
+    short = [p for p in fills if p["l"] < 4.0]
+    for p in short:
+        ax.plot(p["pts"][0][0], p["pts"][0][1], "o", mfc="none", mec="magenta", ms=13, mew=1.8,
+                zorder=8)
+    ax.set_xlim(x0 - pad, x1 + pad)
+    ax.set_ylim(y0 - pad, y1 + pad)
+    ax.set_title(
+        f"B — island {island_idx}: 1 outer + {len(g['inners'])} inner wall(s)\n"
+        f"{len(fills)} fill paths inside, {len(short)} shorter than 4 mm (magenta rings)",
+        fontsize=11,
+    )
+    ax.set_aspect("equal")
+    ax.grid(True, alpha=0.25)
+
+    handles = [mpatches.Patch(color=DEPTH_COLOR[0], label="outer wall")]
+    for d in range(1, len(loops)):
+        handles.append(
+            mpatches.Patch(color=DEPTH_COLOR[min(d, len(DEPTH_COLOR) - 1)], label=f"inner wall {d}")
+        )
+    for r in sorted({p["t"] for p in fills}):
+        handles.append(mpatches.Patch(color=FILL_COLOR[r], label=r))
+    handles.append(mpatches.Patch(color="magenta", label="fill path < 4 mm"))
+    fig.legend(handles=handles, loc="lower center", ncol=min(7, len(handles)), frameon=False)
+    fig.suptitle(f"{path}  —  layer {layer}, beads at true ;WIDTH:", fontsize=12)
+    plt.tight_layout(rect=[0, 0.06, 1, 0.95])
+    plt.savefig(out, dpi=100, bbox_inches="tight")
+
+    print(f"layer {layer}: {len(groups)} islands")
+    for gg in groups:
+        bx = bbox(gg["outer"]["pts"])
+        print(f"  island {gg['idx']}: {len(gg['inners'])} inner wall(s)  "
+              f"x[{bx[0]:.1f},{bx[1]:.1f}] y[{bx[2]:.1f},{bx[3]:.1f}]")
+    print(f"zoomed island {island_idx}; wrote {out}")
+
+
+if __name__ == "__main__":
+    main()


### PR DESCRIPTION
## Summary

Fixes three Benchy-visible Arachne quality defects — all isolated tiny extrusions that add no strength yet cost a full **retract → travel → un-retract** cycle each (wasting print time and risking filament grinding) — plus one genuine double-extrusion. This directly addresses the reported "super tiny inner-body extrusion splats" and the "thin, weird roof part … one outer wall, thin lines of top surface and unexplicably a gap infill bead" on the Benchy rear rail (~layer 200/201).

Every change is validated with [`tools/gcode-analysis/`](tools/gcode-analysis/README.md) against the trusted `classic` generator.

## The defects & fixes

### 1. Gap-fill "splat" beads (~270 on a 3DBenchy)
The auto minimum gap-fill run length was one nozzle diameter (`d`), which let a swarm of sub-`2·d` isolated beads survive along curved/tapering wall-band corners. Raised the auto default to **`2·d`** (0.8 mm at a 0.4 mm nozzle), matching the medial-skeleton spur floor. The residual those beads filled is covered by the squish of the flanking wall beads — no wall-zone void opens (the `classic` generator, which has no gap fill, leaves the same corners bare with no measurable void). Override with `gap_fill_min_length_mm`.

### 2. Gap fill printed *under* a top surface (the "rear rail" defect)
On a thin solid strip, a gap-fill bead ran straight down the centre while the top-surface zig-zag deposited over it — **6 mm²/layer of genuine double-extrusion** that an erosion-based `overlap.py` scan hides (the bead is thin). `blocked_for_surface` carves the gap-fill footprint out of `solid_regions`, so the plain "inside the surface" prune test never fired. `prune_redundant_gap_fill` now also drops a bead **sandwiched by solid surface on both perpendicular sides**; a bead that merely *abuts* a surface on one side (a real thin neck) is kept. Model-wide `GapFill × TopSurface` capsule overlap: **7.3 → 0.5 mm²**, no new voids.

![Benchy rear-rail before/after: the redundant gap-fill bead under the top surface is pruned](https://github.com/user-attachments/assets/26a17608-d793-4dc1-9612-96d526437e98)

*Before (top): the green 0.56 mm gap-fill bead runs the length of the rail directly under the red top-surface fill. After (bottom): the redundant bead is pruned and the top surface fills the strip — matching the `classic` reference.*




### 3. Tiny sparse-infill dashes
`min_infill_extrusion_mm` (default 0.4 mm) now filters **sparse** infill too, not just solid surface fill — dropping isolated sub-threshold corner dashes.

## Results (3DBenchy, arachne)

| metric | before | after |
| --- | --- | --- |
| isolated sub-0.8 mm extrusions (retract-bracketed) | 356 | **120** (−66%) |
| … of which gap-fill splats | 174 | **0** |
| retract cycles | 3157 | **2993** (−164) |
| `GapFill × TopSurface` double-extrusion (model-wide) | 7.3 mm² | **0.5 mm²** |
| wall-zone void (sample) | baseline | unchanged, still ≪ classic |

## Tests & validation
- New unit tests: gap-fill run-length floor (`gap_fill_min_run_len_auto_default_is_two_nozzle`, `short_residual_gap_yields_no_splat_bead`), surface-sandwich prune (`test_prune_gap_fill_sandwiched_by_surface`, `test_keep_gap_fill_abutting_surface_one_side`), sparse-infill filter (`test_min_infill_extrusion_drops_sparse_splats`).
- Full suite green (568 lib + doc/integration tests). `cargo fmt` clean. No new clippy findings (the 10 pre-existing `field_reassign_with_default` lints in `gcode/generator.rs` tests are untouched).
- Wall-zone void coverage verified neutral vs. the pre-fix baseline and well below `classic`.

Documented in `AGENTS.md` (Slicing Pipeline — Deep Knowledge), the settings docs, and `CHANGELOG.md`.



---

### 4. Top-surface "squiggles" where solid fill grazes a wall

Reported on the **Filament Card Caddy** hexagon logo: a burst of tiny top-surface
zig-zag hugging the wall, interleaved with unfilled wedge voids.

![root cause](https://github.com/user-attachments/assets/fce9db4e-2730-4352-8ed9-f560ea7138e0)

**Root cause.** The wall-band trim subtracts the eroded wall-bead footprint from a
surface region whose outline does not follow that footprint exactly. Where the two
meet at a **grazing angle** the subtraction leaves a crescent narrower than one
bead. The scanline still fills it, but since the fill direction is then
near-parallel to the crescent **every span is a stub**.

The reporter circled exactly two of the six hexagon edges — and those are precisely
the two lying **15° off the fill direction**:

| edge | angle | Δ to fill (135°) | sub-1 mm top surface |
| --- | --- | --- | --- |
| e1, e4 | 30° | 75° | 12.4 / 13.7 mm |
| e0, e3 | 90° | 45° | 13.2 / 13.5 mm |
| **e2, e5** | **150°** | **15°** | **22.9 / 24.1 mm** |

Debug geometry confirmed `solid_surface` carried separate sliver sub-paths of
≈4.5 mm² and ≈0.22 mm mean width there. A 135° scanline crossing a 0.22 mm strip
at 150° gives span `0.22/sin 15° ≈ 0.85 mm` — matching the observed repeating
**0.82 mm line / 0.62 mm connector** micro-serpentine. **93 % of that material was
already covered** by the flanking wall bead, buying ≈0.5 mm² of coverage for ~20 mm
of sub-millimetre moves.

**Not an Arachne defect** — `arachne` and `classic` produced *byte-identical* stub
measurements, because the cause is in the surface fill, not the wall generator.

**Fix.** `open_surface_region_for_fill` erodes the surface region by half the
solid-surface extrusion width (erosion *diameter* = one bead: a narrower strip
cannot hold a bead by construction), then re-grows the surviving core by 2× that
radius and **clips it back to the original region**. The clip restores exact
original shape including sharp convex corners — a plain morphological opening
rounds them, and a rounded corner makes the scanline emit *extra* stub spans, the
very artifact being removed (+31 stubs on the Voron cube with plain opening, −1
with the corner-preserving form). It is a **width** filter, not an area filter, so
small-but-printable surfaces are untouched (79 mm² and 37 mm² regions survive
intact while six slivers go to zero).

![before/after](https://github.com/user-attachments/assets/b73ec443-49d0-4d1d-afe0-0f1697903856)

| model | coverage Δ | sub-1 mm segs |
| --- | --- | --- |
| 3DBenchy | −0.0035 % | −19 |
| Voron cube | −0.0003 % | −1 |
| Filament Card Caddy | −0.0005 % | −55 |

The two grazing caddy edges drop **22.9 → 2.4 mm** and **24.1 → 2.8 mm** of sub-1 mm
top surface, with the wedge voids closed as well. Quality gate passes with **no
baseline drift**; 575 tests green; three new unit tests
(`test_open_surface_region_drops_sub_bead_sliver`,
`test_open_surface_region_keeps_printable_regions`,
`test_open_surface_region_degenerate_width_is_noop`).
