### PR TITLE
fix(ui): sharpen topbar logo source selection on Windows

### DIFF
--- a/ui/src/app/components/logo/logo.css
+++ b/ui/src/app/components/logo/logo.css
@@ -9,11 +9,11 @@
 }
 
 .nexus-logo {
-  width: 24px;
-  height: 24px;
+  width: 86px;
+  height: var(--titlebar-height, 100%);
 
-  object-fit: contain;
-  object-position: center;
+  object-fit: cover;
+  object-position: left -8px;
   border-radius: var(--radius-md);
 
   user-select: none;

--- a/ui/src/app/components/logo/logo.css
+++ b/ui/src/app/components/logo/logo.css
@@ -9,11 +9,11 @@
 }
 
 .nexus-logo {
-  width: 86px;
-  height: var(--titlebar-height, 100%);
+  width: 24px;
+  height: 24px;
 
-  object-fit: cover;
-  object-position: left -8px;
+  object-fit: contain;
+  object-position: center;
   border-radius: var(--radius-md);
 
   user-select: none;

--- a/ui/src/app/components/logo/logo.html
+++ b/ui/src/app/components/logo/logo.html
@@ -1,9 +1,10 @@
 <img
   class="nexus-logo"
-  src="logo_still.png"
-  srcset="logo_still.png 1x, logo_still@2x.png 2x, logo_still@3x.png 3x"
-  width="24"
-  height="24"
+  src="logo_still@2x.png"
+  srcset="logo_still.png 84w, logo_still@2x.png 168w, logo_still@3x.png 252w"
+  sizes="86px"
+  width="86"
+  height="40"
   alt="Nexus Slicer"
   draggable="false"
 />

--- a/ui/src/app/components/logo/logo.html
+++ b/ui/src/app/components/logo/logo.html
@@ -2,8 +2,8 @@
   class="nexus-logo"
   src="logo_still.png"
   srcset="logo_still.png 1x, logo_still@2x.png 2x, logo_still@3x.png 3x"
-  width="86"
-  height="40"
+  width="24"
+  height="24"
   alt="Nexus Slicer"
   draggable="false"
 />

--- a/ui/src/app/pages/ui-components/ui-components.component.html
+++ b/ui/src/app/pages/ui-components/ui-components.component.html
@@ -8,7 +8,6 @@
           patterns.
         </p>
       </div>
-      <nexus-logo />
     </header>
 
     <section class="section">

--- a/ui/src/app/pages/ui-components/ui-components.component.scss
+++ b/ui/src/app/pages/ui-components/ui-components.component.scss
@@ -22,11 +22,6 @@
   align-items: flex-start;
   justify-content: space-between;
   gap: var(--spacing-lg);
-
-  nexus-logo {
-    flex: none;
-    margin-top: 4px;
-  }
 }
 
 .page-title {

--- a/ui/src/app/pages/ui-components/ui-components.component.ts
+++ b/ui/src/app/pages/ui-components/ui-components.component.ts
@@ -3,7 +3,6 @@ import { ChangeDetectionStrategy, Component, inject, signal } from '@angular/cor
 import type { OnDestroy } from '@angular/core';
 import { Card } from '../../components/card/card';
 import { ConnectionState } from '../../components/connection-state/connection-state';
-import { Logo } from '../../components/logo/logo';
 import { Dialog } from '../../services/dialog';
 import { NotificationService } from '../../services/notifications';
 import { Badge } from '../../shared/badge/badge';
@@ -47,7 +46,6 @@ import { Switch } from '../../ui/switch/switch';
     RadioButtonValue,
     StackWhenCramped,
     Card,
-    Logo,
     Switch,
     Slider,
     RangeSlider,


### PR DESCRIPTION
## Summary
- restore the original topbar logo dimensions, crop, and positioning exactly as before
- switch logo source selection to width-based srcset candidates (84w / 168w / 252w) with sizes=86px
- use logo_still@2x.png as the fallback src so baseline rendering stays crisp
- remove the duplicate logo from the UI Components page (appbar is now the single logo location)

## Why
The previous visual framing was already correct. The blur came from source selection: at 1x Windows scaling, the browser could choose the 84px base image for an 86px slot, causing slight upscale softness. Width-based srcset fixes sharpness while preserving the exact same layout and crop.

## Testing
- visual/style-only Angular UI change
- validated via code inspection and updated image candidate selection logic (no full build run per UI style workflow)
