### PR TITLE
ui: make the slicer sidebar toggle deterministic on touch

### DIFF
--- a/ui/src/app/nexus/sidebar/sidebar.component.html
+++ b/ui/src/app/nexus/sidebar/sidebar.component.html
@@ -3,7 +3,8 @@
   type="button"
   [class.is-pinned]="!collapsed()"
   [attr.aria-pressed]="!collapsed()"
-  [attr.aria-label]="collapsed() ? 'Pin panel open' : 'Unpin panel'"
+  [attr.aria-label]="collapsed() ? 'Dock panel' : 'Hide panel'"
+  [attr.title]="collapsed() ? 'Dock panel' : 'Hide panel'"
   (click)="onCollapseToggle($event)"
 >
   @if (collapsed()) {
@@ -12,6 +13,16 @@
     <nexus-icon name="pin" />
   }
 </button>
+
+@if (isScrimOpen()) {
+  <button
+    class="sidebar-scrim"
+    type="button"
+    aria-label="Dismiss print settings"
+    tabindex="-1"
+    (click)="dismissOverlay()"
+  ></button>
+}
 
 <div class="sidebar-panel">
   <div class="sidebar-content" #scrollContainer (scroll)="onContentScroll($event)">

--- a/ui/src/app/nexus/sidebar/sidebar.component.scss
+++ b/ui/src/app/nexus/sidebar/sidebar.component.scss
@@ -15,9 +15,11 @@ $transition-easing: ease;
 
   transition: width $transition-duration $transition-easing;
 
-  // Hidden and hover-peek both stay out of layout flow (the panel overlays the
-  // scene); only an explicit pin/dock reserves horizontal space.
-  &.is-collapsed:not(.is-pinned-open) {
+  // Collapsed always floats as an overlay: the host reserves zero width and the
+  // panel slides over the scene. Only a docked (expanded, not collapsed) sidebar
+  // reserves horizontal space. This keeps a peek from ever reflowing the gcode
+  // viewport — the whole point of "peek to tweak, dismiss to view".
+  &.is-collapsed {
     width: 0;
   }
 
@@ -61,6 +63,35 @@ $transition-easing: ease;
     transition:
       transform $transition-duration $transition-easing,
       visibility 0s linear $transition-duration;
+  }
+
+  // A floating peek reads as a raised drawer, not a docked column.
+  :host.is-overlay & {
+    box-shadow: var(--shadow-lg);
+  }
+}
+
+// Dismiss layer for an overlay peek. Gives touch (and mouse) a plain
+// tap-outside-to-close gesture, matching every drawer convention — the piece
+// that was missing, leaving iPad users with no way to close a peek.
+.sidebar-scrim {
+  position: fixed;
+  inset: 0;
+  z-index: -1;
+  border: none;
+  padding: 0;
+  margin: 0;
+  background: var(--scrim, rgba(0, 0, 0, 0.32));
+  cursor: default;
+  animation: sidebar-scrim-in $transition-duration $transition-easing;
+}
+
+@keyframes sidebar-scrim-in {
+  from {
+    opacity: 0;
+  }
+  to {
+    opacity: 1;
   }
 }
 

--- a/ui/src/app/nexus/sidebar/sidebar.ts
+++ b/ui/src/app/nexus/sidebar/sidebar.ts
@@ -34,7 +34,7 @@ const HOVER_CLOSE_DELAY_MS = 240;
     '(mouseleave)': 'onMouseLeave()',
     '[class.is-collapsed]': 'collapsed()',
     '[class.is-expanded]': 'isExpanded()',
-    '[class.is-pinned-open]': 'isPinnedOverlayOpen()',
+    '[class.is-overlay]': 'isOverlay()',
     '[class.is-dragging]': 'isDragging()',
   },
 })
@@ -43,9 +43,12 @@ export class Sidebar {
   private readonly renderer = inject(Renderer2);
   private readonly document = inject(DOCUMENT);
 
+  /** Docked (false) reserves layout space; collapsed (true) floats as an overlay. */
   protected readonly collapsed = signal(this.readCollapsed());
-  protected readonly pinnedOpen = signal(false);
-  protected readonly hovered = signal(false);
+  /** A deliberate tap/click peek that persists until dismissed (scrim/Escape/toggle). */
+  protected readonly overlayOpen = signal(false);
+  /** An ephemeral hover preview (pointer-capable devices only); closes on leave. */
+  protected readonly hoverPreview = signal(false);
   protected readonly isDragging = signal(false);
 
   /** Whether the content has been scrolled far enough to offer a "scroll to top". */
@@ -53,10 +56,21 @@ export class Sidebar {
 
   private readonly scrollContainer = viewChild<ElementRef<HTMLElement>>('scrollContainer');
 
+  // Only arm hover-intent on devices that truly hover. iOS/iPadOS emit synthetic
+  // mouse events on tap with no matching `mouseleave`, which would otherwise leave
+  // a preview stuck open — the exact "sidebar won't close" bug on touch.
+  private readonly supportsHover =
+    typeof window !== 'undefined' && !!window.matchMedia?.('(hover: hover)').matches;
+
   protected readonly isExpanded = computed(
-    () => !this.collapsed() || this.pinnedOpen() || this.hovered(),
+    () => !this.collapsed() || this.overlayOpen() || this.hoverPreview(),
   );
-  protected readonly isPinnedOverlayOpen = computed(() => this.collapsed() && this.pinnedOpen());
+  /** Panel is visible but floating over the scene (collapsed + peeking). */
+  protected readonly isOverlay = computed(
+    () => this.collapsed() && (this.overlayOpen() || this.hoverPreview()),
+  );
+  /** A tap/click peek that warrants a dismissable scrim (hover previews don't). */
+  protected readonly isScrimOpen = computed(() => this.collapsed() && this.overlayOpen());
 
   private dragStartX = 0;
   private dragStartWidth = 0;
@@ -82,8 +96,8 @@ export class Sidebar {
   expand(): void {
     this.clearHoverTimers();
     if (this.collapsed()) {
-      this.hovered.set(false);
-      this.pinnedOpen.set(true);
+      this.hoverPreview.set(false);
+      this.overlayOpen.set(true);
     }
   }
 
@@ -98,55 +112,68 @@ export class Sidebar {
     this.scrollContainer()?.nativeElement.scrollTo({ top: 0, behavior: 'smooth' });
   }
 
+  /**
+   * Dock ⇄ hide toggle. Fully deterministic on every platform: it flips the
+   * persisted docked state and clears any transient peek, so tapping it always
+   * does exactly what it says — no reliance on a follow-up `mouseleave`.
+   */
   protected onCollapseToggle(event: MouseEvent): void {
     event.stopPropagation();
     const next = !this.collapsed();
     this.collapsed.set(next);
     this.clearHoverTimers();
-    this.pinnedOpen.set(false);
-    // Unpinning: keep the panel open as an overlay peek under the cursor so it
-    // doesn't vanish on click; onMouseLeave auto-hides it once the pointer
-    // leaves. Docking: hovered is irrelevant (isExpanded is driven by !collapsed).
-    this.hovered.set(next);
+    this.overlayOpen.set(false);
+    this.hoverPreview.set(false);
     this.saveCollapsed(next);
   }
 
-  /** Hover-intent open: only after a short, deliberate hover. */
+  /** Hover-intent open: only after a short, deliberate hover (pointer devices). */
   protected onMouseEnter(): void {
-    if (!this.collapsed() || this.pinnedOpen()) {
+    if (!this.supportsHover || !this.collapsed() || this.overlayOpen()) {
       return;
     }
     this.clearCloseTimer();
-    if (this.hovered() || this.hoverOpenTimer !== null) {
+    if (this.hoverPreview() || this.hoverOpenTimer !== null) {
       return;
     }
     this.hoverOpenTimer = setTimeout(() => {
       this.hoverOpenTimer = null;
-      this.hovered.set(true);
+      this.hoverPreview.set(true);
     }, HOVER_OPEN_DELAY_MS);
   }
 
   /** Hover-intent close: a brief grace period so the panel doesn't flicker. */
   protected onMouseLeave(): void {
+    if (!this.supportsHover) {
+      return;
+    }
     this.clearOpenTimer();
-    if (!this.hovered()) {
+    if (!this.hoverPreview()) {
       return;
     }
     this.clearCloseTimer();
     this.hoverCloseTimer = setTimeout(() => {
       this.hoverCloseTimer = null;
-      this.hovered.set(false);
+      this.hoverPreview.set(false);
     }, HOVER_CLOSE_DELAY_MS);
   }
 
+  /** Reveal-hint tap: open a persistent overlay peek (the primary touch gesture). */
   protected onOpenPeek(event: MouseEvent): void {
     event.stopPropagation();
     if (!this.collapsed()) {
       return;
     }
     this.clearHoverTimers();
-    this.hovered.set(false);
-    this.pinnedOpen.set(true);
+    this.hoverPreview.set(false);
+    this.overlayOpen.set(true);
+  }
+
+  /** Tap/click the scrim behind an overlay peek to dismiss it (stays hidden). */
+  protected dismissOverlay(): void {
+    this.clearHoverTimers();
+    this.overlayOpen.set(false);
+    this.hoverPreview.set(false);
   }
 
   @HostListener('document:keydown.escape')
@@ -155,8 +182,8 @@ export class Sidebar {
       return;
     }
     this.clearHoverTimers();
-    this.pinnedOpen.set(false);
-    this.hovered.set(false);
+    this.overlayOpen.set(false);
+    this.hoverPreview.set(false);
   }
 
   private clearOpenTimer(): void {


### PR DESCRIPTION
## What

Reworks the main scene's slicer **sidebar show/hide/toggle** into a predictable drawer model that behaves identically on desktop and touch (iPad).

## Why

The sidebar leaned entirely on mouse hover, which broke down during continuous use — especially on iPad while repeatedly entering/leaving the sidebar to free up space for the gcode view:

- **"Hide" got stuck open on touch (core bug).** `onCollapseToggle` collapsed the panel but then set `hovered = true`, a mouse-only trick expecting a later `mouseleave` to finish closing. Touch never fires `mouseleave`, so the panel stayed open.
- **No touch dismiss gesture.** A peek could be opened but there was no scrim / tap-outside / close affordance — only the pin, which *docks* (reserves space) rather than closing.
- **Inconsistent reveal.** A *tapped* peek reserved layout width (shoving the gcode viewport) while a *hover* peek floated over it.
- **Synthetic touch hover could stick** because `onMouseEnter` wasn't gated to hover-capable pointers.

## What changed

- Replaced the tangled `collapsed`/`pinnedOpen`/`hovered` flags with a clean model: `collapsed` (dock⇄hide), `overlayOpen` (persistent tap peek), `hoverPreview` (ephemeral; hover-capable devices only, gated by `matchMedia('(hover: hover)')`).
- **Toggle is now fully deterministic** — no reliance on a follow-up `mouseleave`.
- **A peek is always an overlay** (never reflows the scene); only an explicit dock reserves width.
- Added a **dismiss scrim** behind tap-opened overlays (tap-outside to close), complementing Escape.
- Clearer toggle labels ("Dock panel" / "Hide panel"); overlay gets a raised shadow and uses the existing `--scrim` token (no blur, per the design language).

## Resulting behaviour (all platforms)

- Hidden → tap "Print settings" → floats over the scene (gcode view unaffected).
- Tap scrim / Escape → dismiss (stays hidden). Fast peek-and-go.
- Tap the pin → dock side-by-side; tap again → hide. Same on mouse and touch.
- Desktop keeps the hover-preview nicety, now without a distracting scrim.

## Notes for reviewers

- UI-only change (3 files under `ui/src/app/nexus/sidebar/`). Prettier verified clean; per the UI-style workflow no full build was run.
- Follow-up ideas (not in this PR): default to overlay mode on narrow/touch viewports, a keyboard shortcut to toggle, and swipe-from-edge open/close.