### PR TITLE
feat(profiles): export the profile library as CLI-ready TOML

### DIFF
--- a/AGENTS.md
+++ b/AGENTS.md
@@ -460,8 +460,14 @@ server. [src/profiles/store.rs](src/profiles/store.rs) is the engine-side store.
   `slicer.toml` in [`config_dir()`](src/config/io.rs); the UI↔engine transport
   is JSON. The profile structs are JSON-native (`#[serde(flatten)]` meta + a
   dynamic `serde_json::Value` `params` bag) which the `toml` serializer cannot
-  encode directly, so `ProfileStore` bridges through `serde_json::Value` and
-  drops nulls. **Do not try to `toml::to_string` a profile struct directly.**
+  encode directly, so the conversion goes through `serde_json::Value` with nulls
+  dropped. **Do not try to `toml::to_string` a profile struct directly** — call
+  [`toml_bridge::render_library_toml`](src/profiles/toml_bridge.rs), the one
+  renderer behind both `ProfileStore::save` and the exporter.
+- **The library *shape* is target-independent.** `ProfileLibrary`, `Label` and
+  `ProfileKind` live in [library.rs](src/profiles/library.rs) so wasm (which has
+  no filesystem, hence no `store`) can still use them. Only `ProfileStore` is
+  `cfg(not(target_arch = "wasm32"))`.
 - **SQLite is only history + `gcode_cache`.** Profiles never touch the DB.
 - **Whole-category, last-writer-wins sync.** The unit is a category
   (`ProfileKind::{Printers,Filaments,Processes,Labels}`); the UI sends the full
@@ -502,6 +508,56 @@ server. [src/profiles/store.rs](src/profiles/store.rs) is the engine-side store.
 - **The settings-sidebar notice** reflects this: native = "saved on this
   device", cloud = "saved on the slicer" (safe if the browser is wiped), web =
   "kept in this browser only" (losable).
+
+### Export — written once, never revisited
+
+[src/profiles/export.rs](src/profiles/export.rs) renders the library for
+download in two shapes: a **bundle** (`slicer-profiles.zip`, one TOML per
+profile plus `labels.toml`, `manifest.toml`, `README.md`) and a **single**
+`profiles.toml` identical to what the store writes. Both come from the same
+`ProfileLibrary` serialization.
+
+- **Never name a field — or a category.** The exporter walks the *serialized
+  value* and treats every top-level array as a category. A new profile setting,
+  or a whole new category on `ProfileLibrary`, is exported with **zero** changes
+  here. That is the point of the module; do not add per-feature branches to it.
+  The only category-specific rule is one line (`splits_per_item`): labels are a
+  flat vocabulary and stay in one file, everything else is one file per item.
+- **Every file is an array of tables** (`[[printers]]`), and per-item files are
+  **ordinal-prefixed** (`printers/01-voron-24.toml`). Concatenating a bundle in
+  name order therefore reconstructs a valid `profiles.toml` *with the original
+  order intact* — the contract a future importer relies on, pinned by
+  `concatenating_a_bundle_reconstructs_the_library`.
+- **Deterministic:** fixed zip timestamps, so the same library exports
+  byte-identically and the artifact can be diffed or version-controlled.
+- **Credentials are stripped.** An export is built to be *handed over* (git
+  repo, AirDrop, mail), so `redact_secrets` removes any field named in
+  `SECRET_FIELDS` (`api_key`, `token`, …) anywhere in the tree, in **both**
+  shapes. Matched by name at the value level, so a credential added to any
+  profile later is covered for free. The bundle README and the settings copy
+  both say so; the user re-enters keys after restoring.
+- **The export is faithful to the library *as the engine understands it*** —
+  what `ProfileStore::load` produced and what the next save would write — not a
+  verbatim copy of the bytes on disk. A *typed* field written by a different
+  build is dropped by serde at load, before the exporter sees it (exactly as it
+  already is for `GET /api/profiles`). Free-form `params` entries, where new
+  slicing settings actually land, always survive. Don't overstate this in
+  user-facing copy.
+- **Three transports, one renderer:** `GET /api/profiles/export?format=`
+  (cloud), Tauri `profiles_export` (native) — both export what is *persisted*,
+  i.e. what the CLI on that machine would read — and wasm
+  `exportProfileLibrary(library, format)` for the web runtime, where the browser
+  is the engine and the UI's own library is the only truth. The wasm binding
+  exists only in the `web-slicer` build, so
+  [`BrowserProfilePersistence`](ui/src/app/services/profiles/profile-persistence.ts)
+  looks it up dynamically rather than importing a symbol the cloud/native
+  bindings do not declare.
+- **UI:** [`ProfileExport`](ui/src/app/services/profiles/profile-export.ts) picks
+  the transport and hands the bytes to
+  [`FileExport`](ui/src/app/services/file-export.ts) — the one place that knows
+  the three "save a file" idioms (iOS share sheet, desktop Save-As, browser
+  anchor). G-code downloads go through it too; **do not re-implement a download
+  in a feature**.
 
 ## Scene Engine — SSOT Contract
 

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -22,6 +22,16 @@ these notes and acknowledges contributors. `scripts/gen-changelog-draft.sh` and
 
 ### Added
 
+- **Export your profile library** — Settings → General now has a **Backup &
+  Export** section that downloads every printer, filament, print profile and
+  label as TOML. The default export is a ZIP bundle with one file per profile
+  (`printers/01-voron-24.toml`, …); the dropdown offers a single `profiles.toml`
+  instead — the exact file the engine and CLI read, so it can be dropped into a
+  config directory as-is. Concatenating a bundle reproduces that same file, in
+  the original order. The engine renders the export in every runtime (server,
+  desktop, and in-browser), so the files always match what the slicer reads
+  back. Printer API keys are stripped from the export, so it is safe to share or
+  commit — re-enter them after restoring.
 - **Advanced retraction modes** — the G-code generator now supports firmware
   retraction (`G10`/`G11`, synced to the firmware with `M207`/`M208` on Marlin or
   `SET_RETRACTION` on Klipper), relative extruder distances (`M83`), a

--- a/src/profiles/export.rs
+++ b/src/profiles/export.rs
@@ -1,0 +1,635 @@
+//! Exporting the profile library as TOML the CLI already understands.
+//!
+//! # Why this module exists
+//!
+//! A user's printers, filaments, process profiles and labels are theirs — they
+//! must be able to take them somewhere else: another machine, a backup, a
+//! git repo, or a headless `slicer-engine` invocation. The engine already
+//! *speaks* TOML for exactly this data ([`profiles.toml`][store]), so an export
+//! is not a new format — it is the same document, optionally split up.
+//!
+//! # The one rule: never name a field
+//!
+//! Everything here works on the **serialized value** of a
+//! [`ProfileLibrary`], never on a hand-written list of categories or settings.
+//! A new profile setting, or a whole new category added to `ProfileLibrary`,
+//! flows into the export with no change to this module. That is the entire
+//! design constraint: the export is written once and never touched again as
+//! features land. (The one exception is deliberate: [`SECRET_FIELDS`] names the
+//! credentials that must be stripped — and that too is matched by name at the
+//! value level, so a future credential is covered.)
+//!
+//! # What the export is faithful to
+//!
+//! The export mirrors the library **as this engine understands it** — exactly
+//! what [`ProfileStore::load`][load] produced and what the next save would write
+//! back. It is not a verbatim copy of the bytes on disk: a *typed* field written
+//! by a different build is dropped by serde during load, before the exporter
+//! sees it, just as it is for `GET /api/profiles` and for the next save. Values
+//! in a profile's free-form `params` bag — where slicing settings live, and
+//! therefore where new settings actually land — are preserved whatever they are.
+//!
+//! [load]: super::store::ProfileStore::load
+//!
+//! # The two shapes
+//!
+//! | Format | Artifact | Shape |
+//! | --- | --- | --- |
+//! | [`Bundle`] | `slicer-profiles.zip` | `printers/<slug>.toml`, `filaments/…`, `processes/…`, `labels.toml`, plus `manifest.toml` and `README.md` |
+//! | [`Single`] | `profiles.toml` | Byte-identical to what [`ProfileStore::save`][save] writes |
+//!
+//! Every file in a bundle is an **array of tables** (`[[printers]]`), so
+//!
+//! ```text
+//! cat printers/*.toml filaments/*.toml processes/*.toml labels.toml > profiles.toml
+//! ```
+//!
+//! reconstructs a valid library file. That property is what makes the split
+//! bundle CLI-compatible without a second serializer — and what a future
+//! importer can rely on.
+//!
+//! [`Bundle`]: ProfileExportFormat::Bundle
+//! [`Single`]: ProfileExportFormat::Single
+//! [store]: super::store
+//! [save]: super::store::ProfileStore::save
+
+use std::io::{Cursor, Write};
+
+use anyhow::{Context, Result};
+use serde_json::Value;
+use zip::write::SimpleFileOptions;
+use zip::{CompressionMethod, ZipWriter};
+
+use super::library::ProfileLibrary;
+use super::toml_bridge::{json_to_toml, library_to_value, render_value_toml};
+
+/// Which artifact an export produces.
+#[derive(Debug, Clone, Copy, PartialEq, Eq)]
+pub enum ProfileExportFormat {
+    /// A ZIP archive with one TOML file per profile.
+    Bundle,
+    /// A single `profiles.toml` — the file the engine and CLI read directly.
+    Single,
+}
+
+impl ProfileExportFormat {
+    /// Parse the wire token used by the transports (`bundle` / `toml`).
+    ///
+    /// Unknown tokens are rejected rather than silently defaulting, so a typo
+    /// in a URL never hands the user the wrong artifact.
+    pub fn parse(token: &str) -> Option<Self> {
+        match token.to_ascii_lowercase().as_str() {
+            "bundle" | "zip" => Some(Self::Bundle),
+            "single" | "toml" | "cli" => Some(Self::Single),
+            _ => None,
+        }
+    }
+}
+
+/// A rendered export: the bytes plus how to present them to the user.
+#[derive(Debug, Clone, PartialEq, Eq)]
+pub struct ProfileExportArtifact {
+    /// Suggested download / save-as filename.
+    pub filename: String,
+    /// MIME type for the HTTP response and the browser download.
+    pub mime: &'static str,
+    /// The file contents.
+    pub bytes: Vec<u8>,
+}
+
+/// Render a library in the requested shape.
+///
+/// Credentials are stripped from both shapes — see [`redact_secrets`].
+pub fn export_library(
+    library: &ProfileLibrary,
+    format: ProfileExportFormat,
+) -> Result<ProfileExportArtifact> {
+    let mut value = library_to_value(library)?;
+    redact_secrets(&mut value);
+
+    match format {
+        ProfileExportFormat::Single => Ok(ProfileExportArtifact {
+            filename: "profiles.toml".to_string(),
+            mime: "application/toml",
+            bytes: render_value_toml(value)?.into_bytes(),
+        }),
+        ProfileExportFormat::Bundle => Ok(ProfileExportArtifact {
+            filename: "slicer-profiles.zip".to_string(),
+            mime: "application/zip",
+            bytes: render_bundle(value)?,
+        }),
+    }
+}
+
+/// Field names whose values are credentials and must never leave the machine.
+///
+/// Matched by **name, anywhere in the tree**, so a credential added to any
+/// profile in future is redacted without touching this module — the same
+/// value-level approach the rest of the exporter uses.
+const SECRET_FIELDS: &[&str] = &["api_key", "password", "token", "secret", "access_token"];
+
+/// Remove every credential from a serialized library, in place.
+///
+/// An export is built to be *handed over* — dropped in a git repo, AirDropped,
+/// mailed. A printer's `api_key` grants control of that printer, so it is
+/// stripped rather than shared; the README says so, and the user re-enters it
+/// on the machine that restores the library.
+fn redact_secrets(value: &mut Value) {
+    match value {
+        Value::Object(map) => {
+            map.retain(|key, _| !SECRET_FIELDS.contains(&key.as_str()));
+            for entry in map.values_mut() {
+                redact_secrets(entry);
+            }
+        }
+        Value::Array(items) => items.iter_mut().for_each(redact_secrets),
+        _ => {}
+    }
+}
+
+/// One file in a bundle, before it is compressed.
+struct BundleEntry {
+    path: String,
+    contents: String,
+}
+
+/// Whether a category is split into one file per item.
+///
+/// Profiles are — a printer is a thing you hand to someone. Labels are a flat
+/// vocabulary where a file per tag would be absurd, so they stay in one file.
+/// Anything added later is a profile category until proven otherwise, so the
+/// default is to split.
+fn splits_per_item(category: &str) -> bool {
+    category != "labels"
+}
+
+/// Build the ZIP payload from the serialized library.
+fn render_bundle(library: Value) -> Result<Vec<u8>> {
+    let mut entries = collect_entries(library)?;
+    entries.sort_by(|a, b| a.path.cmp(&b.path));
+
+    let mut writer = ZipWriter::new(Cursor::new(Vec::new()));
+    // Deflate with a fixed timestamp: exporting the same library twice yields
+    // byte-identical archives, so users can diff or version-control them.
+    let options = SimpleFileOptions::default()
+        .compression_method(CompressionMethod::Deflated)
+        .last_modified_time(zip::DateTime::default());
+
+    for entry in entries {
+        writer
+            .start_file(&entry.path, options)
+            .with_context(|| format!("add '{}' to the export archive", entry.path))?;
+        writer
+            .write_all(entry.contents.as_bytes())
+            .with_context(|| format!("write '{}' into the export archive", entry.path))?;
+    }
+
+    Ok(writer
+        .finish()
+        .context("finish the export archive")?
+        .into_inner())
+}
+
+/// Walk the serialized library and turn every category into files.
+///
+/// This is the generic core: the only thing it knows about a category is its
+/// key and that it is (or is not) an array.
+fn collect_entries(library: Value) -> Result<Vec<BundleEntry>> {
+    let Value::Object(root) = library else {
+        anyhow::bail!("profile library did not serialize to a table");
+    };
+
+    let mut entries = Vec::new();
+    let mut counts: Vec<(String, usize)> = Vec::new();
+    // Non-array fields (a future scalar or table on the library) still have to
+    // survive a round-trip, so they are collected into one `library.toml`.
+    let mut leftovers = serde_json::Map::new();
+
+    for (category, value) in &root {
+        let Value::Array(items) = value else {
+            leftovers.insert(category.clone(), value.clone());
+            continue;
+        };
+        counts.push((category.clone(), items.len()));
+        if items.is_empty() {
+            continue;
+        }
+
+        if splits_per_item(category) {
+            let width = index_width(items.len());
+            for (index, item) in items.iter().enumerate() {
+                let stem = file_stem(item, index, width);
+                entries.push(BundleEntry {
+                    path: format!("{category}/{stem}.toml"),
+                    contents: render_category_file(category, std::slice::from_ref(item))?,
+                });
+            }
+        } else {
+            entries.push(BundleEntry {
+                path: format!("{category}.toml"),
+                contents: render_category_file(category, items)?,
+            });
+        }
+    }
+
+    if !leftovers.is_empty() {
+        entries.push(BundleEntry {
+            path: "library.toml".to_string(),
+            contents: render_table(&Value::Object(leftovers))?,
+        });
+    }
+
+    entries.push(BundleEntry {
+        path: "manifest.toml".to_string(),
+        contents: render_manifest(&counts)?,
+    });
+    entries.push(BundleEntry {
+        path: "README.md".to_string(),
+        contents: readme(),
+    });
+
+    Ok(entries)
+}
+
+/// Render items as `[[category]]` array-of-tables, with a provenance header.
+fn render_category_file(category: &str, items: &[Value]) -> Result<String> {
+    let mut table = serde_json::Map::new();
+    table.insert(category.to_string(), Value::Array(items.to_vec()));
+    let body = render_table(&Value::Object(table))?;
+    Ok(format!(
+        "# slicer-engine {version} — {category}\n\
+         # Append this file to profiles.toml, or concatenate the whole bundle.\n\n\
+         {body}",
+        version = crate::version::VERSION,
+    ))
+}
+
+/// Render any JSON value that is a table as a TOML document.
+fn render_table(value: &Value) -> Result<String> {
+    let toml_value =
+        json_to_toml(value.clone()).context("export section serialized to a null document")?;
+    toml::to_string_pretty(&toml_value).context("render export section to TOML")
+}
+
+/// The archive's self-description: what produced it and what is inside.
+///
+/// Counts are derived from the walk, so a new category is described here
+/// automatically.
+fn render_manifest(counts: &[(String, usize)]) -> Result<String> {
+    let mut export = serde_json::Map::new();
+    export.insert("generator".into(), Value::from("slicer-engine"));
+    export.insert("version".into(), Value::from(crate::version::VERSION));
+    export.insert("format".into(), Value::from("bundle"));
+
+    let mut counted = serde_json::Map::new();
+    for (category, count) in counts {
+        counted.insert(category.clone(), Value::from(*count as i64));
+    }
+
+    let mut root = serde_json::Map::new();
+    root.insert("export".into(), Value::Object(export));
+    root.insert("counts".into(), Value::Object(counted));
+    render_table(&Value::Object(root))
+}
+
+/// Human-facing instructions. Deliberately generic — it describes the *rule*
+/// (every file is an array of tables) rather than listing categories, so it
+/// stays true as the library grows.
+fn readme() -> String {
+    format!(
+        "# Profile export\n\n\
+         Exported by slicer-engine {version}.\n\n\
+         Each `.toml` file here holds one profile as a TOML *array of tables*\n\
+         (`[[printers]]`, `[[filaments]]`, …), which is exactly how the engine\n\
+         stores them in `profiles.toml`.\n\n\
+         ## Restoring the whole library\n\n\
+         Concatenate the files back into a single `profiles.toml` and drop it in\n\
+         the slicer's config directory (next to `slicer.toml`). Every `.toml`\n\
+         except `manifest.toml` is part of the library:\n\n\
+         ```sh\n\
+         cat */*.toml $(ls *.toml | grep -v '^manifest.toml$') > profiles.toml\n\
+         ```\n\n\
+         Files are numbered so that name order is library order — keep the\n\
+         prefixes and the profiles come back in the order you had them.\n\n\
+         ## Taking a single profile\n\n\
+         Append any one file to an existing `profiles.toml`. Because every entry\n\
+         is an array-of-tables element, appending adds a profile instead of\n\
+         replacing one.\n\n\
+         ## Manifest\n\n\
+         `manifest.toml` records the engine version that wrote the export and how\n\
+         many entries each category had.\n\n\
+         ## Printer credentials are not included\n\n\
+         API keys and other secrets are stripped, so this archive is safe to\n\
+         share or commit. Re-enter them in the printer settings after restoring.\n",
+        version = crate::version::VERSION,
+    )
+}
+
+/// Zero-padding width for the ordinal prefix, so 100 profiles still sort right.
+fn index_width(count: usize) -> usize {
+    count.to_string().len().max(2)
+}
+
+/// A filesystem-safe, human-recognisable name for one profile, prefixed with
+/// its position in the category.
+///
+/// The ordinal is not decoration: profile order is user-visible (it is the
+/// order the settings list shows), and a bundle is reassembled by concatenating
+/// files in name order. The prefix is what preserves that order — and it makes
+/// every filename unique, so two profiles both called "Draft" cannot collide.
+///
+/// The readable part prefers the profile's `name`, falls back to its `id`, then
+/// to nothing at all (the ordinal alone still identifies the file).
+fn file_stem(item: &Value, index: usize, width: usize) -> String {
+    let slug = item
+        .get("name")
+        .and_then(Value::as_str)
+        .map(slugify)
+        .filter(|s| !s.is_empty())
+        .or_else(|| {
+            item.get("id")
+                .and_then(Value::as_str)
+                .map(slugify)
+                .filter(|s| !s.is_empty())
+        });
+
+    let ordinal = format!("{:0width$}", index + 1, width = width);
+    match slug {
+        Some(slug) => format!("{ordinal}-{slug}"),
+        None => ordinal,
+    }
+}
+
+/// Lowercase ASCII-alphanumeric with single dashes; anything else becomes a
+/// separator. Non-ASCII names (「試作」, "Prüfung") can slug down to nothing —
+/// [`unique_slug`] falls back to the id in that case.
+fn slugify(input: &str) -> String {
+    let mut out = String::with_capacity(input.len());
+    for ch in input.chars() {
+        if ch.is_ascii_alphanumeric() {
+            out.push(ch.to_ascii_lowercase());
+        } else if !out.ends_with('-') {
+            out.push('-');
+        }
+    }
+    let trimmed = out.trim_matches('-');
+    trimmed.chars().take(60).collect::<String>()
+}
+
+#[cfg(test)]
+mod tests {
+    use super::*;
+    use crate::profiles::library::{Label, LabelTone};
+    use crate::profiles::{defaults, ProfileSource};
+    use std::io::Read;
+
+    fn sample_library() -> ProfileLibrary {
+        let mut printer = defaults::default_printer();
+        printer.meta.id = "user-printer-1".into();
+        printer.meta.name = "Voron 2.4 / 0.6mm".into();
+        printer.meta.source = ProfileSource::User;
+        printer.params = serde_json::json!({
+            "nozzle_diameter_mm": 0.6,
+            "retract_mm": 1.2,
+            "gcode_flavor": "marlin",
+        });
+
+        // Same display name as the first: the slug must not collide.
+        let mut twin = defaults::default_printer();
+        twin.meta.id = "user-printer-2".into();
+        twin.meta.name = "Voron 2.4 / 0.6mm".into();
+        twin.meta.source = ProfileSource::User;
+
+        ProfileLibrary {
+            printers: vec![printer, twin],
+            filaments: vec![defaults::default_filament()],
+            processes: vec![defaults::default_process()],
+            labels: vec![Label {
+                id: "label-favorite".into(),
+                name: "Favorite".into(),
+                color: "#b8942f".into(),
+                tone: LabelTone::Dark,
+            }],
+        }
+    }
+
+    fn unzip(bytes: &[u8]) -> Vec<(String, String)> {
+        let mut archive = zip::ZipArchive::new(Cursor::new(bytes.to_vec())).expect("open archive");
+        let mut files = Vec::new();
+        for i in 0..archive.len() {
+            let mut file = archive.by_index(i).expect("entry");
+            let name = file.name().to_string();
+            let mut contents = String::new();
+            file.read_to_string(&mut contents).expect("read entry");
+            files.push((name, contents));
+        }
+        files
+    }
+
+    #[test]
+    fn single_export_matches_the_engine_on_disk_format() {
+        let library = sample_library();
+        let artifact =
+            export_library(&library, ProfileExportFormat::Single).expect("export single");
+
+        assert_eq!(artifact.filename, "profiles.toml");
+        assert_eq!(
+            String::from_utf8(artifact.bytes.clone()).expect("utf8"),
+            crate::profiles::toml_bridge::render_library_toml(&library).expect("render"),
+            "the single-file export must be the exact document the store writes",
+        );
+
+        let restored = crate::profiles::toml_bridge::parse_library_toml(
+            std::str::from_utf8(&artifact.bytes).expect("utf8"),
+        )
+        .expect("parse");
+        assert_eq!(restored, library);
+    }
+
+    #[test]
+    fn credentials_never_leave_in_either_shape() {
+        let mut library = sample_library();
+        library.printers[0].connection.api_key = Some("super-secret-moonraker-key".into());
+        // A credential nested in the free-form params bag must go too.
+        library.printers[1].params = serde_json::json!({
+            "nested": { "token": "another-secret" },
+            "retract_mm": 1.0,
+        });
+
+        for format in [ProfileExportFormat::Single, ProfileExportFormat::Bundle] {
+            let artifact = export_library(&library, format).expect("export");
+            let haystack = String::from_utf8_lossy(&artifact.bytes).into_owned();
+            assert!(
+                !haystack.contains("super-secret-moonraker-key"),
+                "api_key must not appear in {format:?}",
+            );
+            assert!(
+                !haystack.contains("another-secret"),
+                "a nested credential must not appear in {format:?}",
+            );
+        }
+
+        // Everything else about the connection survives, so the profile is
+        // still usable after restoring — only the key has to be re-entered.
+        let single = export_library(&library, ProfileExportFormat::Single).expect("export");
+        let restored = crate::profiles::toml_bridge::parse_library_toml(
+            std::str::from_utf8(&single.bytes).expect("utf8"),
+        )
+        .expect("parse");
+        assert_eq!(restored.printers[0].connection.api_key, None);
+        assert_eq!(
+            restored.printers[0].connection.host,
+            library.printers[0].connection.host,
+        );
+        assert_eq!(restored.printers[1].params["retract_mm"], 1.0);
+    }
+
+    #[test]
+    fn bundle_splits_profiles_and_keeps_labels_together() {
+        let artifact =
+            export_library(&sample_library(), ProfileExportFormat::Bundle).expect("export bundle");
+        assert_eq!(artifact.filename, "slicer-profiles.zip");
+
+        let names: Vec<String> = unzip(&artifact.bytes)
+            .into_iter()
+            .map(|(name, _)| name)
+            .collect();
+
+        assert!(
+            names.contains(&"printers/01-voron-2-4-0-6mm.toml".to_string()),
+            "{names:?}"
+        );
+        // The duplicate display name must land in its own file, not overwrite.
+        assert!(
+            names.contains(&"printers/02-voron-2-4-0-6mm.toml".to_string()),
+            "{names:?}"
+        );
+        assert!(
+            names.iter().any(|n| n.starts_with("filaments/")),
+            "{names:?}"
+        );
+        assert!(
+            names.iter().any(|n| n.starts_with("processes/")),
+            "{names:?}"
+        );
+        assert!(names.contains(&"labels.toml".to_string()), "{names:?}");
+        assert!(names.contains(&"manifest.toml".to_string()), "{names:?}");
+        assert!(names.contains(&"README.md".to_string()), "{names:?}");
+    }
+
+    /// `cat` the bundle back into one document, the way the README tells users
+    /// to. Entries come back in name order, which is library order.
+    fn reassemble(bytes: &[u8]) -> String {
+        let mut document = String::new();
+        for (name, contents) in unzip(bytes) {
+            if name.ends_with(".toml") && name != "manifest.toml" {
+                document.push_str(&contents);
+                document.push('\n');
+            }
+        }
+        document
+    }
+
+    #[test]
+    fn concatenating_a_bundle_reconstructs_the_library() {
+        let library = sample_library();
+        let artifact = export_library(&library, ProfileExportFormat::Bundle).expect("export");
+
+        let restored =
+            crate::profiles::toml_bridge::parse_library_toml(&reassemble(&artifact.bytes))
+                .expect("parse bundle");
+        assert_eq!(
+            restored, library,
+            "concatenating the bundle must yield the original library",
+        );
+    }
+
+    #[test]
+    fn an_empty_category_still_round_trips() {
+        // An empty category contributes no file, so the reassembled document
+        // simply omits that key — which `#[serde(default)]` reads back as an
+        // empty list. The contract is equality of the *library*, not of the
+        // text.
+        let mut library = sample_library();
+        library.filaments.clear();
+        library.labels.clear();
+
+        let artifact = export_library(&library, ProfileExportFormat::Bundle).expect("export");
+        let restored =
+            crate::profiles::toml_bridge::parse_library_toml(&reassemble(&artifact.bytes))
+                .expect("parse bundle");
+        assert_eq!(restored, library);
+    }
+
+    #[test]
+    fn unknown_settings_in_the_params_bag_survive_the_round_trip() {
+        // The future-proofing guarantee, precisely scoped: a setting this build
+        // has never heard of rides along *when it lives in the free-form params
+        // bag* — which is where slicing settings land — because the exporter
+        // walks values, not fields. (A new *typed* field on a profile struct is
+        // dropped by serde at load time, before the exporter sees it, exactly as
+        // it is for `GET /api/profiles` and the next `ProfileStore::save`.)
+        let mut library = sample_library();
+        library.printers[0].params = serde_json::json!({
+            "a_setting_from_the_future": 42.5,
+            "nested": { "deeply": ["a", "b"] },
+        });
+
+        let artifact = export_library(&library, ProfileExportFormat::Bundle).expect("export");
+        let mut document = String::new();
+        for (name, contents) in unzip(&artifact.bytes) {
+            if name.ends_with(".toml") && name != "manifest.toml" {
+                document.push_str(&contents);
+                document.push('\n');
+            }
+        }
+
+        let restored = crate::profiles::toml_bridge::parse_library_toml(&document).expect("parse");
+        assert_eq!(restored.printers[0].params, library.printers[0].params);
+    }
+
+    #[test]
+    fn empty_library_still_produces_a_readable_archive() {
+        let artifact = export_library(&ProfileLibrary::default(), ProfileExportFormat::Bundle)
+            .expect("export");
+        let files = unzip(&artifact.bytes);
+        let names: Vec<&str> = files.iter().map(|(n, _)| n.as_str()).collect();
+        assert_eq!(names, vec!["README.md", "manifest.toml"]);
+
+        let manifest = &files.iter().find(|(n, _)| n == "manifest.toml").unwrap().1;
+        assert!(manifest.contains("printers = 0"), "{manifest}");
+    }
+
+    #[test]
+    fn export_is_reproducible() {
+        let library = sample_library();
+        let a = export_library(&library, ProfileExportFormat::Bundle).expect("a");
+        let b = export_library(&library, ProfileExportFormat::Bundle).expect("b");
+        assert_eq!(
+            a.bytes, b.bytes,
+            "same library must export byte-identically"
+        );
+    }
+
+    #[test]
+    fn file_stem_falls_back_when_a_name_has_no_ascii() {
+        let item = serde_json::json!({ "id": "user-42", "name": "試作" });
+        assert_eq!(file_stem(&item, 0, 2), "01-user-42");
+
+        let nameless = serde_json::json!({});
+        assert_eq!(file_stem(&nameless, 3, 2), "04");
+    }
+
+    #[test]
+    fn format_tokens_parse() {
+        assert_eq!(
+            ProfileExportFormat::parse("bundle"),
+            Some(ProfileExportFormat::Bundle)
+        );
+        assert_eq!(
+            ProfileExportFormat::parse("TOML"),
+            Some(ProfileExportFormat::Single)
+        );
+        assert_eq!(ProfileExportFormat::parse("pdf"), None);
+    }
+}

--- a/src/profiles/library.rs
+++ b/src/profiles/library.rs
@@ -1,0 +1,121 @@
+//! The user-owned profile library — the data model, independent of storage.
+//!
+//! [`ProfileStore`](super::store::ProfileStore) persists this to
+//! `profiles.toml` on native/server targets, and
+//! [`export`](super::export) renders it for download. Both need the shape, but
+//! only the former needs a filesystem, so the types live here where the wasm
+//! build can use them too.
+
+use schemars::JsonSchema;
+use serde::{Deserialize, Serialize};
+
+use super::{FilamentProfile, PrinterProfile, ProcessProfile};
+
+/// Shade of a [`Label`] tint (mirrors `ui/src/app/models/label.model.ts`).
+#[derive(Debug, Clone, Copy, PartialEq, Eq, Default, Serialize, Deserialize, JsonSchema)]
+#[serde(rename_all = "lowercase")]
+pub enum LabelTone {
+    /// Deeper, slightly stronger tint.
+    #[default]
+    Dark,
+    /// The same hue rendered more transparent, so it reads softer.
+    Light,
+}
+
+/// A user-defined, cross-area label — think Finder tags with GitHub-style
+/// colours. Attached to profiles via [`ProfileMeta::label_ids`], kept as a
+/// single flat vocabulary rather than three per-area lists.
+///
+/// [`ProfileMeta::label_ids`]: super::ProfileMeta::label_ids
+#[derive(Debug, Clone, PartialEq, Serialize, Deserialize, JsonSchema)]
+pub struct Label {
+    /// Stable identifier.
+    pub id: String,
+    /// Human-readable name shown in the UI.
+    pub name: String,
+    /// Base hue as a hex string (e.g. `#b8942f`).
+    pub color: String,
+    /// Shade applied to the base hue.
+    #[serde(default)]
+    pub tone: LabelTone,
+}
+
+/// The complete set of user-owned profile instances the engine persists.
+///
+/// Each field is a syncable category; the UI mirrors these as its four profile
+/// stores. Whole-category replacement (last-writer-wins) is the sync unit — see
+/// [`ProfileStore::replace_category`](super::store::ProfileStore::replace_category).
+#[derive(Debug, Clone, Default, PartialEq, Serialize, Deserialize, JsonSchema)]
+pub struct ProfileLibrary {
+    /// User-owned printer (machine) profiles.
+    #[serde(default)]
+    pub printers: Vec<PrinterProfile>,
+    /// User-owned filament (material) profiles.
+    #[serde(default)]
+    pub filaments: Vec<FilamentProfile>,
+    /// User-owned process (print/quality) profiles.
+    #[serde(default)]
+    pub processes: Vec<ProcessProfile>,
+    /// Flat, cross-area label vocabulary.
+    #[serde(default)]
+    pub labels: Vec<Label>,
+}
+
+/// One syncable profile category — the granularity of a write-through.
+#[derive(Debug, Clone, Copy, PartialEq, Eq, Serialize, Deserialize, JsonSchema)]
+#[serde(rename_all = "lowercase")]
+pub enum ProfileKind {
+    /// [`ProfileLibrary::printers`].
+    Printers,
+    /// [`ProfileLibrary::filaments`].
+    Filaments,
+    /// [`ProfileLibrary::processes`].
+    Processes,
+    /// [`ProfileLibrary::labels`].
+    Labels,
+}
+
+impl ProfileKind {
+    /// The lowercase wire/route token for this category (`"printers"`, …).
+    pub fn as_str(self) -> &'static str {
+        match self {
+            ProfileKind::Printers => "printers",
+            ProfileKind::Filaments => "filaments",
+            ProfileKind::Processes => "processes",
+            ProfileKind::Labels => "labels",
+        }
+    }
+
+    /// Parse a category from its wire/route token (case-insensitive).
+    pub fn parse(token: &str) -> Option<Self> {
+        match token.to_ascii_lowercase().as_str() {
+            "printers" => Some(ProfileKind::Printers),
+            "filaments" => Some(ProfileKind::Filaments),
+            "processes" => Some(ProfileKind::Processes),
+            "labels" => Some(ProfileKind::Labels),
+            _ => None,
+        }
+    }
+}
+
+#[cfg(test)]
+mod tests {
+    use super::*;
+
+    #[test]
+    fn profile_kind_parses_and_stringifies() {
+        for kind in [
+            ProfileKind::Printers,
+            ProfileKind::Filaments,
+            ProfileKind::Processes,
+            ProfileKind::Labels,
+        ] {
+            assert_eq!(ProfileKind::parse(kind.as_str()), Some(kind));
+            assert_eq!(
+                ProfileKind::parse(&kind.as_str().to_uppercase()),
+                Some(kind)
+            );
+        }
+        assert_eq!(ProfileKind::parse("bogus"), None);
+    }
+}

--- a/src/profiles/mod.rs
+++ b/src/profiles/mod.rs
@@ -33,28 +33,35 @@
 //! `max_print_speed`), and the user's explicit overrides win over everything.
 
 pub mod defaults;
+pub mod export;
 pub mod filament;
+pub mod library;
 pub mod meta;
 pub mod printer;
 pub mod process;
 pub mod resolve;
+pub mod toml_bridge;
 
 // On-disk profile persistence (TOML). Native/server only — the wasm build has
 // no filesystem and keeps the library in the browser's localStorage instead.
+// The library *shape* and its TOML rendering live in `library` / `toml_bridge`,
+// which every target (including wasm, for export) compiles.
 #[cfg(not(target_arch = "wasm32"))]
 pub mod store;
 
 #[cfg(all(target_arch = "wasm32", feature = "web-slicer"))]
 pub mod wasm;
 
+pub use export::{export_library, ProfileExportArtifact, ProfileExportFormat};
 pub use filament::{material_density, FilamentMaterial, FilamentProfile};
+pub use library::{Label, LabelTone, ProfileKind, ProfileLibrary};
 pub use meta::{ProfileMeta, ProfileSource};
 pub use printer::{BedShape, PrinterConnection, PrinterConnectionKind, PrinterProfile};
 pub use process::{PrintQuality, ProcessProfile};
 pub use resolve::{resolve, ProfileSelection};
 
 #[cfg(not(target_arch = "wasm32"))]
-pub use store::{Label, LabelTone, ProfileKind, ProfileLibrary, ProfileStore};
+pub use store::ProfileStore;
 
 #[cfg(test)]
 mod tests {

--- a/src/profiles/store.rs
+++ b/src/profiles/store.rs
@@ -19,115 +19,23 @@
 //! The library is persisted as **TOML** (`profiles.toml`, beside `slicer.toml`
 //! in the [config dir][crate::config::config_dir]) so it is human-readable and
 //! sits with the other engine config. The transport between UI and engine is
-//! **JSON**.
+//! **JSON**. The conversion between the two lives in
+//! [`toml_bridge`](super::toml_bridge), which this module and the
+//! [exporter](super::export) share so an exported file is the same document
+//! this store would write.
 //!
-//! The profile structs are JSON-native ([`#[serde(flatten)]`][flatten] metadata
-//! plus a dynamic `serde_json::Value` `params` bag), a shape the `toml`
-//! serializer cannot encode directly. So save/load goes through a JSON↔TOML
-//! bridge: the typed structs are taken to a `serde_json::Value` first (which
-//! handles flatten and the params bag perfectly), then converted to a
-//! `toml::Value` with nulls dropped. This keeps the wire schema identical to
-//! the JSON the UI already speaks and never forces a change on the canonical
-//! profile definitions.
-//!
-//! [flatten]: https://serde.rs/field-attrs.html#flatten
+//! The library *shape* itself lives in [`library`](super::library) — it is
+//! needed by targets that have no filesystem (wasm), which this module does
+//! not compile for.
 
 use std::fs;
 use std::path::{Path, PathBuf};
 
 use anyhow::{Context, Result};
-use schemars::JsonSchema;
-use serde::{Deserialize, Serialize};
 
-use super::{FilamentProfile, PrinterProfile, ProcessProfile};
+use super::library::{ProfileKind, ProfileLibrary};
+use super::toml_bridge::{parse_library_toml, render_library_toml};
 use crate::config::config_dir;
-
-/// Shade of a [`Label`] tint (mirrors `ui/src/app/models/label.model.ts`).
-#[derive(Debug, Clone, Copy, PartialEq, Eq, Default, Serialize, Deserialize, JsonSchema)]
-#[serde(rename_all = "lowercase")]
-pub enum LabelTone {
-    /// Deeper, slightly stronger tint.
-    #[default]
-    Dark,
-    /// The same hue rendered more transparent, so it reads softer.
-    Light,
-}
-
-/// A user-defined, cross-area label — think Finder tags with GitHub-style
-/// colours. Attached to profiles via [`ProfileMeta::label_ids`], kept as a
-/// single flat vocabulary rather than three per-area lists.
-///
-/// [`ProfileMeta::label_ids`]: super::ProfileMeta::label_ids
-#[derive(Debug, Clone, PartialEq, Serialize, Deserialize, JsonSchema)]
-pub struct Label {
-    /// Stable identifier.
-    pub id: String,
-    /// Human-readable name shown in the UI.
-    pub name: String,
-    /// Base hue as a hex string (e.g. `#b8942f`).
-    pub color: String,
-    /// Shade applied to the base hue.
-    #[serde(default)]
-    pub tone: LabelTone,
-}
-
-/// The complete set of user-owned profile instances the engine persists.
-///
-/// Each field is a syncable category; the UI mirrors these as its four profile
-/// stores. Whole-category replacement (last-writer-wins) is the sync unit — see
-/// [`ProfileStore::replace_category`].
-#[derive(Debug, Clone, Default, PartialEq, Serialize, Deserialize, JsonSchema)]
-pub struct ProfileLibrary {
-    /// User-owned printer (machine) profiles.
-    #[serde(default)]
-    pub printers: Vec<PrinterProfile>,
-    /// User-owned filament (material) profiles.
-    #[serde(default)]
-    pub filaments: Vec<FilamentProfile>,
-    /// User-owned process (print/quality) profiles.
-    #[serde(default)]
-    pub processes: Vec<ProcessProfile>,
-    /// Flat, cross-area label vocabulary.
-    #[serde(default)]
-    pub labels: Vec<Label>,
-}
-
-/// One syncable profile category — the granularity of a write-through.
-#[derive(Debug, Clone, Copy, PartialEq, Eq, Serialize, Deserialize, JsonSchema)]
-#[serde(rename_all = "lowercase")]
-pub enum ProfileKind {
-    /// [`ProfileLibrary::printers`].
-    Printers,
-    /// [`ProfileLibrary::filaments`].
-    Filaments,
-    /// [`ProfileLibrary::processes`].
-    Processes,
-    /// [`ProfileLibrary::labels`].
-    Labels,
-}
-
-impl ProfileKind {
-    /// The lowercase wire/route token for this category (`"printers"`, …).
-    pub fn as_str(self) -> &'static str {
-        match self {
-            ProfileKind::Printers => "printers",
-            ProfileKind::Filaments => "filaments",
-            ProfileKind::Processes => "processes",
-            ProfileKind::Labels => "labels",
-        }
-    }
-
-    /// Parse a category from its wire/route token (case-insensitive).
-    pub fn parse(token: &str) -> Option<Self> {
-        match token.to_ascii_lowercase().as_str() {
-            "printers" => Some(ProfileKind::Printers),
-            "filaments" => Some(ProfileKind::Filaments),
-            "processes" => Some(ProfileKind::Processes),
-            "labels" => Some(ProfileKind::Labels),
-            _ => None,
-        }
-    }
-}
 
 /// Default library file: `<config_dir>/profiles.toml`, beside `slicer.toml`.
 pub fn profiles_file() -> PathBuf {
@@ -175,12 +83,8 @@ impl ProfileStore {
         }
         let content = fs::read_to_string(&self.path)
             .with_context(|| format!("read profiles '{}'", self.path.display()))?;
-        let toml_value: toml::Value = toml::from_str(&content)
-            .with_context(|| format!("parse profiles TOML '{}'", self.path.display()))?;
-        let json = toml_to_json(toml_value);
-        let library = serde_json::from_value(json)
-            .with_context(|| format!("decode profiles '{}'", self.path.display()))?;
-        Ok(library)
+        parse_library_toml(&content)
+            .with_context(|| format!("load profiles '{}'", self.path.display()))
     }
 
     /// Persist the whole library, creating parent directories as needed.
@@ -189,13 +93,7 @@ impl ProfileStore {
             fs::create_dir_all(parent)
                 .with_context(|| format!("create profiles dir '{}'", parent.display()))?;
         }
-        let json = serde_json::to_value(library).context("serialize profile library")?;
-        // The root is always a struct → a TOML table; only an all-null value
-        // could yield `None`, which cannot happen for `ProfileLibrary`.
-        let toml_value =
-            json_to_toml(json).context("profile library serialized to a null TOML document")?;
-        let content =
-            toml::to_string_pretty(&toml_value).context("render profile library to TOML")?;
+        let content = render_library_toml(library)?;
         fs::write(&self.path, content)
             .with_context(|| format!("write profiles '{}'", self.path.display()))?;
         Ok(())
@@ -230,65 +128,10 @@ impl ProfileStore {
     }
 }
 
-/// Convert a `serde_json::Value` into a `toml::Value`, dropping nulls.
-///
-/// Returns `None` for a bare `null` (and omits null object entries / array
-/// elements) because TOML has no null. This is what lets the profiles' sparse
-/// `params` bag — which defaults to `Value::Null` — round-trip cleanly.
-fn json_to_toml(value: serde_json::Value) -> Option<toml::Value> {
-    use serde_json::Value as J;
-    Some(match value {
-        J::Null => return None,
-        J::Bool(b) => toml::Value::Boolean(b),
-        J::Number(n) => {
-            if let Some(i) = n.as_i64() {
-                toml::Value::Integer(i)
-            } else if let Some(f) = n.as_f64() {
-                toml::Value::Float(f)
-            } else {
-                // u64 above i64::MAX — keep it losslessly as a string.
-                toml::Value::String(n.to_string())
-            }
-        }
-        J::String(s) => toml::Value::String(s),
-        J::Array(items) => toml::Value::Array(items.into_iter().filter_map(json_to_toml).collect()),
-        J::Object(map) => {
-            let mut table = toml::map::Map::new();
-            for (key, val) in map {
-                if let Some(converted) = json_to_toml(val) {
-                    table.insert(key, converted);
-                }
-            }
-            toml::Value::Table(table)
-        }
-    })
-}
-
-/// Convert a `toml::Value` back into a `serde_json::Value`.
-fn toml_to_json(value: toml::Value) -> serde_json::Value {
-    use toml::Value as T;
-    match value {
-        T::String(s) => serde_json::Value::String(s),
-        T::Integer(i) => serde_json::Value::Number(i.into()),
-        T::Float(f) => serde_json::Number::from_f64(f)
-            .map(serde_json::Value::Number)
-            .unwrap_or(serde_json::Value::Null),
-        T::Boolean(b) => serde_json::Value::Bool(b),
-        T::Datetime(dt) => serde_json::Value::String(dt.to_string()),
-        T::Array(items) => serde_json::Value::Array(items.into_iter().map(toml_to_json).collect()),
-        T::Table(table) => serde_json::Value::Object(
-            table
-                .into_iter()
-                .map(|(k, v)| (k, toml_to_json(v)))
-                .collect(),
-        ),
-    }
-}
-
 #[cfg(test)]
 mod tests {
     use super::*;
-    use crate::profiles::{defaults, ProfileSource};
+    use crate::profiles::{defaults, Label, LabelTone, ProfileSource};
 
     fn sample_library() -> ProfileLibrary {
         let mut printer = defaults::default_printer();
@@ -395,22 +238,5 @@ mod tests {
         assert_eq!(updated.processes.len(), 1);
 
         let _ = fs::remove_dir_all(&dir);
-    }
-
-    #[test]
-    fn profile_kind_parses_and_stringifies() {
-        for kind in [
-            ProfileKind::Printers,
-            ProfileKind::Filaments,
-            ProfileKind::Processes,
-            ProfileKind::Labels,
-        ] {
-            assert_eq!(ProfileKind::parse(kind.as_str()), Some(kind));
-            assert_eq!(
-                ProfileKind::parse(&kind.as_str().to_uppercase()),
-                Some(kind)
-            );
-        }
-        assert_eq!(ProfileKind::parse("bogus"), None);
     }
 }

--- a/src/profiles/toml_bridge.rs
+++ b/src/profiles/toml_bridge.rs
@@ -1,0 +1,110 @@
+//! The JSON↔TOML bridge the profile library is persisted and exported through.
+//!
+//! # Why a bridge instead of `toml::to_string(&library)`
+//!
+//! The profile structs are JSON-native: [`#[serde(flatten)]`][flatten] metadata
+//! plus a dynamic `serde_json::Value` `params` bag. The `toml` serializer
+//! cannot encode that shape directly (flattened maps and TOML's lack of `null`
+//! both trip it). So every render goes through a `serde_json::Value` first —
+//! which handles flatten and the params bag perfectly — and is then converted
+//! to a `toml::Value` with nulls dropped.
+//!
+//! Everything here works at the **value level**: it never names a profile
+//! field. A new setting added to any profile therefore appears in
+//! `profiles.toml` and in an export with no change to this module — the
+//! property the exporter is built on.
+//!
+//! [flatten]: https://serde.rs/field-attrs.html#flatten
+
+use anyhow::{Context, Result};
+
+use super::library::ProfileLibrary;
+
+/// Serialize a library to the JSON value every renderer works from.
+pub fn library_to_value(library: &ProfileLibrary) -> Result<serde_json::Value> {
+    serde_json::to_value(library).context("serialize profile library")
+}
+
+/// Render an already-serialized library value as a TOML document.
+///
+/// Split from [`render_library_toml`] so callers that need to transform the
+/// value first — the exporter, which redacts credentials — still go through the
+/// one renderer.
+pub fn render_value_toml(value: serde_json::Value) -> Result<String> {
+    // The root is always a struct → a TOML table; only an all-null value could
+    // yield `None`, which cannot happen for `ProfileLibrary`.
+    let toml_value =
+        json_to_toml(value).context("profile library serialized to a null TOML document")?;
+    toml::to_string_pretty(&toml_value).context("render profile library to TOML")
+}
+
+/// Render a library as the exact TOML document written to `profiles.toml`.
+///
+/// This is the single renderer behind both
+/// [`ProfileStore::save`](super::store::ProfileStore::save) and the
+/// [single-file export](super::export::ProfileExportFormat::Single), so the
+/// two can never drift.
+pub fn render_library_toml(library: &ProfileLibrary) -> Result<String> {
+    render_value_toml(library_to_value(library)?)
+}
+
+/// Parse a `profiles.toml` document back into a library.
+pub fn parse_library_toml(text: &str) -> Result<ProfileLibrary> {
+    let toml_value: toml::Value = toml::from_str(text).context("parse profiles TOML")?;
+    serde_json::from_value(toml_to_json(toml_value)).context("decode profiles")
+}
+
+/// Convert a `serde_json::Value` into a `toml::Value`, dropping nulls.
+///
+/// Returns `None` for a bare `null` (and omits null object entries / array
+/// elements) because TOML has no null. This is what lets the profiles' sparse
+/// `params` bag — which defaults to `Value::Null` — round-trip cleanly.
+pub fn json_to_toml(value: serde_json::Value) -> Option<toml::Value> {
+    use serde_json::Value as J;
+    Some(match value {
+        J::Null => return None,
+        J::Bool(b) => toml::Value::Boolean(b),
+        J::Number(n) => {
+            if let Some(i) = n.as_i64() {
+                toml::Value::Integer(i)
+            } else if let Some(f) = n.as_f64() {
+                toml::Value::Float(f)
+            } else {
+                // u64 above i64::MAX — keep it losslessly as a string.
+                toml::Value::String(n.to_string())
+            }
+        }
+        J::String(s) => toml::Value::String(s),
+        J::Array(items) => toml::Value::Array(items.into_iter().filter_map(json_to_toml).collect()),
+        J::Object(map) => {
+            let mut table = toml::map::Map::new();
+            for (key, val) in map {
+                if let Some(converted) = json_to_toml(val) {
+                    table.insert(key, converted);
+                }
+            }
+            toml::Value::Table(table)
+        }
+    })
+}
+
+/// Convert a `toml::Value` back into a `serde_json::Value`.
+pub fn toml_to_json(value: toml::Value) -> serde_json::Value {
+    use toml::Value as T;
+    match value {
+        T::String(s) => serde_json::Value::String(s),
+        T::Integer(i) => serde_json::Value::Number(i.into()),
+        T::Float(f) => serde_json::Number::from_f64(f)
+            .map(serde_json::Value::Number)
+            .unwrap_or(serde_json::Value::Null),
+        T::Boolean(b) => serde_json::Value::Bool(b),
+        T::Datetime(dt) => serde_json::Value::String(dt.to_string()),
+        T::Array(items) => serde_json::Value::Array(items.into_iter().map(toml_to_json).collect()),
+        T::Table(table) => serde_json::Value::Object(
+            table
+                .into_iter()
+                .map(|(k, v)| (k, toml_to_json(v)))
+                .collect(),
+        ),
+    }
+}

--- a/src/profiles/wasm.rs
+++ b/src/profiles/wasm.rs
@@ -6,6 +6,8 @@
 
 use wasm_bindgen::prelude::*;
 
+use super::export::{export_library, ProfileExportFormat};
+use super::library::ProfileLibrary;
 use super::resolve::ProfileSelection;
 
 /// Resolve a profile selection + sparse override diff into concrete
@@ -21,4 +23,43 @@ pub fn resolve_slice_params(selection: JsValue) -> Result<JsValue, JsValue> {
         .resolve()
         .map_err(|e| JsValue::from_str(&format!("failed to resolve profiles: {e}")))?;
     serde_wasm_bindgen::to_value(&params).map_err(|e| JsValue::from_str(&e.to_string()))
+}
+
+/// Export a profile library as downloadable TOML — the same renderer the
+/// native and server builds use.
+///
+/// In the web runtime the browser *is* the engine: there is no `profiles.toml`
+/// on a server to read, so the caller passes its own library
+/// (`{ printers, filaments, processes, labels }`) in.
+///
+/// `format` is `"bundle"` (a ZIP with one TOML per profile) or `"toml"` (a
+/// single `profiles.toml`). Returns
+/// `{ filename, mime, bytes }` with `bytes` as a `Uint8Array`.
+#[wasm_bindgen(js_name = exportProfileLibrary)]
+pub fn export_profile_library(library: JsValue, format: &str) -> Result<JsValue, JsValue> {
+    let library: ProfileLibrary = serde_wasm_bindgen::from_value(library)
+        .map_err(|e| JsValue::from_str(&format!("invalid profile library: {e}")))?;
+    let format = ProfileExportFormat::parse(format)
+        .ok_or_else(|| JsValue::from_str(&format!("unknown export format '{format}'")))?;
+
+    let artifact = export_library(&library, format)
+        .map_err(|e| JsValue::from_str(&format!("failed to export profiles: {e}")))?;
+
+    let result = js_sys::Object::new();
+    js_sys::Reflect::set(
+        &result,
+        &JsValue::from_str("filename"),
+        &JsValue::from_str(&artifact.filename),
+    )?;
+    js_sys::Reflect::set(
+        &result,
+        &JsValue::from_str("mime"),
+        &JsValue::from_str(artifact.mime),
+    )?;
+    js_sys::Reflect::set(
+        &result,
+        &JsValue::from_str("bytes"),
+        &js_sys::Uint8Array::from(artifact.bytes.as_slice()),
+    )?;
+    Ok(result.into())
 }

--- a/src/server/README.md
+++ b/src/server/README.md
@@ -117,6 +117,7 @@ classDiagram
 | `/api/config`          | PATCH  | Update one config key, persist to `slicer.toml`                               |
 | `/api/profiles`        | GET    | Return the user-owned profile library (printers/filaments/processes/labels)  |
 | `/api/profiles/:kind`  | PUT    | Replace one category from a JSON array, persist to `profiles.toml`           |
+| `/api/profiles/export` | GET    | Download the library as TOML (`?format=bundle` ZIP, `?format=toml` single file) |
 | `/*` (anything else)   | GET    | Serve the Angular bundle from `ui_dir`                                        |
 
 `POST /api/upload` enforces a 500 MB file-size cap, only reads the

--- a/src/server/handlers.rs
+++ b/src/server/handlers.rs
@@ -126,6 +126,49 @@ pub async fn put_profiles_category_handler(
     }
 }
 
+/// Query for `GET /api/profiles/export`.
+#[derive(serde::Deserialize)]
+pub struct ProfileExportQuery {
+    /// `bundle` (ZIP of one TOML per profile) or `toml` (single
+    /// `profiles.toml`). Defaults to `bundle`.
+    pub format: Option<String>,
+}
+
+/// `GET /api/profiles/export` — download the profile library as TOML.
+///
+/// Exports what is actually persisted beside the engine, so the artifact is the
+/// same data the CLI would read on this machine. See
+/// [`crate::profiles::export`] for the two shapes.
+pub async fn export_profiles_handler(
+    query: web::Query<ProfileExportQuery>,
+) -> actix_web::HttpResponse {
+    let token = query.format.as_deref().unwrap_or("bundle");
+    let Some(format) = crate::profiles::ProfileExportFormat::parse(token) else {
+        return actix_web::HttpResponse::BadRequest()
+            .json(serde_json::json!({ "error": format!("unknown export format '{token}'") }));
+    };
+
+    let library = match crate::profiles::ProfileStore::new().load() {
+        Ok(library) => library,
+        Err(e) => {
+            return actix_web::HttpResponse::InternalServerError()
+                .json(serde_json::json!({ "error": e.to_string() }))
+        }
+    };
+
+    match crate::profiles::export_library(&library, format) {
+        Ok(artifact) => actix_web::HttpResponse::Ok()
+            .content_type(artifact.mime)
+            .insert_header((
+                actix_web::http::header::CONTENT_DISPOSITION,
+                format!("attachment; filename=\"{}\"", artifact.filename),
+            ))
+            .body(artifact.bytes),
+        Err(e) => actix_web::HttpResponse::InternalServerError()
+            .json(serde_json::json!({ "error": e.to_string() })),
+    }
+}
+
 /// `DELETE /api/history` — drop every slicing session, uploaded-file row, and
 /// cached G-code entry (and their on-disk artifacts). Backs the settings Danger
 /// Zone "Clear slice history" action. Profiles and configuration are untouched.

--- a/src/server/mod.rs
+++ b/src/server/mod.rs
@@ -150,6 +150,11 @@ async fn run_server(
                 http::header::CONTENT_TYPE,
                 http::header::AUTHORIZATION,
             ])
+            // `Content-Disposition` is not CORS-safelisted, so a cross-origin
+            // client (the dev server, or any UI served from another origin)
+            // cannot read the filename the engine chose for a download unless
+            // it is explicitly exposed.
+            .expose_headers(vec![http::header::CONTENT_DISPOSITION])
             .supports_credentials();
 
         App::new()
@@ -174,6 +179,10 @@ async fn run_server(
                     .route("/config", web::get().to(handlers::get_config_handler))
                     .route("/config", web::patch().to(handlers::patch_config_handler))
                     .route("/profiles", web::get().to(handlers::get_profiles_handler))
+                    .route(
+                        "/profiles/export",
+                        web::get().to(handlers::export_profiles_handler),
+                    )
                     .route(
                         "/profiles/{kind}",
                         web::put().to(handlers::put_profiles_category_handler),

--- a/ui-desktop/src-tauri/src/commands.rs
+++ b/ui-desktop/src-tauri/src/commands.rs
@@ -74,6 +74,38 @@ pub fn profiles_save_category(kind: String, items: Value) -> Result<Value, Strin
     serde_json::to_value(library).map_err(|e| e.to_string())
 }
 
+/// A rendered profile export, ready for the webview to save or share.
+#[derive(serde::Serialize)]
+pub struct ProfileExport {
+    /// Suggested save-as filename.
+    pub filename: String,
+    /// MIME type, for the share sheet and the blob the UI builds.
+    pub mime: String,
+    /// File contents.
+    pub bytes: Vec<u8>,
+}
+
+/// Export the on-disk profile library as TOML (`bundle` ZIP or single
+/// `profiles.toml`).
+///
+/// Reads `profiles.toml` rather than taking the UI's copy, so what the user
+/// downloads is exactly what this machine's CLI would read.
+#[tauri::command]
+pub fn profiles_export(format: String) -> Result<ProfileExport, String> {
+    let parsed = slicer_engine::profiles::ProfileExportFormat::parse(&format)
+        .ok_or_else(|| format!("unknown export format '{format}'"))?;
+    let library = slicer_engine::profiles::ProfileStore::new()
+        .load()
+        .map_err(|e| e.to_string())?;
+    let artifact =
+        slicer_engine::profiles::export_library(&library, parsed).map_err(|e| e.to_string())?;
+    Ok(ProfileExport {
+        filename: artifact.filename,
+        mime: artifact.mime.to_string(),
+        bytes: artifact.bytes,
+    })
+}
+
 // ── Printer transport ─────────────────────────────────────────────────────────
 //
 // The desktop runtime talks to printers **from this native process** using the

--- a/ui-desktop/src-tauri/src/lib.rs
+++ b/ui-desktop/src-tauri/src/lib.rs
@@ -61,6 +61,7 @@ pub fn run() {
             commands::get_system_accent,
             commands::profiles_load,
             commands::profiles_save_category,
+            commands::profiles_export,
             commands::printer_check,
             commands::printer_detect,
             commands::printer_send,

--- a/ui/src/app/components/profiles/profile-export-button.html
+++ b/ui/src/app/components/profiles/profile-export-button.html
@@ -1,0 +1,37 @@
+<div class="export-split" [class.is-open]="menuOpen()">
+  <button
+    class="export-action"
+    type="button"
+    [disabled]="exporter.isExporting()"
+    (click)="exportBundle()"
+  >
+    <nexus-icon name="download" />
+    {{ exporter.isExporting() ? 'Exporting…' : 'Export profiles' }}
+  </button>
+  <button
+    class="export-caret"
+    type="button"
+    #caret
+    aria-haspopup="menu"
+    aria-label="Choose export format"
+    [attr.aria-expanded]="menuOpen()"
+    [disabled]="exporter.isExporting()"
+    (click)="toggleMenu()"
+  >
+    <nexus-icon name="nav-arrow-down" />
+  </button>
+</div>
+
+<ng-template #menuTpl>
+  <div class="export-menu" role="menu">
+    @for (option of options; track option.value) {
+      <button type="button" role="menuitem" class="export-menu-item" (click)="pick(option.value)">
+        <nexus-icon [name]="option.icon" class="export-menu-icon" aria-hidden="true" />
+        <span class="export-menu-body">
+          <span class="export-menu-label">{{ option.label }}</span>
+          <span class="export-menu-desc">{{ option.description }}</span>
+        </span>
+      </button>
+    }
+  </div>
+</ng-template>

--- a/ui/src/app/components/profiles/profile-export-button.scss
+++ b/ui/src/app/components/profiles/profile-export-button.scss
@@ -1,0 +1,170 @@
+/* The component host is the flex item in a settings row, so it — not the
+   inner split — must refuse to shrink, or the primary label wraps. */
+:host {
+  flex: none;
+}
+
+/* Split button: primary action plus a caret for the alternative file shape.
+   Same anatomy as the slice card's send-split control, sized for a settings
+   row (labelled primary rather than icon-only). */
+.export-split {
+  display: inline-flex;
+  align-items: stretch;
+  height: 32px;
+  flex-shrink: 0;
+  border: 1px solid var(--color-border);
+  border-radius: var(--radius-md);
+  background: var(--color-surface);
+  box-shadow: var(--shadow-xs);
+  overflow: hidden;
+  transition:
+    border-color var(--duration-fast) var(--ease-standard),
+    box-shadow var(--duration-fast) var(--ease-standard);
+
+  &:hover {
+    border-color: var(--accent-border);
+  }
+
+  &.is-open {
+    border-color: var(--accent);
+    box-shadow: 0 0 0 2px var(--color-focus-ring);
+  }
+
+  .export-action,
+  .export-caret {
+    display: inline-flex;
+    align-items: center;
+    justify-content: center;
+    border: none;
+    background: transparent;
+    color: var(--color-text-secondary);
+    cursor: pointer;
+    transition:
+      background-color var(--duration-fast) var(--ease-standard),
+      color var(--duration-fast) var(--ease-standard);
+
+    &:hover:not(:disabled) {
+      background: var(--color-surface-hover);
+      color: var(--color-text-primary);
+    }
+
+    &:focus-visible {
+      outline: none;
+      background: var(--color-surface-hover);
+      color: var(--color-text-primary);
+    }
+
+    &:disabled {
+      opacity: 0.5;
+      cursor: progress;
+    }
+  }
+
+  .export-action {
+    gap: 6px;
+    padding: 0 12px;
+    color: var(--accent);
+    font-size: var(--font-size-sm);
+    font-weight: var(--font-weight-medium);
+    white-space: nowrap;
+    --icon-size: 16px;
+
+    &:hover:not(:disabled) {
+      color: var(--accent-hover);
+    }
+  }
+
+  .export-caret {
+    width: 26px;
+    border-left: 1px solid var(--color-border);
+    color: var(--color-text-tertiary);
+    --icon-size: 16px;
+
+    nexus-icon {
+      transition: transform var(--duration-normal) var(--ease-standard);
+    }
+  }
+
+  &.is-open .export-caret {
+    background: var(--color-surface-hover);
+    color: var(--color-text-primary);
+
+    nexus-icon {
+      transform: rotate(180deg);
+    }
+  }
+}
+
+/* Rendered body-level through FloatingService; emulated-encapsulation
+   attributes still tag these nodes, so scoped styles apply. */
+.export-menu {
+  display: flex;
+  flex-direction: column;
+  gap: 2px;
+  min-width: 268px;
+  padding: var(--spacing-xs);
+  border: 1px solid var(--color-border);
+  border-radius: var(--radius-lg);
+  background: var(--color-bg-secondary);
+  box-shadow: var(--shadow-lg);
+  animation: export-menu-pop var(--duration-fast) var(--ease-standard);
+}
+
+@keyframes export-menu-pop {
+  from {
+    opacity: 0;
+    transform: translateY(-4px);
+  }
+  to {
+    opacity: 1;
+    transform: translateY(0);
+  }
+}
+
+.export-menu-item {
+  display: flex;
+  align-items: flex-start;
+  gap: 10px;
+  width: 100%;
+  padding: 9px 10px;
+  border: none;
+  border-radius: var(--radius-md);
+  background: transparent;
+  color: var(--color-text-primary);
+  text-align: left;
+  cursor: pointer;
+  transition: background-color var(--duration-fast) var(--ease-standard);
+
+  &:hover,
+  &:focus-visible {
+    outline: none;
+    background: var(--color-surface-hover);
+  }
+}
+
+.export-menu-icon {
+  flex: none;
+  margin-top: 1px;
+  color: var(--color-text-tertiary);
+  --icon-size: 17px;
+}
+
+.export-menu-body {
+  display: flex;
+  flex-direction: column;
+  gap: 2px;
+  flex: 1;
+  min-width: 0;
+}
+
+.export-menu-label {
+  font-size: var(--font-size-sm);
+  font-weight: var(--font-weight-medium);
+  line-height: 1.3;
+}
+
+.export-menu-desc {
+  font-size: var(--font-size-xs);
+  color: var(--color-text-tertiary);
+  line-height: 1.3;
+}

--- a/ui/src/app/components/profiles/profile-export-button.ts
+++ b/ui/src/app/components/profiles/profile-export-button.ts
@@ -1,0 +1,113 @@
+import {
+  ChangeDetectionStrategy,
+  Component,
+  DestroyRef,
+  inject,
+  signal,
+  viewChild,
+} from '@angular/core';
+import type { ElementRef, TemplateRef } from '@angular/core';
+import { ProfileExport } from '../../services/profiles/profile-export';
+import type { ProfileExportFormat } from '../../services/profiles/profile-persistence';
+import { FloatingService } from '../../shared/floating';
+import type { FloatingRef } from '../../shared/floating';
+import { Icon } from '../../shared/icon/icon';
+
+/** One row of the export menu. */
+interface ExportOption {
+  value: ProfileExportFormat;
+  label: string;
+  description: string;
+  icon: string;
+}
+
+/**
+ * Split button that downloads the profile library.
+ *
+ * The primary button exports the **bundle** — a ZIP with one TOML file per
+ * profile, which is what most people want (readable, shareable, one file per
+ * thing). The caret opens the alternative: a single `profiles.toml`, the exact
+ * file the engine and CLI read, for dropping straight into a config directory.
+ *
+ * Dumb apart from one injected service: it renders two choices and calls
+ * {@link ProfileExport}. The list is fixed because there are exactly two file
+ * *shapes* a library can take — new profile settings change neither.
+ */
+@Component({
+  selector: 'nexus-profile-export-button',
+  imports: [Icon],
+  templateUrl: './profile-export-button.html',
+  styleUrl: './profile-export-button.scss',
+  changeDetection: ChangeDetectionStrategy.OnPush,
+})
+export class ProfileExportButton {
+  protected readonly exporter = inject(ProfileExport);
+  private readonly floating = inject(FloatingService);
+
+  private readonly caretEl = viewChild<ElementRef<HTMLElement>>('caret');
+  private readonly menuTpl = viewChild<TemplateRef<unknown>>('menuTpl');
+  private menuRef: FloatingRef | null = null;
+
+  protected readonly menuOpen = signal(false);
+
+  protected readonly options: ExportOption[] = [
+    {
+      value: 'bundle',
+      label: 'Bundle (separate files)',
+      description: 'ZIP with one TOML per printer, filament and profile',
+      icon: 'box-iso',
+    },
+    {
+      value: 'toml',
+      label: 'CLI configuration',
+      description: 'A single profiles.toml for the slicer config directory',
+      icon: 'developer',
+    },
+  ];
+
+  constructor() {
+    inject(DestroyRef).onDestroy(() => this.closeMenu());
+  }
+
+  /** The primary action: the separate-files bundle. */
+  protected exportBundle(): void {
+    void this.exporter.export('bundle');
+  }
+
+  protected pick(format: ProfileExportFormat): void {
+    this.closeMenu();
+    void this.exporter.export(format);
+  }
+
+  protected toggleMenu(): void {
+    this.menuOpen() ? this.closeMenu() : this.openMenu();
+  }
+
+  private openMenu(): void {
+    const trigger = this.caretEl()?.nativeElement;
+    const tpl = this.menuTpl();
+    if (!trigger || !tpl) {
+      return;
+    }
+    this.menuOpen.set(true);
+    this.menuRef = this.floating.openTemplate(
+      tpl,
+      {},
+      {
+        reference: trigger,
+        interactive: true,
+        panelClass: 'nexus-floating--fit',
+        originElement: trigger,
+        options: { placement: 'bottom-end', offset: 4, padding: 8 },
+        onOutsidePointer: () => this.closeMenu(),
+        onEscape: () => this.closeMenu(),
+      },
+    );
+  }
+
+  private closeMenu(): void {
+    this.menuOpen.set(false);
+    this.menuRef?.close();
+    this.menuRef = null;
+  }
+}

--- a/ui/src/app/pages/settings/general.html
+++ b/ui/src/app/pages/settings/general.html
@@ -130,6 +130,22 @@
     </div>
   </div>
 
+  <h2 class="subhead">Backup &amp; Export</h2>
+  <div class="settings-card">
+    <div class="settings-field">
+      <span class="settings-field-label">
+        <span class="settings-field-title">Profile library</span>
+        <span class="settings-field-desc">
+          Download your printers, filaments, print profiles and labels as TOML — the same format the
+          slicer reads. Export a bundle of separate files, or one
+          <code>profiles.toml</code> for the command line. {{ exportScopeNote }} Printer API keys
+          are left out, so the file is safe to share.
+        </span>
+      </span>
+      <nexus-profile-export-button />
+    </div>
+  </div>
+
   <h2 class="subhead">3D View</h2>
   <div class="settings-card">
     <div class="settings-field">

--- a/ui/src/app/pages/settings/general.ts
+++ b/ui/src/app/pages/settings/general.ts
@@ -9,6 +9,8 @@ import {
   type RenderQuality,
   type TwoFingerGesture,
 } from '../../services/viewer-control';
+import { ProfileExportButton } from '../../components/profiles/profile-export-button';
+import { resolveRuntimeMode } from '../../runtime/domain/runtime-mode.util';
 import { AppVersion } from '../../services/app-version';
 import { Button } from '../../ui/button/button';
 import { SectionHeader } from '../../ui/section-header/section-header';
@@ -17,7 +19,7 @@ import { FovCube } from '../../ui/fov-cube/fov-cube';
 
 @Component({
   selector: 'nexus-settings-general',
-  imports: [Button, RouterLink, SectionHeader, Slider, FovCube],
+  imports: [Button, ProfileExportButton, RouterLink, SectionHeader, Slider, FovCube],
   templateUrl: './general.html',
   styleUrl: './general.scss',
   changeDetection: ChangeDetectionStrategy.OnPush,
@@ -36,6 +38,16 @@ export class GeneralSettings implements OnInit {
 
   protected readonly minFov = MIN_FIELD_OF_VIEW;
   protected readonly maxFov = MAX_FIELD_OF_VIEW;
+
+  /**
+   * Where the exported library comes from. Engine-backed runtimes export the
+   * copy persisted next to the slicer — the one the CLI would read — while the
+   * web runtime, where the browser is the engine, exports this browser's copy.
+   */
+  protected readonly exportScopeNote =
+    resolveRuntimeMode() === 'web'
+      ? 'Exports the library kept in this browser.'
+      : 'Exports the library saved with the slicer.';
 
   /** Build-time version metadata read from the WASM bundle (SSOT). */
   protected readonly info = this.appVersion.info;

--- a/ui/src/app/services/file-export.ts
+++ b/ui/src/app/services/file-export.ts
@@ -1,0 +1,140 @@
+import { Injectable, inject } from '@angular/core';
+import { save } from '@tauri-apps/plugin-dialog';
+import { writeFile } from '@tauri-apps/plugin-fs';
+import { isTauriHost, isTauriMobile } from '../runtime/domain/runtime-mode.util';
+import { NotificationService } from './notifications';
+
+/** A "Save as" file-type filter, as the native dialog expects it. */
+export interface FileTypeFilter {
+  /** Label shown in the dialog's type dropdown. */
+  name: string;
+  /** Extensions without the dot, e.g. `['gcode', 'gco']`. */
+  extensions: string[];
+}
+
+/** Grace period before an object URL is released (see {@link FileExport.saveBytes}). */
+const REVOKE_DELAY_MS = 60_000;
+
+/**
+ * Hands a file to the user, using whatever "save a file" means on the platform
+ * the app is running on.
+ *
+ * There are three genuinely different idioms and no portable one:
+ *
+ * - **iOS/iPadOS** — there is no Save-As panel at all. The export idiom is the
+ *   share sheet (Save to Files, AirDrop, Mail), which performs the copy itself.
+ *   Tauri's `save()` *does* exist on iOS but writes an empty placeholder outside
+ *   the sandbox, so the follow-up write lands nowhere and the user gets a
+ *   0-byte file. The bytes are staged in the app's cache directory first,
+ *   because the sandbox is always writable and `UIActivityViewController` needs
+ *   a real file on disk.
+ * - **Desktop (Tauri)** — the webview does not reliably honour `<a download>`
+ *   against a custom `asset://` URL, so use the native Save-As dialog plus a
+ *   filesystem write.
+ * - **Browser** — an anchor with `download` and an object URL.
+ *
+ * Every download in the app goes through here so those platform quirks are
+ * solved once, not per feature.
+ */
+@Injectable({ providedIn: 'root' })
+export class FileExport {
+  private readonly notifications = inject(NotificationService);
+
+  /** Save in-memory bytes, e.g. an export rendered by the engine. */
+  async saveBytes(
+    bytes: Uint8Array,
+    filename: string,
+    options: { mime?: string; filters?: FileTypeFilter[]; savedLabel?: string } = {},
+  ): Promise<void> {
+    const blob = new Blob([bytes as BlobPart], {
+      type: options.mime ?? 'application/octet-stream',
+    });
+    const url = URL.createObjectURL(blob);
+    try {
+      await this.saveFromUrl(url, filename, options);
+    } finally {
+      // The browser path only *starts* the download on click; revoking in the
+      // same task can cancel it. Release on a later task instead — the native
+      // paths have already read the blob by the time they return.
+      setTimeout(() => URL.revokeObjectURL(url), REVOKE_DELAY_MS);
+    }
+  }
+
+  /** Save whatever a URL resolves to — a blob URL, `asset://`, or an HTTP URL. */
+  async saveFromUrl(
+    url: string,
+    filename: string,
+    options: { filters?: FileTypeFilter[]; savedLabel?: string } = {},
+  ): Promise<void> {
+    if (isTauriMobile()) {
+      await this.shareViaSystemSheet(url, filename);
+      return;
+    }
+
+    if (isTauriHost()) {
+      try {
+        const destination = await save({
+          defaultPath: filename,
+          ...(options.filters ? { filters: options.filters } : {}),
+        });
+        if (!destination) {
+          return; // user cancelled the dialog
+        }
+        const bytes = new Uint8Array(await (await fetch(url)).arrayBuffer());
+        await writeFile(destination, bytes);
+        // Always name the destination: on desktop the user picked a path and
+        // needs to know where the file actually went.
+        this.notifications.success(
+          'Saved',
+          options.savedLabel
+            ? `${options.savedLabel} saved to ${destination}`
+            : `Saved to ${destination}`,
+        );
+      } catch (error) {
+        this.notifications.error('Save failed', messageOf(error));
+      }
+      return;
+    }
+
+    const link = document.createElement('a');
+    link.href = url;
+    link.download = filename;
+    link.click();
+  }
+
+  /**
+   * iOS export: stage the file inside the app's own cache directory, then hand
+   * it to `UIActivityViewController`.
+   */
+  private async shareViaSystemSheet(url: string, filename: string): Promise<void> {
+    try {
+      const [{ invoke }, { appCacheDir, join }, { mkdir, writeFile: writeFsFile }] =
+        await Promise.all([
+          import('@tauri-apps/api/core'),
+          import('@tauri-apps/api/path'),
+          import('@tauri-apps/plugin-fs'),
+        ]);
+
+      const directory = await appCacheDir();
+      await mkdir(directory, { recursive: true }).catch(() => undefined);
+      const staged = await join(directory, filename);
+
+      const bytes = new Uint8Array(await (await fetch(url)).arrayBuffer());
+      await writeFsFile(staged, bytes);
+
+      // Anchor the iPad popover near the top-right, where the triggering
+      // control lives. An unanchored share sheet raises and terminates the app.
+      await invoke('share_file', {
+        path: staged,
+        x: Math.round(window.innerWidth * 0.9),
+        y: Math.round(window.innerHeight * 0.1),
+      });
+    } catch (error) {
+      this.notifications.error('Share failed', messageOf(error));
+    }
+  }
+}
+
+function messageOf(error: unknown): string {
+  return error instanceof Error ? error.message : String(error);
+}

--- a/ui/src/app/services/profiles/profile-export.ts
+++ b/ui/src/app/services/profiles/profile-export.ts
@@ -1,0 +1,79 @@
+import { Injectable, inject, signal } from '@angular/core';
+import { FileExport } from '../file-export';
+import { NotificationService } from '../notifications';
+import { FilamentsStore } from './filaments-store';
+import { LabelsStore } from './labels-store';
+import { PrintProfilesStore } from './print-profiles-store';
+import { PrintersStore } from './printers-store';
+import {
+  ProfilePersistence,
+  type ProfileExportFormat,
+  type ProfileLibrarySnapshot,
+} from './profile-persistence';
+
+/**
+ * Downloads the user's profile library as TOML.
+ *
+ * The **engine** renders every export, in all three runtimes — there is no
+ * TypeScript TOML writer here. That is deliberate: the exported files are the
+ * same documents the engine reads back (`profiles.toml`), so a profile the user
+ * exports today keeps working, and a setting added tomorrow appears in the
+ * export without anyone touching this code.
+ *
+ * Where the data comes from differs by runtime, and only because the truth
+ * does: native and cloud export the library persisted next to the engine (what
+ * the CLI on that machine would read), while the web runtime — where the
+ * browser is the engine — exports the library held in this tab.
+ */
+@Injectable({ providedIn: 'root' })
+export class ProfileExport {
+  private readonly persistence = inject(ProfilePersistence);
+  private readonly fileExport = inject(FileExport);
+  private readonly notifications = inject(NotificationService);
+  private readonly printers = inject(PrintersStore);
+  private readonly filaments = inject(FilamentsStore);
+  private readonly processes = inject(PrintProfilesStore);
+  private readonly labels = inject(LabelsStore);
+
+  /** True while an export is being rendered, so the button can show progress. */
+  readonly isExporting = signal(false);
+
+  /** Render the library in the requested shape and hand it to the user. */
+  async export(format: ProfileExportFormat): Promise<void> {
+    if (this.isExporting()) {
+      return;
+    }
+    this.isExporting.set(true);
+    try {
+      const artifact = await this.persistence.exportLibrary(format, this.snapshot());
+      await this.fileExport.saveBytes(artifact.bytes, artifact.filename, {
+        mime: artifact.mime,
+        filters: [filterFor(format)],
+        savedLabel: 'Profiles',
+      });
+    } catch (error) {
+      this.notifications.error(
+        'Export failed',
+        error instanceof Error ? error.message : String(error),
+      );
+    } finally {
+      this.isExporting.set(false);
+    }
+  }
+
+  /** The library as this tab currently holds it. */
+  private snapshot(): ProfileLibrarySnapshot {
+    return {
+      printers: this.printers.items(),
+      filaments: this.filaments.items(),
+      processes: this.processes.items(),
+      labels: this.labels.items(),
+    };
+  }
+}
+
+function filterFor(format: ProfileExportFormat): { name: string; extensions: string[] } {
+  return format === 'bundle'
+    ? { name: 'ZIP archive', extensions: ['zip'] }
+    : { name: 'TOML', extensions: ['toml'] };
+}

--- a/ui/src/app/services/profiles/profile-persistence.ts
+++ b/ui/src/app/services/profiles/profile-persistence.ts
@@ -20,6 +20,21 @@ export interface ProfileLibrarySnapshot {
 }
 
 /**
+ * Shape of a profile export. Mirrors the engine's `ProfileExportFormat`.
+ *
+ * - `bundle` — a ZIP with one TOML file per profile.
+ * - `toml` — a single `profiles.toml`, the file the engine and CLI read.
+ */
+export type ProfileExportFormat = 'bundle' | 'toml';
+
+/** A rendered export, ready to be saved. */
+export interface ProfileExportArtifact {
+  filename: string;
+  mime: string;
+  bytes: Uint8Array;
+}
+
+/**
  * Persists the user-owned profile library *next to the engine* so it survives a
  * browser cache wipe. There is one implementation per runtime mode:
  *
@@ -76,6 +91,22 @@ export abstract class ProfilePersistence {
     return this.loadLibrary();
   }
 
+  /**
+   * Render the profile library as TOML for download.
+   *
+   * The engine does the rendering in every runtime, so the artifact is exactly
+   * what the CLI reads — there is no TypeScript TOML writer to drift.
+   *
+   * `local` is the UI's own copy of the library. Engine-backed runtimes ignore
+   * it and export what is actually persisted next to the engine (the source of
+   * truth the CLI would read); the web runtime, where the browser *is* the
+   * engine, has nothing else to export, so it hands this to the WASM exporter.
+   */
+  abstract exportLibrary(
+    format: ProfileExportFormat,
+    local: ProfileLibrarySnapshot,
+  ): Promise<ProfileExportArtifact>;
+
   /** Backend-specific whole-library fetch. Only called when engine-backed. */
   protected abstract fetchLibrary(): Promise<ProfileLibrarySnapshot>;
   /** Backend-specific whole-category write. */
@@ -90,6 +121,35 @@ export class BrowserProfilePersistence extends ProfilePersistence {
   }
   protected async persistCategory(): Promise<void> {
     // No engine store — the profile store already wrote localStorage.
+  }
+
+  /**
+   * Export through the WASM engine: in this runtime the browser *is* the
+   * engine, so the library the UI holds is the library, and the same Rust
+   * renderer the server and desktop use produces the bytes.
+   *
+   * The binding ships with the `web-slicer` WASM build — the one this runtime
+   * always loads. It is looked up dynamically because the cloud/native bundles
+   * are generated from a WASM build without the profile bindings (they export
+   * through REST / Tauri instead), and their type declarations therefore do not
+   * declare it.
+   */
+  async exportLibrary(
+    format: ProfileExportFormat,
+    local: ProfileLibrarySnapshot,
+  ): Promise<ProfileExportArtifact> {
+    const wasm = (await import('../../../generated/scene-wasm/scene_engine')) as unknown as {
+      default: (options: { module_or_path: string }) => Promise<unknown>;
+      exportProfileLibrary?: (
+        library: ProfileLibrarySnapshot,
+        format: ProfileExportFormat,
+      ) => ProfileExportArtifact;
+    };
+    await wasm.default({ module_or_path: 'scene_engine_bg.wasm' });
+    if (!wasm.exportProfileLibrary) {
+      throw new Error('This build cannot export profiles');
+    }
+    return wasm.exportProfileLibrary(local, format);
   }
 }
 
@@ -120,6 +180,19 @@ export class RemoteProfilePersistence extends ProfilePersistence {
       throw new Error(`PUT /profiles/${category} failed (${response.status})`);
     }
   }
+
+  async exportLibrary(format: ProfileExportFormat): Promise<ProfileExportArtifact> {
+    const response = await fetch(`${this.base}/profiles/export?format=${format}`);
+    if (!response.ok) {
+      throw new Error(`GET /profiles/export failed (${response.status})`);
+    }
+    const bytes = new Uint8Array(await response.arrayBuffer());
+    return {
+      filename: filenameFromDisposition(response.headers.get('Content-Disposition'), format),
+      mime: response.headers.get('Content-Type') ?? mimeFor(format),
+      bytes,
+    };
+  }
 }
 
 /** Native backend: Tauri `invoke` into the engine's on-disk store. */
@@ -135,6 +208,26 @@ export class NativeProfilePersistence extends ProfilePersistence {
     const { invoke } = await import('@tauri-apps/api/core');
     await invoke('profiles_save_category', { kind: category, items });
   }
+
+  async exportLibrary(format: ProfileExportFormat): Promise<ProfileExportArtifact> {
+    const { invoke } = await import('@tauri-apps/api/core');
+    const artifact = await invoke<{ filename: string; mime: string; bytes: number[] }>(
+      'profiles_export',
+      { format },
+    );
+    return { ...artifact, bytes: Uint8Array.from(artifact.bytes) };
+  }
+}
+
+/** Fallback MIME type when a response does not state one. */
+function mimeFor(format: ProfileExportFormat): string {
+  return format === 'bundle' ? 'application/zip' : 'application/toml';
+}
+
+/** Read the server's suggested filename, falling back to the engine's naming. */
+function filenameFromDisposition(header: string | null, format: ProfileExportFormat): string {
+  const match = header?.match(/filename="?([^"]+)"?/i);
+  return match?.[1] ?? (format === 'bundle' ? 'slicer-profiles.zip' : 'profiles.toml');
 }
 
 /**

--- a/ui/src/app/services/slicer.ts
+++ b/ui/src/app/services/slicer.ts
@@ -1,5 +1,3 @@
-import { save } from '@tauri-apps/plugin-dialog';
-import { writeFile } from '@tauri-apps/plugin-fs';
 import { Injectable, computed, effect, inject, signal, untracked } from '@angular/core';
 import { environment } from '../../environments/environment';
 import { SlicingParams } from '../../generated/slicer-engine-ws-client-message-v1';
@@ -9,10 +7,10 @@ import { RuntimeOrchestrator } from '../runtime/application/runtime-orchestrator
 import { RuntimeSession } from '../runtime/application/runtime-session';
 import { RuntimeHistorySession } from '../runtime/domain/history-models';
 import { RuntimeMode } from '../runtime/domain/runtime-mode';
-import { isTauriMobile } from '../runtime/domain/runtime-mode.util';
 import { RuntimeMeshInput, RuntimeSceneSnapshot } from '../runtime/domain/scene-commands';
 import { createRuntime } from '../runtime/factory/runtime-factory';
 import { RuntimeEvent } from '../runtime/ports/runtime-events';
+import { FileExport } from './file-export';
 import { NotificationService } from './notifications';
 import { ActiveSelection } from './profiles/active-selection';
 import { SceneEngine } from './scene-engine';
@@ -109,6 +107,7 @@ export class Slicer {
   private readonly appVersion = inject(AppVersion);
   private readonly viewerControl = inject(ViewerControl);
   private readonly workplateNames = inject(WorkplateNames);
+  private readonly fileExport = inject(FileExport);
   private readonly runtimeMode = this.resolveRuntimeMode();
   private readonly runtime = createRuntime({
     mode: this.runtimeMode,
@@ -756,84 +755,16 @@ export class Slicer {
     await this.downloadFromUrl(session.download_url, filename);
   }
 
-  private async downloadFromUrl(url: string, filename: string): Promise<void> {
-    // iOS has no Save-As panel. Its export idiom is the share sheet, which lets
-    // the user drop the file into Files, AirDrop it, mail it — and, crucially,
-    // performs the copy itself. Tauri's `save()` does exist on iOS, but it
-    // exports an *empty* placeholder and hands back a URL outside the sandbox,
-    // so the follow-up write lands nowhere and the user gets a 0-byte file.
-    if (isTauriMobile()) {
-      await this.shareViaSystemSheet(url, filename);
-      return;
-    }
-
-    if (this.runtimeMode === 'native') {
-      // Tauri's webview does not reliably honour `<a download>` against a
-      // custom `asset://` URL (it's meant for `<img>`/`<video>` src, not
-      // forcing a save) — depending on OS/WebView the link just navigates or
-      // is silently ignored instead of prompting a save. Use the native
-      // "Save As" dialog + filesystem write instead: fetch the bytes (works
-      // for both `asset://` URLs and blob URLs) and write them to the
-      // user-chosen path.
-      try {
-        const destination = await save({
-          defaultPath: filename,
-          filters: [{ name: 'G-code', extensions: ['gcode', 'gco', 'g'] }],
-        });
-        if (!destination) {
-          return; // user cancelled the dialog
-        }
-        const bytes = new Uint8Array(await (await fetch(url)).arrayBuffer());
-        await writeFile(destination, bytes);
-        this.notifications.success('Saved', `G-code saved to ${destination}`);
-      } catch (error) {
-        const message = error instanceof Error ? error.message : String(error);
-        this.notifications.error('Save failed', message);
-      }
-      return;
-    }
-
-    const link = document.createElement('a');
-    link.href = url;
-    link.download = filename;
-    link.click();
-  }
-
   /**
-   * iOS export: stage the G-code inside the app's own cache directory, then
-   * hand that file to `UIActivityViewController`.
-   *
-   * Staging is what makes this work — the sandbox is always writable, whereas
-   * any location the user picks is not, and the share sheet needs a real file
-   * on disk rather than the `asset://`/blob URL the UI holds.
+   * Hand the G-code to the user. The platform-specific "save a file" idioms
+   * (iOS share sheet, desktop Save-As, browser download) live in
+   * {@link FileExport}; this only supplies the G-code type filter.
    */
-  private async shareViaSystemSheet(url: string, filename: string): Promise<void> {
-    try {
-      const [{ invoke }, { appCacheDir, join }, { mkdir, writeFile: writeFsFile }] =
-        await Promise.all([
-          import('@tauri-apps/api/core'),
-          import('@tauri-apps/api/path'),
-          import('@tauri-apps/plugin-fs'),
-        ]);
-
-      const directory = await appCacheDir();
-      await mkdir(directory, { recursive: true }).catch(() => undefined);
-      const staged = await join(directory, filename);
-
-      const bytes = new Uint8Array(await (await fetch(url)).arrayBuffer());
-      await writeFsFile(staged, bytes);
-
-      // Anchor the iPad popover near the top-right, where the Download control
-      // lives. An unanchored share sheet raises and terminates the app.
-      await invoke('share_file', {
-        path: staged,
-        x: Math.round(window.innerWidth * 0.9),
-        y: Math.round(window.innerHeight * 0.1),
-      });
-    } catch (error) {
-      const message = error instanceof Error ? error.message : String(error);
-      this.notifications.error('Share failed', message);
-    }
+  private async downloadFromUrl(url: string, filename: string): Promise<void> {
+    await this.fileExport.saveFromUrl(url, filename, {
+      filters: [{ name: 'G-code', extensions: ['gcode', 'gco', 'g'] }],
+      savedLabel: 'G-code',
+    });
   }
 
   private resolveRuntimeMode(): RuntimeMode {


### PR DESCRIPTION
Users could not get their printers, filaments, process profiles and labels out of the app. This adds an export in the format the engine already speaks — and, per the brief, it is written **once**: adding a profile setting, or a whole new category, requires no change to the export code.

## The rule that makes it one-time

`src/profiles/export.rs` walks the **serialized** `ProfileLibrary` instead of a hand-written field list. Every top-level array is a category; the only category-specific rule is a single line (`splits_per_item`) that keeps the flat `labels` vocabulary in one file. A new field, or a new category on `ProfileLibrary`, is exported automatically.

## Two shapes

| Format | Artifact | Shape |
| --- | --- | --- |
| **Bundle** (primary button) | `slicer-profiles.zip` | `printers/01-voron-24.toml`, `filaments/…`, `processes/…`, `labels.toml`, plus `manifest.toml` + `README.md` |
| **CLI configuration** (dropdown) | `profiles.toml` | Byte-identical to what `ProfileStore::save` writes — drop it in the config dir and it works |

Every file is a TOML **array of tables** and per-item files are **ordinal-prefixed**, so

```sh
cat */*.toml $(ls *.toml | grep -v '^manifest.toml$') > profiles.toml
```

reconstructs a valid library file **with the original order intact**. That is the contract a future importer relies on, and it is pinned by a test. Archives are byte-reproducible (fixed zip timestamps), so an export can be diffed or version-controlled.

## Credentials are stripped

An export is built to be *handed over* — a git repo, AirDrop, the iOS share sheet. `redact_secrets` removes any field named in `SECRET_FIELDS` (`api_key`, `token`, …) anywhere in the tree, in both shapes, while keeping the rest of the printer connection intact. Matched by name at the value level, so a credential added later is covered for free. The bundle README and the settings copy both say so.

## Supporting changes

- `ProfileLibrary`/`Label`/`ProfileKind` split into `profiles::library`, and the JSON↔TOML bridge into `profiles::toml_bridge` — so wasm (no filesystem, hence no `store`) can export, and **one renderer** backs both save and export.
- **Three transports, one renderer:** `GET /api/profiles/export?format=` (cloud), Tauri `profiles_export` (native) — both export what is *persisted*, i.e. what the CLI on that machine would read — and the wasm `exportProfileLibrary` binding for the web runtime, where the browser is the engine.
- `Content-Disposition` is now exposed via CORS; it is not safelisted, so a cross-origin UI could not read the engine's chosen filename.
- Extracted `Slicer`'s platform save matrix into a reusable `FileExport` service (iOS share sheet / desktop Save-As / browser anchor). G-code downloads now go through it too.

## UI

A new **Backup & Export** section on Settings → General, with a split button modelled on the existing "send to printer" control: primary exports the bundle, the caret offers the single `profiles.toml`.

## Verification

- `cargo test` — 652 + 20 tests pass; `cargo fmt --check` and clippy clean; Tauri crate checks; UI typecheck and production build pass.
- Exercised **through the running UI in a browser** against a real 15-profile library: both formats downloaded, the bundle unzipped to per-profile TOMLs, and reassembling it parsed equal to the single `profiles.toml` export.
- Redaction verified end-to-end against an isolated library with a real `api_key`: absent from every file in both shapes, `host`/`port`/`kind` preserved.

## Notes

The export is faithful to the library **as the engine understands it** — what `ProfileStore::load` produced and what the next save would write — not a verbatim copy of the on-disk bytes. A *typed* field written by a different build is dropped by serde at load, before the exporter sees it, exactly as it already is for `GET /api/profiles`. Free-form `params` entries, where new slicing settings actually land, always survive. The docs state this precisely rather than overclaiming.

Import is out of scope, but the bundle format was chosen so a future importer is a plain `toml::from_str` of concatenated files.
