### PR TITLE
fix(viewer): keep viewport-cube ortho snap sticky through pan/zoom

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -168,6 +168,15 @@ these notes and acknowledges contributors. `scripts/gen-changelog-draft.sh` and
   units with a clear error. Applies to both the CLI file path and the
   byte-upload path used by the UI/WASM and WS server.
 
+- **Viewport-cube ortho snap popped back to perspective on pan/zoom** —
+  clicking a cube face to inspect a model in a flat, dimension-true view (e.g.
+  a selected face of a slice) lost that view the instant you panned or
+  zoomed, which is exactly when you want to hold still: dragging around and
+  zooming in to evaluate detail. Only a genuine **rotate** now breaks the
+  snap free (past the existing sticky threshold); panning and zooming any
+  distance keep the projection flattened, letting you inspect a snapped view
+  up close without it ever popping back to perspective.
+
 ## [0.1.0] - 2026-08-23
 
 ### Added

--- a/ui/src/app/components/viewer/README.md
+++ b/ui/src/app/components/viewer/README.md
@@ -207,12 +207,14 @@ raycaster, gizmo), the viewer applies a clear priority order:
 
 Clicking a viewport-cube face/edge/corner snaps the camera to that view **and
 flattens the projection to orthographic** — the CAD convention that a snapped
-view is dimension-true. The snap is then **pinned**: it survives until a gesture
-breaks it free — a **pan**, a **zoom**, or a **rotate dragged past the breakout
-distance** — at which point the projection reverts to whatever the toolbar preset
-was (normally perspective). Because the revert targets the toolbar `currentView`,
-leaving the snap lands back in perspective only when the user _entered_ it from
-perspective; a toolbar ortho preset stays ortho.
+view is dimension-true. The snap is then **pinned**: it survives pan and zoom
+of any distance — sticky, so a selected face can be inspected up close without
+ever popping back to perspective — and only breaks free on a genuine **rotate
+dragged past the breakout distance**, at which point the projection reverts to
+whatever the toolbar preset was (normally perspective). Because the revert
+targets the toolbar `currentView`, leaving the snap lands back in perspective
+only when the user _entered_ it from perspective; a toolbar ortho preset stays
+ortho.
 
 The rotate behaviour is a true **detent, Shapr3D-style**. While the snap is held
 the camera does **not move at all**: a rotate gesture shorter than
@@ -224,15 +226,20 @@ path. Cross that distance and the snap "pops": the camera starts orbiting from
 the snapped orientation and the projection animates back. Interacting with the
 cube again always keeps ortho.
 
-| Action                                                  | Auto-ortho         |
-| ------------------------------------------------------- | ------------------ |
-| Cube face/edge/corner snap                              | engage (→ ortho)   |
-| Rotate **inside** the breakout distance                 | keep — view frozen |
-| **Rotate past breakout** (1-finger / left-drag / swipe) | **revert** (pops)  |
-| Cube drag-orbit / roll / re-snap                        | keep               |
-| **Pan** (2-finger / right-drag / ⌥-swipe)               | **revert**         |
-| **Zoom** (pinch / wheel / autoscroll)                   | **revert**         |
-| Toolbar view toggle / home reset                        | cancel (manual)    |
+A pan or zoom releases the *freeze* — otherwise the very next frame would pin
+the camera straight back and the gesture would appear to do nothing — but
+never the *projection*: `autoOrtho` stays engaged, so the view keeps its flat,
+dimension-true look while the user pans/zooms around it freely.
+
+| Action                                                   | Auto-ortho          |
+| --------------------------------------------------------- | ------------------- |
+| Cube face/edge/corner snap                                 | engage (→ ortho)    |
+| Rotate **inside** the breakout distance                    | keep — view frozen  |
+| **Rotate past breakout** (1-finger / left-drag / swipe)    | **revert** (pops)   |
+| Cube drag-orbit / roll / re-snap                            | keep                 |
+| Pan (2-finger / right-drag / ⌥-swipe)                      | keep — sticky        |
+| Zoom (pinch / wheel / autoscroll)                           | keep — sticky        |
+| Toolbar view toggle / home reset                           | cancel (manual)      |
 
 This lives across two files. Both the projection override (`autoOrtho`) and the
 detent (`snapHoldPose`) are in [`SceneCamera`](scene/camera.ts). Engaging
@@ -264,7 +271,9 @@ it each frame (rather than accumulating) is what makes the hand-off seamless —
 `OrbitControls` re-derives its orbit frame from the camera's current position
 every update, so the instant the pin is released the view simply starts following
 the pointer from the snapped orientation, with no jump and no replay of the
-absorbed movement.
+absorbed movement. A pan or zoom releases the same pin early via
+`releaseSnapPinForPanZoom()` — a plain `snapHoldPose = null`, nothing else — so
+the gesture is free to move the camera while `autoOrtho` stays engaged.
 
 **Reverting** animates over the same `VIEW_TRANSITION_MS` + easing as the
 toolbar's perspective/ortho toggle, so the morph reads identically whichever
@@ -277,13 +286,16 @@ fights the gesture that triggered it — the render loop advances it on **every*
 frame, including frames where `OrbitControls` is driving the camera, so the user
 can keep dragging/zooming straight through the transition.
 
-The revert trigger is emitted only from the genuine pan/zoom input sites and from
-the pointer-travel breakout detector in [`SceneControls`](scene/controls.ts)
-(`setRevertGestureSink`) — a rotate inside the detent and cube-driven moves never
-emit it. Travel is measured in **pixels**, not camera angle, precisely because a
-held snap does not rotate the camera at all. The budget is per gesture: reset on
-each pointer down/up and, on the trackpad-swipe path (which has no pointer
-brackets), after an idle gap.
+The revert trigger (`setRevertGestureSink` in [`SceneControls`](scene/controls.ts))
+is emitted **only** by the pointer-travel breakout detector for a rotate gesture
+— a rotate inside the detent, cube-driven moves, and any pan/zoom never emit it.
+Travel is measured in **pixels**, not camera angle, precisely because a held
+snap does not rotate the camera at all. The budget is per gesture: reset on each
+pointer down/up and, on the trackpad-swipe path (which has no pointer brackets),
+after an idle gap. Pan/zoom instead emit a separate, lighter
+`setPanZoomGestureSink` that only releases the freeze (see above) — the two
+sinks are deliberately distinct so the projection-reverting side effects of
+`notifyUserViewGesture` never fire for a gesture that is supposed to stay sticky.
 
 ### Pen-priority palm rejection ("wrist detection")
 

--- a/ui/src/app/components/viewer/scene/camera.ts
+++ b/ui/src/app/components/viewer/scene/camera.ts
@@ -64,11 +64,14 @@ export class SceneCamera {
    * True while the projection has been *temporarily* forced to orthographic by
    * a viewport-cube snap (see {@link animateToDirection}). Distinct from the
    * user's `currentView`: the cube engages this without touching the toolbar
-   * preset. It is released together with the {@link snapHoldPose} detent once a
-   * gesture breaks the snap free — a pan, a zoom, or a rotate dragged past
-   * `SNAP_BREAKOUT_TRAVEL_PX` ({@link notifyUserViewGesture}) — reverting to
-   * `currentView`. Everything below that distance, and any further cube
-   * interaction, keeps it engaged.
+   * preset. It is released together with the {@link snapHoldPose} detent only
+   * when a **rotate** gesture is dragged past `SNAP_BREAKOUT_TRAVEL_PX`
+   * ({@link notifyUserViewGesture}) — reverting to `currentView`. A pan or
+   * zoom of any distance keeps it engaged (see
+   * {@link releaseSnapPinForPanZoom}), which is what lets the user inspect a
+   * snapped face up close without the view popping back to perspective.
+   * Everything below the rotate breakout distance, and any further cube
+   * interaction, also keeps it engaged.
    */
   private autoOrtho = false;
 
@@ -78,7 +81,9 @@ export class SceneCamera {
    * frame's `OrbitControls.update()`, so a rotate gesture inside the breakout
    * distance moves the view **not at all** instead of drifting off the snapped
    * orientation. Cleared when the snap breaks free
-   * ({@link notifyUserViewGesture}), when the cube itself orbits/rolls the view
+   * ({@link notifyUserViewGesture}), when a pan/zoom gesture starts
+   * ({@link releaseSnapPinForPanZoom} — the projection stays ortho, only the
+   * freeze is lifted), when the cube itself orbits/rolls the view
    * ({@link orbitBy}), or when a toolbar preset takes over.
    */
   private snapHoldPose: { position: Vector3; up: Vector3; target: Vector3 } | null = null;
@@ -281,13 +286,15 @@ export class SceneCamera {
   }
 
   /**
-   * Called when a gesture breaks a held viewport-cube snap free — a pan, a zoom,
-   * or a rotate dragged past `SNAP_BREAKOUT_TRAVEL_PX` (a rotate inside that
-   * distance never gets here, and neither do cube gestures). Releases both the
-   * {@link snapHoldPose} detent, so the camera starts following the gesture, and
-   * the forced orthographic projection, reverting to the user's `currentView` —
-   * so leaving the snap lands back in perspective only when the user *entered*
-   * it from perspective; a toolbar ortho preset stays ortho.
+   * Called when a **rotate** gesture breaks a held viewport-cube snap free —
+   * dragged past `SNAP_BREAKOUT_TRAVEL_PX` (a rotate inside that distance
+   * never gets here, and neither do cube gestures, nor any pan/zoom — those
+   * are sticky and never call this; see {@link releaseSnapPinForPanZoom}).
+   * Releases both the {@link snapHoldPose} detent, so the camera starts
+   * following the gesture, and the forced orthographic projection, reverting
+   * to the user's `currentView` — so leaving the snap lands back in
+   * perspective only when the user *entered* it from perspective; a toolbar
+   * ortho preset stays ortho.
    *
    * The projection **animates** back over {@link VIEW_TRANSITION_MS} with the
    * same easing as the toolbar's perspective/ortho toggle, so the morph reads
@@ -331,7 +338,10 @@ export class SceneCamera {
    * `OrbitControls.update()` and the inertia step, so whatever rotation those
    * applied this frame is undone before anything is drawn — the snapped view
    * therefore appears completely motionless until the gesture travels past
-   * `SNAP_BREAKOUT_TRAVEL_PX` and {@link notifyUserViewGesture} releases the pin.
+   * `SNAP_BREAKOUT_TRAVEL_PX` and {@link notifyUserViewGesture} releases the pin,
+   * or a pan/zoom gesture releases it early via
+   * {@link releaseSnapPinForPanZoom} so it can move the camera freely while
+   * staying in ortho.
    *
    * Discarding the rotation each frame (rather than accumulating it) is what
    * makes the hand-off seamless: `OrbitControls` derives its orbit frame from
@@ -358,6 +368,23 @@ export class SceneCamera {
       up: this.camera.up.clone(),
       target: this.controls.target.clone(),
     };
+  }
+
+  /**
+   * Release the snap detent so a pan or zoom gesture can move the camera
+   * freely, **without** touching {@link autoOrtho} or reverting the
+   * projection. Pan/zoom are deliberately sticky: they let the user inspect a
+   * snapped ortho view (e.g. a selected face) up close without ever popping
+   * back to perspective — only a genuine rotate past
+   * `SNAP_BREAKOUT_TRAVEL_PX` does that (see {@link notifyUserViewGesture}).
+   *
+   * Without this, {@link applySnapHold} would re-pin the camera back to the
+   * detent on the very next frame and the pan/zoom would appear to do
+   * nothing. A no-op once the pin is already clear, so it is safe to call on
+   * every pan/zoom event.
+   */
+  releaseSnapPinForPanZoom(): void {
+    this.snapHoldPose = null;
   }
 
   /**

--- a/ui/src/app/components/viewer/scene/controls.ts
+++ b/ui/src/app/components/viewer/scene/controls.ts
@@ -15,8 +15,12 @@ import type { OrbitControls } from 'three/examples/jsm/controls/OrbitControls.js
 const TOUCH_DISABLED = -1 as unknown as TOUCH;
 const TWO_FINGER_DOLLY_DEAD_ZONE_PX = 1.5;
 const TWO_FINGER_ROLL_DEAD_ZONE_RAD = 0.01;
-/** Right-drag travel (px) before it counts as a pan for the auto-ortho revert. */
-const RIGHT_PAN_REVERT_THRESHOLD_PX = 3;
+/**
+ * Right-drag travel (px) before it counts as a genuine pan for releasing the
+ * viewport-cube snap's frozen detent (not the ortho projection — pan is
+ * sticky). Avoids releasing on a bare right-click that never moves.
+ */
+const RIGHT_PAN_RELEASE_THRESHOLD_PX = 3;
 /**
  * Straight-line pointer travel (px) that breaks a viewport-cube snap free.
  *
@@ -145,20 +149,30 @@ export class SceneControls {
   private twoFingerGesture: 'orbit' | 'pan' = 'orbit';
 
   /**
-   * Fired when a gesture breaks a held viewport-cube snap free — a pan, a zoom,
-   * or a rotate dragged past {@link SNAP_BREAKOUT_TRAVEL_PX}. Used by the
-   * auto-ortho behaviour to release the detent and revert the temporary
-   * orthographic projection to the user's chosen view. A rotate inside the
-   * breakout distance and cube-driven camera moves deliberately do not fire it,
+   * Fired when a *rotate* gesture breaks a held viewport-cube snap free — a
+   * drag/swipe past {@link SNAP_BREAKOUT_TRAVEL_PX}. Used by the auto-ortho
+   * behaviour to release the detent and revert the temporary orthographic
+   * projection to the user's chosen view.
+   *
+   * Deliberately **not** fired by pan or zoom: those preserve the dimension-
+   * true flat view (you are moving *around* the same look direction, not away
+   * from it), which is exactly the sticky behaviour the snap exists to give —
+   * e.g. inspecting a sliced face in ortho by panning/zooming around it
+   * without ever popping back to perspective. Only actually orbiting to a new
+   * look direction counts as leaving the snap. A rotate inside the breakout
+   * distance and cube-driven camera moves also deliberately do not fire it,
    * so the snapped view never slips on an accidental nudge. See
    * {@link SceneCamera.notifyUserViewGesture}.
    */
   private revertGestureSink: (() => void) | null = null;
 
-  /** Handlers for the pointer-drag revert detectors, retained for cleanup. */
-  private rightPanPointerDownHandler: ((event: PointerEvent) => void) | null = null;
-  private rightPanPointerMoveHandler: ((event: PointerEvent) => void) | null = null;
-  private rightPanPointerUpHandler: ((event: PointerEvent) => void) | null = null;
+  /** See {@link setPanZoomGestureSink}. */
+  private panZoomGestureSink: (() => void) | null = null;
+
+  /** Handlers for the rotate snap-breakout detector, retained for cleanup. */
+  private rotateBreakoutPointerDownHandler: ((event: PointerEvent) => void) | null = null;
+  private rotateBreakoutPointerMoveHandler: ((event: PointerEvent) => void) | null = null;
+  private rotateBreakoutPointerUpHandler: ((event: PointerEvent) => void) | null = null;
 
   /**
    * @param cancelDragCallback  Called when a two-finger gesture begins so
@@ -182,7 +196,7 @@ export class SceneControls {
     this.installAutoscrollZoom();
     this.installAlwaysOnWheelZoom();
     this.installWebKitGestureZoom();
-    this.installRightPanRevertDetection();
+    this.installRotateBreakoutDetection();
     // Orbit is the fixed cursor mode: left-drag rotates, right-drag pans.
     // Middle mouse is reserved for autoscroll zoom; disable OrbitControls' drag-dolly.
     const MIDDLE = null as unknown as MOUSE;
@@ -200,11 +214,11 @@ export class SceneControls {
   }
 
   /**
-  /**
-   * Register a callback fired whenever the user pans, zooms, or drags the main
-   * viewport far enough to break a viewport-cube snap free (never on a small
-   * rotate inside the detent, nor on a cube gesture). Drives the auto-ortho
-   * revert. Pass `null` to clear.
+   * Register a callback fired whenever the user drags a *rotate* gesture far
+   * enough to break a viewport-cube snap free (never on a small rotate inside
+   * the detent, nor on a cube gesture, nor on any pan/zoom — those are sticky,
+   * see {@link setPanZoomGestureSink}). Drives the auto-ortho revert to
+   * perspective. Pass `null` to clear.
    */
   setRevertGestureSink(sink: (() => void) | null): void {
     this.revertGestureSink = sink;
@@ -212,6 +226,21 @@ export class SceneControls {
 
   private emitRevertGesture(): void {
     this.revertGestureSink?.();
+  }
+
+  /**
+   * Register a callback fired on every pan or zoom gesture in the main
+   * viewport. Used to release the viewport-cube snap's frozen detent (see
+   * {@link SceneCamera.releaseSnapPinForPanZoom}) so the gesture can move the
+   * camera — without reverting the temporary orthographic projection, unlike
+   * {@link setRevertGestureSink}. Pass `null` to clear.
+   */
+  setPanZoomGestureSink(sink: (() => void) | null): void {
+    this.panZoomGestureSink = sink;
+  }
+
+  private emitPanZoomGesture(): void {
+    this.panZoomGestureSink?.();
   }
 
   /** Begin a fresh breakout budget for the next rotate gesture. */
@@ -367,37 +396,39 @@ export class SceneControls {
     this.uninstallAutoscrollZoom();
     this.uninstallRendererPointerListeners();
     this.uninstallWebKitGestureZoom();
-    this.uninstallRightPanRevertDetection();
+    this.uninstallRotateBreakoutDetection();
     this.renderer.domElement.removeEventListener('wheel', this.wheelHandler, { capture: true });
   }
 
   // -------------------------------------------------------------------------
-  // Pointer-drag revert detection (right-drag pan + rotate snap breakout)
+  // Pointer-drag detection (rotate snap breakout + right-drag pan release)
   // -------------------------------------------------------------------------
 
   /**
-   * Watches raw pointer drags to drive the auto-ortho revert. Two cases share
-   * these listeners:
+   * Watches raw pointer drags for two purposes that share the same listeners:
    *
-   * - **Right-drag = pan.** OrbitControls pans internally (not via our helpers),
-   *   so we observe the drag to notify the revert. A tiny travel threshold
-   *   avoids reverting on a bare right-click that never moves.
-   * - **Left-drag / touch / pen = rotate.** Distance from the drag origin is the
-   *   snap-breakout metric. It has to be measured in *pixels* here rather than
-   *   in camera angle, because while a snap is held the camera does not rotate
-   *   at all ({@link SceneCamera.applySnapHold}) — there is no angle to measure.
+   * - **Left-drag / touch / pen = rotate.** Drives the auto-ortho revert (see
+   *   {@link revertGestureSink}). Distance from the drag origin is the
+   *   snap-breakout metric, measured in *pixels* rather than camera angle
+   *   because while a snap is held the camera does not rotate at all
+   *   ({@link SceneCamera.applySnapHold}).
+   * - **Right-drag = pan.** OrbitControls pans internally (not via our
+   *   helpers), so this only needs to release the frozen snap detent (see
+   *   {@link panZoomGestureSink}) once the drag genuinely moves — a tiny
+   *   travel threshold avoids firing on a bare right-click that never moves —
+   *   never the revert-to-perspective sink; pan is sticky.
    *
    * We only observe — never `preventDefault`/`stopPropagation` — so
    * OrbitControls still performs the gesture.
    */
-  private installRightPanRevertDetection(): void {
+  private installRotateBreakoutDetection(): void {
     const el = this.renderer.domElement;
     let panPointerId: number | null = null;
     let panStartX = 0;
     let panStartY = 0;
     let panEmitted = false;
 
-    this.rightPanPointerDownHandler = (event: PointerEvent): void => {
+    this.rotateBreakoutPointerDownHandler = (event: PointerEvent): void => {
       if (event.button === 2) {
         panPointerId = event.pointerId;
         panStartX = event.clientX;
@@ -415,14 +446,14 @@ export class SceneControls {
         this.resetBreakout();
       }
     };
-    this.rightPanPointerMoveHandler = (event: PointerEvent): void => {
+    this.rotateBreakoutPointerMoveHandler = (event: PointerEvent): void => {
       if (event.pointerId === panPointerId && !panEmitted) {
         if (
           Math.hypot(event.clientX - panStartX, event.clientY - panStartY) >
-          RIGHT_PAN_REVERT_THRESHOLD_PX
+          RIGHT_PAN_RELEASE_THRESHOLD_PX
         ) {
           panEmitted = true;
-          this.emitRevertGesture();
+          this.emitPanZoomGesture();
         }
         return;
       }
@@ -432,7 +463,7 @@ export class SceneControls {
         );
       }
     };
-    this.rightPanPointerUpHandler = (event: PointerEvent): void => {
+    this.rotateBreakoutPointerUpHandler = (event: PointerEvent): void => {
       if (event.pointerId === panPointerId) {
         panPointerId = null;
         panEmitted = false;
@@ -443,26 +474,26 @@ export class SceneControls {
       }
     };
 
-    el.addEventListener('pointerdown', this.rightPanPointerDownHandler);
-    el.addEventListener('pointermove', this.rightPanPointerMoveHandler);
-    el.addEventListener('pointerup', this.rightPanPointerUpHandler);
-    el.addEventListener('pointercancel', this.rightPanPointerUpHandler);
+    el.addEventListener('pointerdown', this.rotateBreakoutPointerDownHandler);
+    el.addEventListener('pointermove', this.rotateBreakoutPointerMoveHandler);
+    el.addEventListener('pointerup', this.rotateBreakoutPointerUpHandler);
+    el.addEventListener('pointercancel', this.rotateBreakoutPointerUpHandler);
   }
 
-  private uninstallRightPanRevertDetection(): void {
+  private uninstallRotateBreakoutDetection(): void {
     const el = this.renderer.domElement;
-    if (this.rightPanPointerDownHandler) {
-      el.removeEventListener('pointerdown', this.rightPanPointerDownHandler);
-      this.rightPanPointerDownHandler = null;
+    if (this.rotateBreakoutPointerDownHandler) {
+      el.removeEventListener('pointerdown', this.rotateBreakoutPointerDownHandler);
+      this.rotateBreakoutPointerDownHandler = null;
     }
-    if (this.rightPanPointerMoveHandler) {
-      el.removeEventListener('pointermove', this.rightPanPointerMoveHandler);
-      this.rightPanPointerMoveHandler = null;
+    if (this.rotateBreakoutPointerMoveHandler) {
+      el.removeEventListener('pointermove', this.rotateBreakoutPointerMoveHandler);
+      this.rotateBreakoutPointerMoveHandler = null;
     }
-    if (this.rightPanPointerUpHandler) {
-      el.removeEventListener('pointerup', this.rightPanPointerUpHandler);
-      el.removeEventListener('pointercancel', this.rightPanPointerUpHandler);
-      this.rightPanPointerUpHandler = null;
+    if (this.rotateBreakoutPointerUpHandler) {
+      el.removeEventListener('pointerup', this.rotateBreakoutPointerUpHandler);
+      el.removeEventListener('pointercancel', this.rotateBreakoutPointerUpHandler);
+      this.rotateBreakoutPointerUpHandler = null;
     }
   }
 
@@ -495,7 +526,10 @@ export class SceneControls {
     }
     event.preventDefault();
     event.stopImmediatePropagation();
-    this.emitRevertGesture();
+    // Zoom is sticky — it never breaks a held viewport-cube ortho snap (see
+    // {@link revertGestureSink}), but it does need to release the frozen
+    // detent so the zoom actually shows (see {@link panZoomGestureSink}).
+    this.emitPanZoomGesture();
 
     const zoomSpeed = this.controls.zoomSpeed;
     let normalised: number;
@@ -985,7 +1019,10 @@ export class SceneControls {
    * `factor < 1` zooms in, `factor > 1` zooms out.
    */
   private applyTouchDolly(factor: number, cx: number, cy: number): void {
-    this.emitRevertGesture();
+    // Zoom is sticky — release the frozen snap detent (never the ortho
+    // projection itself) so the dolly actually shows. See
+    // {@link panZoomGestureSink}.
+    this.emitPanZoomGesture();
     const { camera } = this;
     const target = this.controls.target;
     camera.updateMatrixWorld(true);
@@ -1018,7 +1055,10 @@ export class SceneControls {
 
   /** Translate camera + target by a screen-space pixel delta. */
   private applyTouchPan(dxPx: number, dyPx: number): void {
-    this.emitRevertGesture();
+    // Pan is sticky — release the frozen snap detent (never the ortho
+    // projection itself) so the pan actually shows. See
+    // {@link panZoomGestureSink}.
+    this.emitPanZoomGesture();
     const { camera } = this;
     const target = this.controls.target;
     camera.updateMatrix();
@@ -1078,7 +1118,10 @@ export class SceneControls {
     }
     event.preventDefault();
     event.stopPropagation();
-    this.emitRevertGesture();
+    // Autoscroll is a zoom gesture — sticky; release the frozen snap detent so
+    // the continuous zoom each frame actually shows. See
+    // {@link panZoomGestureSink}.
+    this.emitPanZoomGesture();
     const el = this.renderer.domElement;
     el.setPointerCapture(event.pointerId);
     el.style.cursor = 'ns-resize';

--- a/ui/src/app/components/viewer/scene/index.ts
+++ b/ui/src/app/components/viewer/scene/index.ts
@@ -281,11 +281,17 @@ export class ViewerScene {
     this._controls = new SceneControls(this.camera, this.controls, this.renderer, () =>
       this._selection.cancelActiveDrag(),
     );
-    // A deliberate free-view gesture in the main viewport — pan, zoom, or a
-    // rotate dragged past the sticky intent threshold — reverts the viewport-
-    // cube's temporary orthographic snap; a small rotate and cube gestures never
-    // fire this, so the mode only changes on a clear user intent.
+    // A deliberate rotate dragged past the sticky intent threshold reverts the
+    // viewport-cube's temporary orthographic snap; a small rotate and cube
+    // gestures never fire this, so the mode only changes on a clear user
+    // intent to look elsewhere.
     this._controls.setRevertGestureSink(() => this._camera.notifyUserViewGesture());
+    // Pan and zoom are sticky — they never revert the snap (see above) — but
+    // still need to release its frozen detent so the gesture actually moves
+    // the camera. This lets the user inspect a snapped ortho view (e.g. a
+    // selected face) up close by panning/zooming without ever popping back to
+    // perspective.
+    this._controls.setPanZoomGestureSink(() => this._camera.releaseSnapPinForPanZoom());
     this._grid = new SceneGrid(this.scene, this.camera, this.controls, this.renderer, printArea);
 
     // The loop only draws when something changed, and several sub-systems paint


### PR DESCRIPTION
## Problem

Clicking a viewport-cube face snaps the camera to that view and flattens the projection to orthographic - great for inspecting a selected face up close. But panning or zooming while that snap was held immediately popped the projection back to perspective, even though neither gesture changes the look direction. That defeats the primary reason to use the snap: select a face, go ortho, then pan/zoom around to inspect detail - without the view ever reverting mid-inspection.

Only a genuine rotate dragged past the existing sticky breakout distance (SNAP_BREAKOUT_TRAVEL_PX, 70px) should end the snap; pan and zoom should stay sticky indefinitely.

## Root cause

Every pan/zoom input path (mouse wheel, pinch, touch pan/dolly, right-drag pan, middle-button autoscroll) called the same emitRevertGesture() sink as the rotate-breakout detector, immediately reverting autoOrtho and animating the projection back to the toolbar's previous preset.

## Fix

- SceneCamera.notifyUserViewGesture() (full revert: pops autoOrtho off and animates back to perspective) is now called only from the rotate snap-breakout path.
- Added SceneCamera.releaseSnapPinForPanZoom() - a much narrower operation that just clears the frozen snapHoldPose detent (so applySnapHold() stops re-pinning the camera every frame and the pan/zoom actually shows) while leaving autoOrtho/the projection untouched.
- SceneControls now exposes two distinct sinks: setRevertGestureSink (rotate only) and setPanZoomGestureSink (pan/zoom), wired up separately in ViewerScene.
- Renamed installRightPanRevertDetection -> installRotateBreakoutDetection and its handlers to reflect that right-drag pan now only releases the detent, never reverts the projection.

## Docs

- Updated the "Viewport-cube auto-ortho" section of ui/src/app/components/viewer/README.md and its action table to reflect that pan/zoom are sticky.
- Added a CHANGELOG.md entry under [Unreleased] / Fixed.

## Verification

- `pnpm exec ng build --configuration development` succeeds with no new TypeScript errors (temporarily backfilled the gitignored src/generated/src/schemas artifacts from a sibling worktree to unblock the build; not part of this diff).
- `pnpm exec prettier --check` passes on all touched files.
- No existing tests reference this behavior (no camera.ts/controls.ts spec files exist), so no test updates were needed.
