### PR TITLE
slicing: exclude-object and sequential printing

### DIFF
--- a/.github/instructions/no-issue-numbers.instructions.md
+++ b/.github/instructions/no-issue-numbers.instructions.md
@@ -1,0 +1,50 @@
+---
+description: "Use whenever writing or editing prose the user or a contributor reads — commit messages, PR titles/descriptions, CHANGELOG entries, README and module docs, code comments, doc comments, and UI copy. Do not reference GitHub issue or PR numbers (#123) unless the user explicitly asked for that specific reference."
+name: "No Issue Numbers in Prose Unless Asked"
+---
+
+# No Issue / PR Numbers in Prose
+
+**Describe the change, not its paperwork.** A reader of the code, the changelog,
+or the UI cares *what* something does and *why* — not which tracker ticket it
+came from. Issue and PR numbers are noise to them and rot the moment the repo
+moves hosts or the numbering is renumbered.
+
+## The rule
+
+Do **not** write GitHub issue or PR references — `#123`, `issue #123`,
+`(#123)`, `GH-123`, `fixes #123`, a bare `123` standing in for a ticket, or a
+full `https://github.com/owner/repo/issues/123` URL — in any of:
+
+- **CHANGELOG.md** entries
+- **Commit messages** and **PR titles / descriptions**
+- **Markdown docs** — `README.md`, `AGENTS.md`, module `README.md`s, `RELEASING.md`, etc.
+- **Code comments** and **doc comments** (`///`, `//`, `/* … */`, `#[doc]`, JSDoc)
+- **UI copy** — anything a user reads on screen
+- **Skills and instructions** files
+
+Say what changed instead. Replace *"per-object identity (#22)"* with *"per-object
+identity for exclude-object support"*; replace *"Fixes #487: skirt gap"* with
+*"Fix the skirt gap so loops close toward the object"*.
+
+## The only exceptions — the user asked
+
+Include a number **only** when the user explicitly requests that specific
+reference in this task. For example:
+
+- "link the PR to issue 22", "add `Closes #22` so GitHub auto-closes it"
+- "reference the tracking issue in the changelog"
+- The `Closes #NN` / `Fixes #NN` line a repo requires in a **PR description** to
+  trigger GitHub's auto-close — add it when opening a PR that resolves an issue,
+  since that is a functional directive, not prose. Keep it to that one line; do
+  not sprinkle the number through the rest of the description.
+
+When in doubt, leave the number out — it is trivial to add on request and
+tedious to scrub after the fact.
+
+## Applying to existing text
+
+When you touch a file that already contains issue numbers in prose (not in a
+sanctioned auto-close line the user wants kept), remove them as part of the edit
+and reword so the sentence still reads naturally — do not simply delete the
+`(#123)` and leave a dangling clause.

--- a/.github/instructions/no-issue-numbers.instructions.md
+++ b/.github/instructions/no-issue-numbers.instructions.md
@@ -17,7 +17,7 @@ Do **not** write GitHub issue or PR references — `#123`, `issue #123`,
 full `https://github.com/owner/repo/issues/123` URL — in any of:
 
 - **CHANGELOG.md** entries
-- **Commit messages** and **PR titles / descriptions**
+- **Commit messages** and **PR titles**
 - **Markdown docs** — `README.md`, `AGENTS.md`, module `README.md`s, `RELEASING.md`, etc.
 - **Code comments** and **doc comments** (`///`, `//`, `/* … */`, `#[doc]`, JSDoc)
 - **UI copy** — anything a user reads on screen
@@ -42,9 +42,4 @@ reference in this task. For example:
 When in doubt, leave the number out — it is trivial to add on request and
 tedious to scrub after the fact.
 
-## Applying to existing text
 
-When you touch a file that already contains issue numbers in prose (not in a
-sanctioned auto-close line the user wants kept), remove them as part of the edit
-and reword so the sentence still reads naturally — do not simply delete the
-`(#123)` and leave a dangling clause.

--- a/AGENTS.md
+++ b/AGENTS.md
@@ -637,6 +637,17 @@ segmentation, so it is built once, here.
   errors**: the clearances are machine estimates and refusing to slice would be
   worse than saying what to check. Only objects printed *before* another are
   height-checked; the last one has nothing reaching over it.
+- **The extruder clearances describe the machine, not the process.** Two
+  printers can run the same `by_object` process yet have different gantry
+  heights and duct radii, so `extruder_clearance_height_mm` /
+  `extruder_clearance_radius_mm` carry the **Hardware** `x-group` (printer
+  contract), alongside nozzle diameter — mirroring PrusaSlicer's Printer
+  Settings, and the same rationale that put `preferred_orientation_deg` on the
+  printer profile. Only the print-behaviour toggles (`print_sequence`,
+  `exclude_object`, `between_objects_gcode`) are process settings, under the
+  **Objects** group. They are intrinsic machine specs, so they carry **no**
+  `x-relevant-when` gate (a printer always has a clearance) — which also avoids
+  a cross-contract gate pointing at a process field in another tab.
 - **Object names are sanitised and de-duplicated in the engine.** Klipper parses
   `EXCLUDE_OBJECT_DEFINE NAME=…` as a G-code parameter, so a space splits the
   token, and two parts sharing a name would cancel together. Every runtime feeds

--- a/AGENTS.md
+++ b/AGENTS.md
@@ -38,6 +38,7 @@ make build-release build-windows build-macos build-wasm test lint fmt
 | **Wall Restrictions**          | [src/core/walls.rs](src/core/walls.rs)       | Single-wall first/top-layer constraints                                                       |
 | **Infill Boundary**            | [src/core/infill.rs](src/core/infill.rs)     | Interior region calculation and sparse infill                                                 |
 | **Pipeline**                   | [src/core/pipeline.rs](src/core/pipeline.rs) | `process_mesh` — orchestrates the full slicing pipeline                                       |
+| **Multi-object plates**        | [src/core/objects.rs](src/core/objects.rs)   | `slice_plate` — per-object identity for exclude-object & sequential printing                  |
 | **Scene Engine**               | [src/scene/](src/scene/)                     | Single source of truth for object placement (CLI / WS / WASM all consume `SceneState::apply`) |
 | **Clipper2 Integration**       | [src/core/](src/core/)                       | Geometric polygon clipping operations throughout                                              |
 | **Library Interface**          | [src/lib.rs](src/lib.rs)                     | Public API exposing core functionality                                                        |
@@ -67,7 +68,8 @@ src/
 │   ├── surfaces.rs        # generate_top_bottom_surfaces*, rectilinear infill fill
 │   ├── walls.rs           # apply_single_wall_restrictions (per-island), compute_per_island_strip_masks
 │   ├── infill.rs          # calculate_interior_region, add_infill_to_layers
-│   └── pipeline.rs        # process_mesh (full pipeline orchestrator)
+│   ├── pipeline.rs        # process_mesh (full pipeline orchestrator)
+│   └── objects.rs         # slice_plate — multi-object plates, object identity (#22/#112)
 ├── scene/                 # Unified scene engine (issue #51 — SSOT for object placement)
 │   ├── mod.rs             # Re-exports public API
 │   ├── transform.rs       # Transform { translation, rotation: Quat, scale }; apply_transform; Euler-XYZ deg helpers
@@ -592,6 +594,82 @@ accept more, so the UI keeps a strict split of responsibilities:
 - **The viewer mirrors, it does not own.** `Viewer.syncWasmMeshes()` diffs `sceneEngine.objects()` against its Three.js nodes and adds/disposes to match, so an object created by *anyone* (add button, `Duplicate`, undo) renders without the viewer being told. Do not add a second place that constructs display meshes.
 - **`SlicerFile` holds a list, not a file.** `files` accumulates `{fileId, filename}`; `upload(file)` appends and attaches to the open workplate. `fetchFile` adopts a file as the *primary* displayed model (it sets `selectedFile`, which retargets the viewer's `model` input); additional objects must use **`downloadFile`**, which registers without touching `selectedFile` — otherwise restoring an N-object plate leaves only the last file on screen.
 - **`toSliceDtos`** ([scene-slice-dto.ts](ui/src/app/runtime/adapters/cloud/scene-slice-dto.ts)) resolves each object to its file via `source_id` and throws rather than guessing. It is a pure function with tests pinning the regression; keep the mapping there, not inline in the runtime adapter.
+
+## Object identity through slicing — exclude-object & sequential printing
+
+[src/core/objects.rs](src/core/objects.rs) is where a *plate* (several placed
+objects) becomes *layers* without losing track of which part is which. Issues
+#22 (exclude object) and #112 (sequential printing) need exactly the same
+segmentation, so it is built once, here.
+
+- **[`slice_plate`](src/core/objects.rs) is the single slicing entry point.**
+  CLI, WS server, wasm `web-slicer` and the desktop Tauri bridge all hand it a
+  `&[ObjectInput]` instead of merging meshes themselves. Do not re-introduce a
+  "just concatenate the faces and call `process_mesh`" site — that is the merge
+  that erased object identity in the first place.
+- **The merged fast path is not optional.** When
+  [`SlicingParams::object_aware()`](src/settings/params.rs) is false (neither
+  `exclude_object` nor `print_sequence = by_object`), `slice_plate` merges and
+  calls `process_mesh` exactly as before, so the default configuration produces
+  **byte-identical G-code**. Object-aware slicing runs the pipeline once *per
+  object*, which is **not** output-equivalent: `calculate_interior_region`
+  averages the wall-bead count across a layer's islands, so an island's interior
+  estimate depends on what else shares its layer. Slicing a part alone is the
+  more faithful result, but it is still a change and must only happen when asked
+  for. `merged_path_matches_a_plain_process_mesh` pins this.
+- **`SliceLayer::path_objects` is a parallel array with an empty sentinel**, like
+  `path_overhang`: empty means "not sliced object-aware", and `None` at an index
+  means "belongs to no object". Every helper that rebuilds a layer's parallel
+  arrays — notably [`adhesion::prepend`](src/adhesion/mod.rs) — must carry it
+  along or the tags silently shift onto the wrong paths.
+- **Adhesion is plate-wide in `by_layer`, object-owned in `by_object`.** In
+  layer order the skirt/brim is generated **once on the merged stack** and
+  tagged `None`, so cancelling one part does not take the plate's adhesion with
+  it; in object order each object is a self-contained print and owns its own.
+- **Layers merge by Z slot, not by index.** Two parts resting on the bed slice
+  onto the same grid, but a part lifted off the bed keeps its own (its bottom
+  layers are *its* bottom layers). `merge_layers_by_z` groups within a quarter
+  layer and takes at most one layer per object per slot, so emitted Z is always
+  strictly ascending.
+- **Sequential order is front-to-back** (`min_y`, then `min_x`) — the gantry
+  sweeps from behind, so finishing the nearest part first keeps the carriage
+  away from finished work longest. Clearance problems are **warnings, not
+  errors**: the clearances are machine estimates and refusing to slice would be
+  worse than saying what to check. Only objects printed *before* another are
+  height-checked; the last one has nothing reaching over it.
+- **Object names are sanitised and de-duplicated in the engine.** Klipper parses
+  `EXCLUDE_OBJECT_DEFINE NAME=…` as a G-code parameter, so a space splits the
+  token, and two parts sharing a name would cancel together. Every runtime feeds
+  user-chosen filenames straight in, so `unique_object_name` fixes both centrally
+  rather than at each call site.
+
+### Emitting the markers
+
+Three `GcodeDialect` methods carry it into firmware syntax:
+`object_definitions`, `object_start`, `object_end`. The **defaults implement
+`M486`** (Marlin 2.0.9.3+, RepRapFirmware, Prusa); `KlipperDialect` overrides
+them with `EXCLUDE_OBJECT_*`, which additionally carries `CENTER` and `POLYGON`
+so the firmware knows where a cancelled object lives.
+
+- **Definitions are emitted before the start script.** Klipper's
+  `[exclude_object]` module and Moonraker both expect to meet every object
+  before the print begins, so a front-end can list the parts the moment the file
+  loads.
+- **The marker block switches *before* a path's travel**, so the hop between two
+  parts is charged to the one it is heading for — the PrusaSlicer/OrcaSlicer
+  convention, and what lets a firmware skip a cancelled object's approach moves
+  along with its extrusions.
+- **`M486 A"name"` is spent once per object** (`first_use`); repeating the name
+  on every layer would bloat the file for no gain.
+- **The sequential hand-over happens before the layer's own Z move.** Order is
+  load-bearing: close the marker block → retract → lift above the tallest thing
+  already printed → travel across → `between_objects_gcode`. The layer block
+  that follows then drops to the new object's first layer *over empty bed*.
+  Doing any of it afterwards lowers the nozzle into the part just finished.
+  Pinned by `sequential_lifts_clear_of_the_finished_object_before_travelling`.
+- **The exclusion polygon is a convex hull, resampled to ≤ 64 points.** A turned
+  cylinder hulls to one vertex per facet and would push a multi-kilobyte line
+  into the file for no added precision.
 
 ## Slicing Pipeline — Deep Knowledge
 

--- a/AGENTS.md
+++ b/AGENTS.md
@@ -637,17 +637,19 @@ segmentation, so it is built once, here.
   errors**: the clearances are machine estimates and refusing to slice would be
   worse than saying what to check. Only objects printed *before* another are
   height-checked; the last one has nothing reaching over it.
-- **The extruder clearances describe the machine, not the process.** Two
-  printers can run the same `by_object` process yet have different gantry
-  heights and duct radii, so `extruder_clearance_height_mm` /
-  `extruder_clearance_radius_mm` carry the **Hardware** `x-group` (printer
-  contract), alongside nozzle diameter — mirroring PrusaSlicer's Printer
-  Settings, and the same rationale that put `preferred_orientation_deg` on the
-  printer profile. Only the print-behaviour toggles (`print_sequence`,
-  `exclude_object`, `between_objects_gcode`) are process settings, under the
-  **Objects** group. They are intrinsic machine specs, so they carry **no**
-  `x-relevant-when` gate (a printer always has a clearance) — which also avoids
-  a cross-contract gate pointing at a process field in another tab.
+- **What lives on the printer vs. the process.** Whether the machine *can*
+  cancel an object (`exclude_object`) and how much room its printhead needs
+  (`extruder_clearance_height_mm` / `extruder_clearance_radius_mm`) are
+  properties of the **machine**, so all three carry the **Hardware** `x-group`
+  (printer contract), alongside nozzle diameter — mirroring PrusaSlicer's
+  Printer Settings and the rationale that put `preferred_orientation_deg` on the
+  printer profile. Two printers can run the same `by_object` process yet differ
+  in gantry height, duct radius, and firmware object support. Only the
+  print-behaviour choices (`print_sequence`, `between_objects_gcode`) are
+  process settings, under the **Objects** group. The clearances are intrinsic
+  machine specs, so they carry **no** `x-relevant-when` gate (a printer always
+  has a clearance) — which also avoids a cross-contract gate pointing at a
+  process field in another tab.
 - **Object names are sanitised and de-duplicated in the engine.** Klipper parses
   `EXCLUDE_OBJECT_DEFINE NAME=…` as a G-code parameter, so a space splits the
   token, and two parts sharing a name would cancel together. Every runtime feeds

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -37,7 +37,9 @@ these notes and acknowledges contributors. `scripts/gen-changelog-draft.sh` and
     across. Optional custom G-code runs between objects. Parts taller than the
     machine's gantry clearance, or closer together than its extruder clearance
     radius, are reported as warnings before slicing rather than discovered as a
-    crash.
+    crash. Choosing it in the UI shows an honest heads-up that the feature
+    depends on the printer's clearances, with a link straight to where they are
+    set.
 
   Both are off by default, and with both off the plate is merged and sliced
   exactly as before — no change to existing G-code. The **process** settings

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -42,9 +42,10 @@ these notes and acknowledges contributors. `scripts/gen-changelog-draft.sh` and
     set.
 
   Both are off by default, and with both off the plate is merged and sliced
-  exactly as before — no change to existing G-code. The **process** settings
-  (`print_sequence`, `exclude_object`, `between_objects_gcode`) live under a new
-  **Objects** group; the two **extruder clearances**
+  exactly as before — no change to existing G-code. **Print order**
+  (`print_sequence`) and the optional between-objects G-code live under a new
+  **Objects** process group; whether the machine can **skip a failed object**
+  (`exclude_object`) and its two **extruder clearances**
   (`extruder_clearance_height_mm`, `extruder_clearance_radius_mm`) describe the
   machine, so they sit with the printer's hardware settings. The CLI exposes
   `--exclude-object` and `--print-sequence by-object`.

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -22,6 +22,30 @@ these notes and acknowledges contributors. `scripts/gen-changelog-draft.sh` and
 
 ### Added
 
+- **Cancel one object mid-print, or print them one at a time.** The plate now
+  keeps track of which part every extrusion belongs to, which unlocks two
+  features that share that segmentation:
+
+  - **Exclude object** — each object's moves are wrapped in firmware object
+    markers (Klipper `EXCLUDE_OBJECT_*`, Marlin / RepRapFirmware `M486`), and
+    the file declares every part up front with its name, centre and footprint.
+    Mainsail, Fluidd and OctoPrint list the plate's objects, so a part that
+    fails halfway can be cancelled while the rest of the plate carries on.
+  - **Sequential printing** — with **Print order → by object** each part is
+    finished completely before the next one starts, front to back, with the
+    nozzle lifting clear of everything already on the bed before it travels
+    across. Optional custom G-code runs between objects. Parts taller than the
+    machine's gantry clearance, or closer together than its extruder clearance
+    radius, are reported as warnings before slicing rather than discovered as a
+    crash.
+
+  Both are off by default, and with both off the plate is merged and sliced
+  exactly as before — no change to existing G-code. New settings live under
+  **Objects**: `print_sequence`, `exclude_object`,
+  `extruder_clearance_height_mm`, `extruder_clearance_radius_mm` and
+  `between_objects_gcode`; the CLI exposes `--exclude-object` and
+  `--print-sequence by-object`.
+
 - **Multiple objects per workplate** — a plate is now a build plate rather than
   a single file. An **Add model** button in the 3D toolbar (and a multi-select
   file picker) places more models on the plate you already have, instead of

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -40,11 +40,12 @@ these notes and acknowledges contributors. `scripts/gen-changelog-draft.sh` and
     crash.
 
   Both are off by default, and with both off the plate is merged and sliced
-  exactly as before — no change to existing G-code. New settings live under
-  **Objects**: `print_sequence`, `exclude_object`,
-  `extruder_clearance_height_mm`, `extruder_clearance_radius_mm` and
-  `between_objects_gcode`; the CLI exposes `--exclude-object` and
-  `--print-sequence by-object`.
+  exactly as before — no change to existing G-code. The **process** settings
+  (`print_sequence`, `exclude_object`, `between_objects_gcode`) live under a new
+  **Objects** group; the two **extruder clearances**
+  (`extruder_clearance_height_mm`, `extruder_clearance_radius_mm`) describe the
+  machine, so they sit with the printer's hardware settings. The CLI exposes
+  `--exclude-object` and `--print-sequence by-object`.
 
 - **Multiple objects per workplate** — a plate is now a build plate rather than
   a single file. An **Add model** button in the 3D toolbar (and a multi-select

--- a/src/adhesion/mod.rs
+++ b/src/adhesion/mod.rs
@@ -123,6 +123,9 @@ fn push_loop(layer: &mut SliceLayer, path: Path, role: ExtrusionRole, width: f64
     if !layer.path_overhang.is_empty() {
         layer.path_overhang.push(OverhangClass::None);
     }
+    if !layer.path_objects.is_empty() {
+        layer.path_objects.push(None);
+    }
 }
 
 /// Pad every parallel per-path array on `layer` up to `layer.paths.len()` so a
@@ -146,6 +149,13 @@ fn normalise(layer: &mut SliceLayer) {
     if !layer.path_overhang.is_empty() {
         while layer.path_overhang.len() < n {
             layer.path_overhang.push(OverhangClass::None);
+        }
+    }
+    // Same sentinel rule for object tags: an empty vector means "this layer was
+    // not sliced object-aware" and must stay empty.
+    if !layer.path_objects.is_empty() {
+        while layer.path_objects.len() < n {
+            layer.path_objects.push(None);
         }
     }
 }
@@ -182,12 +192,23 @@ fn prepend(layer: &mut SliceLayer, additions: SliceLayer) {
         o
     };
 
+    // Adhesion belongs to the plate, not to any one object: a skirt or brim
+    // still has to print when a single part is cancelled, so its tag is `None`.
+    let objects = if layer.path_objects.is_empty() {
+        Vec::new()
+    } else {
+        let mut o = vec![None; additions_count];
+        o.extend(layer.path_objects.iter().copied());
+        o
+    };
+
     layer.paths = paths;
     layer.path_roles = roles;
     layer.path_widths = widths;
     layer.path_vertex_widths = vwidths;
     layer.path_is_open = is_open;
     layer.path_overhang = overhang;
+    layer.path_objects = objects;
 }
 
 /// Concentric offset loops stepping **outward** from `footprint`, keeping only

--- a/src/cli/commands/slice.rs
+++ b/src/cli/commands/slice.rs
@@ -243,6 +243,26 @@ pub struct SliceCommand {
     #[arg(long)]
     pub spiral_vase: bool,
 
+    /// Print order for a plate holding several models.
+    ///
+    /// - `by-layer` — every object advances one layer at a time (default).
+    /// - `by-object` — each object is finished before the next one starts,
+    ///   front to back. Objects taller than the machine's gantry clearance, or
+    ///   closer together than its extruder clearance radius, are reported as
+    ///   warnings before slicing.
+    ///
+    /// When omitted, uses the value from settings.
+    #[arg(long, value_name = "ORDER")]
+    pub print_sequence: Option<String>,
+
+    /// Wrap each object's moves in firmware object markers so a single failed
+    /// part can be cancelled mid-print (Klipper `EXCLUDE_OBJECT_*`,
+    /// Marlin/RepRap `M486`).
+    ///
+    /// When omitted, uses the value from settings.
+    #[arg(long)]
+    pub exclude_object: bool,
+
     /// Dump internal geometry at every pipeline stage to this directory for
     /// visual debugging.  Produces per-layer `layer_NNNN.svg` files
     /// (Inkscape / browser) with each pipeline stage as a coloured group.
@@ -481,6 +501,22 @@ impl SliceCommand {
             slice_params.spiral_vase = true;
         }
 
+        // Object identity (issues #22 / #112). Both are plain opt-ins here; the
+        // decision of *how* to slice a plate lives in `slice_plate`, so every
+        // runtime behaves the same.
+        if let Some(ref order) = self.print_sequence {
+            slice_params.print_sequence = crate::settings::params::PrintSequence::parse(order)
+                .ok_or_else(|| {
+                    format!(
+                        "Unknown print sequence: '{}'. Supported: by-layer, by-object",
+                        order
+                    )
+                })?;
+        }
+        if self.exclude_object {
+            slice_params.exclude_object = true;
+        }
+
         // Validate every input file exists before doing any work, naming the
         // offender so a typo in a long multi-model command is obvious.
         for path in &self.input {
@@ -653,36 +689,40 @@ impl SliceCommand {
         }
 
         // Bake each object's transform exactly once, at the slicer boundary
-        // (SSOT contract in src/scene/README.md), and concatenate the results
-        // into the single mesh the pipeline sees — the same merge the WS
-        // server's `handle_slice` performs. `Face` stores vertices by value,
-        // so concatenation needs no index remapping.
-        let mut baked_mesh = crate::mesh::types::Mesh::new();
-        for object in &scene.objects {
-            let baked = apply_transform(object.mesh.as_ref(), &object.transform);
-            baked_mesh.vertices.extend(baked.vertices);
-            baked_mesh.faces.extend(baked.faces);
-        }
-        if baked_mesh.faces.is_empty() {
+        // (SSOT contract in src/scene/README.md). The objects are kept apart —
+        // `slice_plate` merges them itself unless the configuration needs
+        // per-object identity (exclude-object / sequential printing), which is
+        // the same decision the WS server's `handle_slice` delegates.
+        let mut plate_objects: Vec<crate::core::ObjectInput> = scene
+            .objects
+            .iter()
+            .map(|object| {
+                crate::core::ObjectInput::new(
+                    object.name.clone(),
+                    apply_transform(object.mesh.as_ref(), &object.transform),
+                )
+            })
+            .collect();
+        if plate_objects.iter().all(|o| o.mesh.faces.is_empty()) {
             return Err("Combined scene has no triangles — nothing to slice".into());
         }
 
-        // Apply optional mesh decimation. The original (baked) mesh is kept
-        // in `baked_mesh` for reference; only the pipeline receives the
-        // potentially-decimated copy.
-        let mesh = if slice_params.mesh_quality == MeshQuality::Draft {
-            let before = baked_mesh.faces.len();
-            let decimated =
-                crate::mesh::transforms::decimate_mesh(&baked_mesh, slice_params.mesh_quality);
+        // Apply optional mesh decimation, per object so the plate keeps its
+        // segmentation.
+        if slice_params.mesh_quality == MeshQuality::Draft {
+            let before: usize = plate_objects.iter().map(|o| o.mesh.faces.len()).sum();
+            for object in &mut plate_objects {
+                object.mesh =
+                    crate::mesh::transforms::decimate_mesh(&object.mesh, slice_params.mesh_quality);
+            }
+            let after: usize = plate_objects.iter().map(|o| o.mesh.faces.len()).sum();
             logger.log_debug(&format!(
                 "mesh decimation (draft): {} → {} faces",
-                before,
-                decimated.faces.len()
+                before, after
             ));
-            decimated
-        } else {
-            baked_mesh
-        };
+        }
+        // Whole-plate geometry, for the analysis log and the debug pipeline.
+        let mesh = crate::core::merge_meshes(&plate_objects);
 
         // Compute and log mesh geometry (verbose detail available to this CLI request).
         {
@@ -718,7 +758,7 @@ impl SliceCommand {
 
         // Run the unified slicing pipeline. All step-level logging is handled
         // inside process_mesh and routed through `logger`.
-        let layers = if let Some(ref debug_dir) = self.debug_geometry {
+        let plate = if let Some(ref debug_dir) = self.debug_geometry {
             std::fs::create_dir_all(debug_dir).map_err(|e| {
                 format!(
                     "Failed to create debug directory '{}': {}",
@@ -746,10 +786,11 @@ impl SliceCommand {
                 svg_count,
                 debug_geometry.len()
             ));
-            layers
+            crate::core::PlateSlice::from_layers(layers)
         } else {
-            crate::core::process_mesh(&mesh, &slice_params, &logger)
+            crate::core::slice_plate(&plate_objects, &slice_params, &logger)
         };
+        let layers = &plate.layers;
 
         // Resolve per-flavor lifecycle marker config from config.
         // CLI flags override the enabled field.
@@ -823,8 +864,12 @@ impl SliceCommand {
             }
         }
 
+        // Attach the plate's objects so the dialect can emit firmware object
+        // markers (empty for a plate sliced without object identity).
+        generator = generator.with_objects(plate.objects.clone());
+
         let t_gcode = PhaseTimer::start(phases::GCODE_GENERATION, &logger);
-        let (gcode, stats) = generator.generate_with_stats(&layers, &slice_params);
+        let (gcode, stats) = generator.generate_with_stats(layers, &slice_params);
         t_gcode.finish();
 
         // Determine output path

--- a/src/core/README.md
+++ b/src/core/README.md
@@ -32,8 +32,11 @@ function so the order is impossible to misread.
 
 ## The contract
 
-1. **`process_mesh` is the only public entry point** for the full pipeline.
-   The CLI, the WS server, and the wasm preview all call it. There is no
+1. **`process_mesh` is the only public entry point** for the full pipeline —
+   and [`slice_plate`](objects.rs) is the only way to reach *it*. The CLI, the
+   WS server, the wasm preview and the desktop bridge all hand `slice_plate` a
+   list of placed objects; it decides whether the plate can be merged into one
+   mesh (the default) or has to be sliced object by object. There is no
    "subset" pipeline; partial slicing is achieved by feeding fewer params,
    not by skipping steps.
 2. **All progress is reported through `ProcessLogger`.** No `eprintln!`,
@@ -45,6 +48,10 @@ function so the order is impossible to misread.
 4. **`SliceLayer` is the sole carrier between phases.** Each phase reads from
    and writes back into the same `Vec<SliceLayer>`; nothing escapes to
    global state.
+5. **Object identity is added around the pipeline, never inside it.** A part
+   knows nothing of its neighbours: [`objects.rs`](objects.rs) slices each one
+   with the untouched pipeline and only then tags and interleaves the results.
+   No phase branches on "which object is this?".
 
 ---
 
@@ -59,6 +66,7 @@ classDiagram
         +path_widths: Vec~Option~f64~~
         +solid_regions: Paths
         +unsupported_regions: Paths
+        +path_objects: Vec~Option~usize~~
     }
     class ExtrusionRole {
         <<enum>>
@@ -75,8 +83,12 @@ classDiagram
     SliceLayer "1" *-- "*" ExtrusionRole : path_roles
 ```
 
-`paths`, `path_roles`, and `path_widths` are parallel arrays — index `i`
-identifies the same emitted contour across all three. `solid_regions` is a
+`paths`, `path_roles`, `path_widths` and `path_objects` are parallel arrays —
+index `i` identifies the same emitted contour across all of them. `path_objects`
+follows the `path_overhang` convention: **empty means "not sliced object-aware"**
+and a `None` entry means "belongs to no object" (plate-wide bed adhesion). Any
+helper that rebuilds these arrays has to carry every one of them, or the tags
+shift onto the wrong paths. `solid_regions` is a
 union of every top / bottom surface area on this layer; sparse infill
 subtracts from it to avoid double-printing. `unsupported_regions` is the raw
 layer footprint that has nothing solid in the layer below; the wall-

--- a/src/core/mod.rs
+++ b/src/core/mod.rs
@@ -1,6 +1,7 @@
 //! Core slicing operations and data structures
 
 mod infill;
+mod objects;
 mod pipeline;
 mod slicer;
 mod surfaces;
@@ -8,6 +9,10 @@ mod types;
 mod walls;
 
 pub use infill::add_infill_to_layers;
+pub use objects::{
+    merge_meshes, sequential_order, sequential_warnings, slice_plate, ObjectIdentity, ObjectInput,
+    PlateSlice,
+};
 pub use pipeline::process_mesh;
 #[cfg(not(target_arch = "wasm32"))]
 pub use pipeline::process_mesh_debug;

--- a/src/core/objects.rs
+++ b/src/core/objects.rs
@@ -174,18 +174,24 @@ pub fn slice_plate(
     let mut per_object_layers: Vec<Vec<SliceLayer>> = Vec::with_capacity(objects.len());
     let mut used_names: Vec<String> = Vec::with_capacity(objects.len());
 
+    let object_count = objects.len();
     for (index, object) in objects.iter().enumerate() {
         logger.log_debug(&format!(
             "object {}/{}: '{}'",
             index + 1,
-            objects.len(),
+            object_count,
             object.name
         ));
         let name = unique_object_name(&object.name, index, &used_names);
         used_names.push(name.clone());
         identities.push(identity_for(index, name, &object.mesh));
+        // Scope the phase markers to this object so a progress bar keyed on
+        // phase names keeps moving forward as the pipeline restarts per object,
+        // and can label each phase "(i of N)".
+        logger.set_object_scope(index + 1, object_count);
         per_object_layers.push(process_mesh(&object.mesh, slice_params, logger));
     }
+    logger.clear_object_scope();
 
     let layers = if sequential {
         for warning in sequential_warnings(&identities, params) {

--- a/src/core/objects.rs
+++ b/src/core/objects.rs
@@ -1,0 +1,786 @@
+//! Multi-object plates: slicing that preserves per-object identity.
+//!
+//! The scene engine tracks discrete objects, but the slicer historically saw
+//! one merged mesh — by the time layers existed, every trace of "which part is
+//! this?" was gone.  Two features need that identity back:
+//!
+//! - **Exclude object** (issue #22) — wrap each object's moves in firmware
+//!   markers so one failed part can be cancelled without aborting the plate.
+//! - **Sequential printing** (issue #112) — finish one object before starting
+//!   the next.
+//!
+//! Both are served by the same segmentation, which is why they are built here
+//! once.  [`slice_plate`] is the single entry point: CLI, WebSocket server and
+//! the in-browser wasm slicer all call it instead of merging meshes themselves.
+//!
+//! ## The merged fast path is not optional
+//!
+//! When neither feature is enabled ([`SlicingParams::object_aware`] is false)
+//! the plate is merged into one mesh and handed to [`process_mesh`] exactly as
+//! before, so the default configuration keeps producing byte-identical G-code.
+//! Object-aware slicing runs the pipeline once *per object*, which is not
+//! output-equivalent: `calculate_interior_region` averages the wall-bead count
+//! across the islands of a layer, so an island's interior estimate depends on
+//! what else shares its layer.  Slicing a part on its own is the more faithful
+//! result, but it is still a *change*, and it must only happen when the user
+//! asked for a feature that requires it.
+//!
+//! ## Where adhesion goes
+//!
+//! A skirt is drawn around everything on the plate and a brim spans whatever it
+//! touches, so in `by_layer` order adhesion is generated **once, on the merged
+//! layer stack**, and its paths are tagged as belonging to no object — a
+//! cancelled part must not take the plate's adhesion with it.  In `by_object`
+//! order each object is a self-contained print, so it gets (and owns) its own
+//! adhesion.
+
+use crate::logging::ProcessLogger;
+use crate::mesh::types::Mesh;
+use crate::settings::params::{AdhesionType, PrintSequence, SlicingParams};
+
+use super::pipeline::process_mesh;
+use super::types::{OverhangClass, SliceLayer};
+
+/// Upper bound on the vertex count of an emitted exclusion polygon.
+///
+/// Klipper accepts an arbitrarily long `POLYGON=`, but a turned cylinder hulls
+/// to one point per facet and would push a multi-kilobyte line into the file
+/// for no added precision.  The hull is evenly resampled down to this many
+/// vertices, which still traces a round part to well under a nozzle width.
+const MAX_EXCLUSION_POLYGON_POINTS: usize = 64;
+
+/// One object on the plate, as handed to the slicer.
+///
+/// The mesh is expected to be **already baked** into plate coordinates — the
+/// scene engine applies transforms exactly once, at this boundary (see
+/// `src/scene/README.md`).
+#[derive(Debug, Clone)]
+pub struct ObjectInput {
+    /// Display name, used verbatim in the G-code object markers after
+    /// sanitisation.
+    pub name: String,
+    /// Baked triangle mesh in plate coordinates.
+    pub mesh: Mesh,
+}
+
+impl ObjectInput {
+    /// Construct an input from a name and a baked mesh.
+    pub fn new(name: impl Into<String>, mesh: Mesh) -> Self {
+        Self {
+            name: name.into(),
+            mesh,
+        }
+    }
+}
+
+/// Identity and footprint of one print object, as the G-code needs it.
+///
+/// Produced by [`slice_plate`] and consumed by
+/// [`crate::gcode::GcodeGenerator`], which renders it into
+/// `EXCLUDE_OBJECT_DEFINE` (Klipper) or `M486` (Marlin / RepRapFirmware).
+#[derive(Debug, Clone, PartialEq)]
+pub struct ObjectIdentity {
+    /// Index into [`PlateSlice::objects`]; matches the tag stored in
+    /// [`SliceLayer::path_objects`].
+    pub index: usize,
+    /// Firmware-safe object name, unique across the plate.
+    pub name: String,
+    /// XY centre of the object's bounding box, in mm.
+    pub center: (f64, f64),
+    /// Convex hull of the object's XY footprint, in mm, counter-clockwise.
+    pub polygon: Vec<(f64, f64)>,
+    /// Axis-aligned XY bounds as `(min_x, min_y, max_x, max_y)`, in mm.
+    pub bbox: (f64, f64, f64, f64),
+    /// Height of the object above the bed, in mm.
+    pub height_mm: f64,
+}
+
+impl ObjectIdentity {
+    /// Shortest XY gap between this object's bounding box and `other`'s.
+    ///
+    /// `0.0` when the boxes touch or overlap.
+    pub fn bbox_gap(&self, other: &ObjectIdentity) -> f64 {
+        let (ax0, ay0, ax1, ay1) = self.bbox;
+        let (bx0, by0, bx1, by1) = other.bbox;
+        let dx = (bx0 - ax1).max(ax0 - bx1).max(0.0);
+        let dy = (by0 - ay1).max(ay0 - by1).max(0.0);
+        (dx * dx + dy * dy).sqrt()
+    }
+}
+
+/// A sliced plate: the layer stream to emit, plus who owns what.
+///
+/// `objects` is empty for a plate sliced through the merged fast path; in that
+/// case every path in `layers` carries no object tag and the G-code contains no
+/// object markers.
+#[derive(Debug, Clone, Default)]
+pub struct PlateSlice {
+    /// Layers in emission order.  In `by_object` order this is the
+    /// concatenation of each object's own stack, so `z` restarts at every
+    /// object boundary.
+    pub layers: Vec<SliceLayer>,
+    /// Object identities, indexed by the tag in [`SliceLayer::path_objects`].
+    pub objects: Vec<ObjectIdentity>,
+}
+
+impl PlateSlice {
+    /// Wrap an already-sliced, untagged layer stack (the single-object case).
+    pub fn from_layers(layers: Vec<SliceLayer>) -> Self {
+        Self {
+            layers,
+            objects: Vec::new(),
+        }
+    }
+}
+
+/// Slice a whole plate, preserving per-object identity when the configuration
+/// needs it.
+///
+/// This is the one place any runtime turns a list of placed objects into
+/// layers.  See the module docs for why the merged path is kept intact.
+pub fn slice_plate(
+    objects: &[ObjectInput],
+    params: &SlicingParams,
+    logger: &dyn ProcessLogger,
+) -> PlateSlice {
+    if !params.object_aware() || objects.is_empty() {
+        return PlateSlice::from_layers(process_mesh(&merge_meshes(objects), params, logger));
+    }
+
+    let sequential = params.print_sequence == PrintSequence::ByObject;
+
+    // In `by_layer` order the plate's adhesion is generated once on the merged
+    // stack (below), so the per-object passes must not each grow their own.
+    let per_object_params = if sequential || params.adhesion_type == AdhesionType::None {
+        None
+    } else {
+        let mut p = params.clone();
+        p.adhesion_type = AdhesionType::None;
+        Some(p)
+    };
+    let slice_params = per_object_params.as_ref().unwrap_or(params);
+
+    logger.log_info(&format!(
+        "slicing {} objects individually ({})",
+        objects.len(),
+        if sequential {
+            "sequential print order"
+        } else {
+            "object-tagged layers"
+        }
+    ));
+
+    let mut identities = Vec::with_capacity(objects.len());
+    let mut per_object_layers: Vec<Vec<SliceLayer>> = Vec::with_capacity(objects.len());
+    let mut used_names: Vec<String> = Vec::with_capacity(objects.len());
+
+    for (index, object) in objects.iter().enumerate() {
+        logger.log_debug(&format!(
+            "object {}/{}: '{}'",
+            index + 1,
+            objects.len(),
+            object.name
+        ));
+        let name = unique_object_name(&object.name, index, &used_names);
+        used_names.push(name.clone());
+        identities.push(identity_for(index, name, &object.mesh));
+        per_object_layers.push(process_mesh(&object.mesh, slice_params, logger));
+    }
+
+    let layers = if sequential {
+        for warning in sequential_warnings(&identities, params) {
+            logger.log_warn(&warning);
+        }
+        let order = sequential_order(&identities);
+        logger.log_info(&format!(
+            "sequential print order: {}",
+            order
+                .iter()
+                .map(|&i| identities[i].name.as_str())
+                .collect::<Vec<_>>()
+                .join(" → ")
+        ));
+        let mut layers = Vec::new();
+        for &object_index in &order {
+            for layer in &per_object_layers[object_index] {
+                // Drop empty layers: in one merged stack they were harmless
+                // (an extra Z move), but concatenated per object they would be
+                // the *only* layers carrying no object tag, leaving the
+                // generator unable to tell whose Z they are — and an untagged
+                // layer at an object boundary is exactly where the nozzle must
+                // not descend.
+                if layer.paths.is_empty() {
+                    continue;
+                }
+                layers.push(tagged_copy(layer, object_index));
+            }
+        }
+        layers
+    } else {
+        let mut layers = merge_layers_by_z(&per_object_layers, params.layer_height);
+        if params.adhesion_type != AdhesionType::None {
+            crate::adhesion::apply_adhesion(&mut layers, params);
+        }
+        layers
+    };
+
+    PlateSlice {
+        layers,
+        objects: identities,
+    }
+}
+
+/// Concatenate every object's baked triangles into the single mesh the
+/// classic (non-object-aware) pipeline slices.
+///
+/// `Face` stores its vertices by value, so concatenation needs no index
+/// remapping.
+pub fn merge_meshes(objects: &[ObjectInput]) -> Mesh {
+    let mut combined = Mesh::new();
+    for object in objects {
+        combined
+            .vertices
+            .extend(object.mesh.vertices.iter().copied());
+        combined.faces.extend(object.mesh.faces.iter().cloned());
+    }
+    combined
+}
+
+/// Print order for sequential printing: front to back, then left to right.
+///
+/// A cartesian gantry sweeps over the bed from behind, so finishing the parts
+/// nearest the front first keeps the carriage away from everything already
+/// printed for as long as possible — the same heuristic PrusaSlicer, Cura and
+/// OrcaSlicer apply.  Ties fall back to the object index so the order is
+/// deterministic.
+pub fn sequential_order(objects: &[ObjectIdentity]) -> Vec<usize> {
+    let mut order: Vec<usize> = (0..objects.len()).collect();
+    order.sort_by(|&a, &b| {
+        let (ax, ay) = (objects[a].bbox.0, objects[a].bbox.1);
+        let (bx, by) = (objects[b].bbox.0, objects[b].bbox.1);
+        ay.partial_cmp(&by)
+            .unwrap_or(std::cmp::Ordering::Equal)
+            .then(ax.partial_cmp(&bx).unwrap_or(std::cmp::Ordering::Equal))
+            .then(a.cmp(&b))
+    });
+    order
+}
+
+/// Collision risks that make a plate unsafe to print one object at a time.
+///
+/// Two independent hazards, both measured against the machine's declared
+/// clearances:
+///
+/// - **Vertical** — every object except the last one printed has to pass under
+///   the gantry while the *next* one prints, so anything taller than
+///   [`SlicingParams::extruder_clearance_height_mm`] is a crash waiting to
+///   happen.
+/// - **Horizontal** — the hotend and its fan duct sweep a disc around the
+///   nozzle, so two objects closer than
+///   [`SlicingParams::extruder_clearance_radius_mm`] cannot both be reached
+///   without the duct grazing the finished one.
+///
+/// Returned as warnings rather than errors: the clearances are machine
+/// estimates, and refusing to slice would be worse than telling the user what
+/// to check.
+pub fn sequential_warnings(objects: &[ObjectIdentity], params: &SlicingParams) -> Vec<String> {
+    let mut warnings = Vec::new();
+    if objects.len() < 2 {
+        return warnings;
+    }
+
+    let order = sequential_order(objects);
+    let clearance_height = params.extruder_clearance_height_mm;
+    if clearance_height > 0.0 {
+        // The last object printed has nothing printed after it, so its height
+        // is irrelevant — only the ones the gantry still has to reach over.
+        for &index in order.iter().take(order.len() - 1) {
+            let object = &objects[index];
+            if object.height_mm > clearance_height {
+                warnings.push(format!(
+                    "sequential printing: '{}' is {:.1} mm tall, above the {:.1} mm gantry \
+                     clearance — the carriage may hit it while printing a later object",
+                    object.name, object.height_mm, clearance_height
+                ));
+            }
+        }
+    }
+
+    let clearance_radius = params.extruder_clearance_radius_mm;
+    if clearance_radius > 0.0 {
+        for a in 0..objects.len() {
+            for b in (a + 1)..objects.len() {
+                let gap = objects[a].bbox_gap(&objects[b]);
+                if gap < clearance_radius {
+                    warnings.push(format!(
+                        "sequential printing: '{}' and '{}' are {:.1} mm apart, closer than the \
+                         {:.1} mm extruder clearance radius — space them further apart",
+                        objects[a].name, objects[b].name, gap, clearance_radius
+                    ));
+                }
+            }
+        }
+    }
+
+    warnings
+}
+
+/// Build the identity record for one object from its baked mesh.
+fn identity_for(index: usize, name: String, mesh: &Mesh) -> ObjectIdentity {
+    let mut min_x = f64::INFINITY;
+    let mut min_y = f64::INFINITY;
+    let mut min_z = f64::INFINITY;
+    let mut max_x = f64::NEG_INFINITY;
+    let mut max_y = f64::NEG_INFINITY;
+    let mut max_z = f64::NEG_INFINITY;
+    let mut points: Vec<(f64, f64)> = Vec::with_capacity(mesh.vertices.len());
+    for v in &mesh.vertices {
+        min_x = min_x.min(v.x);
+        min_y = min_y.min(v.y);
+        min_z = min_z.min(v.z);
+        max_x = max_x.max(v.x);
+        max_y = max_y.max(v.y);
+        max_z = max_z.max(v.z);
+        points.push((v.x, v.y));
+    }
+    if points.is_empty() {
+        return ObjectIdentity {
+            index,
+            name,
+            center: (0.0, 0.0),
+            polygon: Vec::new(),
+            bbox: (0.0, 0.0, 0.0, 0.0),
+            height_mm: 0.0,
+        };
+    }
+
+    let polygon = resample_ring(convex_hull(points), MAX_EXCLUSION_POLYGON_POINTS);
+    ObjectIdentity {
+        index,
+        name,
+        center: (0.5 * (min_x + max_x), 0.5 * (min_y + max_y)),
+        polygon,
+        bbox: (min_x, min_y, max_x, max_y),
+        height_mm: (max_z - min_z).max(0.0),
+    }
+}
+
+/// Andrew's monotone chain convex hull, returned counter-clockwise and without
+/// a repeated closing vertex.
+fn convex_hull(mut points: Vec<(f64, f64)>) -> Vec<(f64, f64)> {
+    points.sort_by(|a, b| {
+        a.0.partial_cmp(&b.0)
+            .unwrap_or(std::cmp::Ordering::Equal)
+            .then(a.1.partial_cmp(&b.1).unwrap_or(std::cmp::Ordering::Equal))
+    });
+    points.dedup_by(|a, b| (a.0 - b.0).abs() < 1e-9 && (a.1 - b.1).abs() < 1e-9);
+    if points.len() < 3 {
+        return points;
+    }
+
+    let cross = |o: (f64, f64), a: (f64, f64), b: (f64, f64)| {
+        (a.0 - o.0) * (b.1 - o.1) - (a.1 - o.1) * (b.0 - o.0)
+    };
+
+    let mut hull: Vec<(f64, f64)> = Vec::with_capacity(points.len() * 2);
+    for &p in &points {
+        while hull.len() >= 2 && cross(hull[hull.len() - 2], hull[hull.len() - 1], p) <= 0.0 {
+            hull.pop();
+        }
+        hull.push(p);
+    }
+    let lower_len = hull.len() + 1;
+    for &p in points.iter().rev().skip(1) {
+        while hull.len() >= lower_len && cross(hull[hull.len() - 2], hull[hull.len() - 1], p) <= 0.0
+        {
+            hull.pop();
+        }
+        hull.push(p);
+    }
+    hull.pop();
+    hull
+}
+
+/// Evenly resample a closed ring down to at most `max_points` vertices.
+///
+/// Keeps the first vertex so the polygon still starts where the hull did.
+fn resample_ring(ring: Vec<(f64, f64)>, max_points: usize) -> Vec<(f64, f64)> {
+    if ring.len() <= max_points || max_points == 0 {
+        return ring;
+    }
+    let n = ring.len();
+    (0..max_points).map(|k| ring[k * n / max_points]).collect()
+}
+
+/// Sanitise `name` for a firmware object marker and disambiguate duplicates.
+///
+/// Klipper parses `EXCLUDE_OBJECT_DEFINE NAME=…` as a G-code parameter, so
+/// whitespace and `=` would split the token; a duplicate name would make two
+/// parts cancel together.  Both are corrected here rather than at the call
+/// sites, because every runtime feeds user-chosen filenames straight in.
+fn unique_object_name(name: &str, index: usize, used: &[String]) -> String {
+    let mut sanitized: String = name
+        .trim()
+        .chars()
+        .map(|c| {
+            if c.is_ascii_alphanumeric() || matches!(c, '-' | '.' | '_' | '#' | '+') {
+                c
+            } else {
+                '_'
+            }
+        })
+        .collect();
+    if sanitized.is_empty() {
+        sanitized = "object".to_string();
+    }
+    if !used.iter().any(|u| u == &sanitized) {
+        return sanitized;
+    }
+    format!("{sanitized}_id_{index}")
+}
+
+/// Copy `layer`, tagging every path as belonging to `object_index`.
+fn tagged_copy(layer: &SliceLayer, object_index: usize) -> SliceLayer {
+    let mut copy = layer.clone();
+    copy.path_objects = vec![Some(object_index); copy.paths.len()];
+    copy
+}
+
+/// Interleave per-object layer stacks into one plate-wide stack.
+///
+/// Layers are grouped into shared Z slots: two objects resting on the bed slice
+/// onto an identical grid, while an object lifted off the bed keeps its own
+/// (its bottom layers are its own bottom layers, not the plate's).  A slot
+/// collects at most one layer per object and takes the mean Z of its members,
+/// so the emitted Z sequence is strictly ascending.
+fn merge_layers_by_z(per_object: &[Vec<SliceLayer>], layer_height: f64) -> Vec<SliceLayer> {
+    // Quarter of a layer: comfortably absorbs the float noise of two baked
+    // meshes resting on the same bed, while never welding two genuinely
+    // different heights the nozzle would have to visit separately.
+    let tolerance = (layer_height * 0.25).max(1e-6);
+    let mut cursors = vec![0usize; per_object.len()];
+    let mut out: Vec<SliceLayer> = Vec::new();
+
+    loop {
+        let mut slot_z = f64::INFINITY;
+        for (object_index, layers) in per_object.iter().enumerate() {
+            if let Some(layer) = layers.get(cursors[object_index]) {
+                if layer.z < slot_z {
+                    slot_z = layer.z;
+                }
+            }
+        }
+        if !slot_z.is_finite() {
+            break;
+        }
+
+        let mut slot = SliceLayer::new(slot_z);
+        let mut z_sum = 0.0;
+        let mut z_count = 0usize;
+        for (object_index, layers) in per_object.iter().enumerate() {
+            let Some(layer) = layers.get(cursors[object_index]) else {
+                continue;
+            };
+            if layer.z - slot_z > tolerance {
+                continue;
+            }
+            z_sum += layer.z;
+            z_count += 1;
+            cursors[object_index] += 1;
+            append_tagged(&mut slot, layer, object_index);
+        }
+        if z_count > 0 {
+            slot.z = z_sum / z_count as f64;
+        }
+
+        // A graded plate keeps its overhang classes; an ungraded one keeps the
+        // empty-vector sentinel that means "no dynamic overhang override".
+        if slot.path_overhang.iter().all(|c| *c == OverhangClass::None) {
+            slot.path_overhang.clear();
+        }
+        out.push(slot);
+    }
+
+    out
+}
+
+/// Append every path of `layer` to `slot`, tagged as `object_index`.
+fn append_tagged(slot: &mut SliceLayer, layer: &SliceLayer, object_index: usize) {
+    for (path_index, path) in layer.paths.iter().enumerate() {
+        slot.paths.push(path.clone());
+        slot.path_roles.push(layer.role_for_path(path_index));
+        slot.path_widths.push(layer.width_for_path(path_index));
+        slot.path_vertex_widths
+            .push(layer.vertex_widths_for_path(path_index));
+        slot.path_is_open.push(layer.is_path_open(path_index));
+        slot.path_overhang.push(layer.overhang_for_path(path_index));
+        slot.path_objects.push(Some(object_index));
+    }
+    for region in layer.solid_regions.iter() {
+        slot.solid_regions.push(region.clone());
+    }
+    for region in layer.unsupported_regions.iter() {
+        slot.unsupported_regions.push(region.clone());
+    }
+}
+
+#[cfg(test)]
+mod tests {
+    use super::*;
+    use crate::logging::NullLogger;
+    use crate::mesh::types::{Face, Vertex};
+
+    /// Axis-aligned box mesh with its minimum corner at `(x, y, 0)`.
+    fn box_mesh(x: f64, y: f64, size: f64, height: f64) -> Mesh {
+        let v = |dx: f64, dy: f64, dz: f64| Vertex::new(x + dx, y + dy, dz);
+        let c = [
+            v(0.0, 0.0, 0.0),
+            v(size, 0.0, 0.0),
+            v(size, size, 0.0),
+            v(0.0, size, 0.0),
+            v(0.0, 0.0, height),
+            v(size, 0.0, height),
+            v(size, size, height),
+            v(0.0, size, height),
+        ];
+        let quad = |a: usize, b: usize, cc: usize, d: usize| {
+            [
+                Face::new([c[a], c[b], c[cc]]),
+                Face::new([c[a], c[cc], c[d]]),
+            ]
+        };
+        let mut faces = Vec::new();
+        faces.extend(quad(0, 3, 2, 1)); // bottom
+        faces.extend(quad(4, 5, 6, 7)); // top
+        faces.extend(quad(0, 1, 5, 4));
+        faces.extend(quad(1, 2, 6, 5));
+        faces.extend(quad(2, 3, 7, 6));
+        faces.extend(quad(3, 0, 4, 7));
+        Mesh {
+            vertices: c.to_vec(),
+            faces,
+            aabb: None,
+        }
+    }
+
+    fn two_object_params() -> SlicingParams {
+        SlicingParams {
+            layer_height: 0.5,
+            wall_count: 1,
+            infill_density: 0.0,
+            top_layers: 0,
+            bottom_layers: 0,
+            ..Default::default()
+        }
+    }
+
+    fn plate() -> Vec<ObjectInput> {
+        vec![
+            ObjectInput::new("cube a", box_mesh(0.0, 0.0, 10.0, 5.0)),
+            ObjectInput::new("cube b", box_mesh(60.0, 60.0, 10.0, 3.0)),
+        ]
+    }
+
+    #[test]
+    fn merged_path_leaves_layers_untagged() {
+        let params = two_object_params();
+        assert!(!params.object_aware());
+        let slice = slice_plate(&plate(), &params, &NullLogger);
+        assert!(slice.objects.is_empty(), "no identities without a feature");
+        assert!(slice
+            .layers
+            .iter()
+            .all(|l| l.path_objects.is_empty() && l.object_for_path(0).is_none()));
+    }
+
+    #[test]
+    fn merged_path_matches_a_plain_process_mesh() {
+        let params = two_object_params();
+        let objects = plate();
+        let direct = process_mesh(&merge_meshes(&objects), &params, &NullLogger);
+        let plate_slice = slice_plate(&objects, &params, &NullLogger);
+        assert_eq!(direct.len(), plate_slice.layers.len());
+        for (a, b) in direct.iter().zip(plate_slice.layers.iter()) {
+            assert_eq!(a.paths.len(), b.paths.len());
+            assert!((a.z - b.z).abs() < 1e-12);
+        }
+    }
+
+    #[test]
+    fn exclude_object_tags_every_path_by_layer() {
+        let mut params = two_object_params();
+        params.exclude_object = true;
+        let slice = slice_plate(&plate(), &params, &NullLogger);
+
+        assert_eq!(slice.objects.len(), 2);
+        assert_eq!(slice.objects[0].name, "cube_a");
+        assert_eq!(slice.objects[1].name, "cube_b");
+
+        // Both objects rest on the bed, so their grids coincide: the first
+        // layers share one slot and carry both tags.
+        let first = &slice.layers[0];
+        let tags: std::collections::BTreeSet<_> = (0..first.paths.len())
+            .filter_map(|i| first.object_for_path(i))
+            .collect();
+        assert_eq!(tags, [0, 1].into_iter().collect());
+
+        // The taller object outlives the shorter one, so the top layers are
+        // single-object.
+        let last = slice.layers.last().unwrap();
+        let tags: std::collections::BTreeSet<_> = (0..last.paths.len())
+            .filter_map(|i| last.object_for_path(i))
+            .collect();
+        assert_eq!(tags, [0].into_iter().collect());
+    }
+
+    #[test]
+    fn by_layer_z_is_ascending_and_slots_are_shared() {
+        let mut params = two_object_params();
+        params.exclude_object = true;
+        let slice = slice_plate(&plate(), &params, &NullLogger);
+        for pair in slice.layers.windows(2) {
+            assert!(pair[1].z > pair[0].z, "layer Z must strictly ascend");
+        }
+        // 5 mm and 3 mm objects at 0.5 mm layers share the bottom 6 slots.
+        assert_eq!(slice.layers.len(), 10);
+    }
+
+    #[test]
+    fn by_object_emits_each_object_contiguously() {
+        let mut params = two_object_params();
+        params.print_sequence = PrintSequence::ByObject;
+        let slice = slice_plate(&plate(), &params, &NullLogger);
+
+        let sequence: Vec<usize> = slice
+            .layers
+            .iter()
+            .map(|l| l.object_for_path(0).expect("every layer is owned"))
+            .collect();
+        // Front-most object (cube a at y=0) prints first, and each object's
+        // layers form one unbroken run.
+        let mut runs: Vec<usize> = Vec::new();
+        for object in sequence {
+            if runs.last() != Some(&object) {
+                runs.push(object);
+            }
+        }
+        assert_eq!(runs, vec![0, 1]);
+        // Z restarts for the second object.
+        let boundary = slice
+            .layers
+            .windows(2)
+            .position(|p| p[1].z < p[0].z)
+            .expect("Z restarts at the object boundary");
+        assert_eq!(slice.layers[boundary + 1].z, slice.layers[0].z);
+    }
+
+    #[test]
+    fn sequential_order_is_front_to_back() {
+        let objects = vec![
+            identity_for(0, "back".into(), &box_mesh(0.0, 80.0, 10.0, 5.0)),
+            identity_for(1, "front".into(), &box_mesh(0.0, 0.0, 10.0, 5.0)),
+            identity_for(2, "middle".into(), &box_mesh(0.0, 40.0, 10.0, 5.0)),
+        ];
+        assert_eq!(sequential_order(&objects), vec![1, 2, 0]);
+    }
+
+    #[test]
+    fn sequential_warnings_flag_tall_and_close_objects() {
+        let params = SlicingParams {
+            extruder_clearance_height_mm: 10.0,
+            extruder_clearance_radius_mm: 30.0,
+            ..Default::default()
+        };
+        let objects = vec![
+            identity_for(0, "tall".into(), &box_mesh(0.0, 0.0, 10.0, 40.0)),
+            identity_for(1, "far".into(), &box_mesh(0.0, 100.0, 10.0, 5.0)),
+        ];
+        let warnings = sequential_warnings(&objects, &params);
+        assert_eq!(warnings.len(), 1, "{warnings:?}");
+        assert!(warnings[0].contains("gantry clearance"));
+
+        let close = vec![
+            identity_for(0, "a".into(), &box_mesh(0.0, 0.0, 10.0, 5.0)),
+            identity_for(1, "b".into(), &box_mesh(15.0, 0.0, 10.0, 5.0)),
+        ];
+        let warnings = sequential_warnings(&close, &params);
+        assert_eq!(warnings.len(), 1, "{warnings:?}");
+        assert!(warnings[0].contains("clearance radius"));
+    }
+
+    #[test]
+    fn the_last_object_printed_may_be_taller_than_the_gantry() {
+        let params = SlicingParams {
+            extruder_clearance_height_mm: 10.0,
+            extruder_clearance_radius_mm: 0.0,
+            ..Default::default()
+        };
+        // The tall one is at the back, so it prints last and nothing has to
+        // reach over it.
+        let objects = vec![
+            identity_for(0, "short_front".into(), &box_mesh(0.0, 0.0, 10.0, 5.0)),
+            identity_for(1, "tall_back".into(), &box_mesh(0.0, 100.0, 10.0, 60.0)),
+        ];
+        assert!(sequential_warnings(&objects, &params).is_empty());
+    }
+
+    #[test]
+    fn duplicate_names_are_disambiguated_and_sanitised() {
+        let used = vec!["part".to_string()];
+        assert_eq!(unique_object_name("part", 1, &used), "part_id_1");
+        assert_eq!(unique_object_name("my part.stl", 0, &[]), "my_part.stl");
+        assert_eq!(unique_object_name("   ", 3, &[]), "object");
+    }
+
+    #[test]
+    fn hull_of_a_box_is_its_four_corners() {
+        let identity = identity_for(0, "box".into(), &box_mesh(5.0, 7.0, 10.0, 4.0));
+        assert_eq!(identity.polygon.len(), 4);
+        assert_eq!(identity.bbox, (5.0, 7.0, 15.0, 17.0));
+        assert_eq!(identity.center, (10.0, 12.0));
+        assert_eq!(identity.height_mm, 4.0);
+    }
+
+    #[test]
+    fn long_hulls_are_resampled() {
+        let ring: Vec<(f64, f64)> = (0..360)
+            .map(|d| {
+                let a = (d as f64).to_radians();
+                (a.cos() * 20.0, a.sin() * 20.0)
+            })
+            .collect();
+        let reduced = resample_ring(ring, MAX_EXCLUSION_POLYGON_POINTS);
+        assert_eq!(reduced.len(), MAX_EXCLUSION_POLYGON_POINTS);
+    }
+
+    #[test]
+    fn plate_adhesion_is_generated_once_and_owned_by_nobody() {
+        let mut params = two_object_params();
+        params.exclude_object = true;
+        params.adhesion_type = AdhesionType::Skirt;
+        params.skirt_loops = 1;
+        params.skirt_distance = 2.0;
+        params.skirt_height = 1;
+        params.nozzle_diameter_mm = 0.4;
+
+        let slice = slice_plate(&plate(), &params, &NullLogger);
+        let first = &slice.layers[0];
+        let skirts: Vec<usize> = (0..first.paths.len())
+            .filter(|&i| first.role_for_path(i) == crate::core::ExtrusionRole::Skirt)
+            .collect();
+        // The two parts are far apart, so one plate-wide skirt pass still
+        // yields one loop per island — what matters is that it ran **once**,
+        // over the merged plate, rather than once inside each object's own
+        // pipeline (which would also have drawn a loop where the parts are).
+        assert_eq!(skirts.len(), 2);
+        assert!(
+            skirts.iter().all(|&i| first.object_for_path(i).is_none()),
+            "adhesion must survive cancelling a single object"
+        );
+        // The object paths that follow keep their tags aligned after the
+        // prepend.
+        assert!((0..first.paths.len())
+            .filter(|&i| first.role_for_path(i) != crate::core::ExtrusionRole::Skirt)
+            .all(|i| first.object_for_path(i).is_some()));
+    }
+}

--- a/src/core/types.rs
+++ b/src/core/types.rs
@@ -208,6 +208,19 @@ pub struct SliceLayer {
     /// Indexed parallel to [`SliceLayer::paths`].  Shorter-than-paths vectors
     /// default to [`OverhangClass::None`] (no override).
     pub path_overhang: Vec<OverhangClass>,
+    /// Per-path owning **print object** index, for firmware object exclusion
+    /// (`EXCLUDE_OBJECT` / `M486`) and sequential printing.
+    ///
+    /// `path_objects[i]` identifies which object on the plate produced
+    /// `paths[i]`, indexing into the plate's object list
+    /// ([`crate::core::PlateSlice::objects`]).  `None` — and any index past the
+    /// end of the vector — means the path belongs to **no** object: bed
+    /// adhesion (skirt / brim / raft) covers the whole plate and must never be
+    /// cancelled with a single part.
+    ///
+    /// Left empty by the single-mesh pipeline; populated only when the plate is
+    /// sliced object by object (see [`crate::core::slice_plate`]).
+    pub path_objects: Vec<Option<usize>>,
 }
 
 impl SliceLayer {
@@ -223,6 +236,7 @@ impl SliceLayer {
             unsupported_regions: Paths::default(),
             path_is_open: Vec::new(),
             path_overhang: Vec::new(),
+            path_objects: Vec::new(),
         }
     }
 
@@ -266,5 +280,13 @@ impl SliceLayer {
     /// [`crate::settings::params::SlicingParams::enable_overhang_speed`] is off.
     pub fn overhang_for_path(&self, i: usize) -> OverhangClass {
         self.path_overhang.get(i).copied().unwrap_or_default()
+    }
+
+    /// Return the owning print-object index for path `i`, if any.
+    ///
+    /// `None` for plate-wide geometry (bed adhesion) and for every path of a
+    /// layer that was not sliced object-aware.
+    pub fn object_for_path(&self, i: usize) -> Option<usize> {
+        self.path_objects.get(i).copied().flatten()
     }
 }

--- a/src/gcode/README.md
+++ b/src/gcode/README.md
@@ -89,10 +89,44 @@ classDiagram
         +with_marker_config(cfg) Self
         +with_start_script(lines) Self
         +with_end_script(lines) Self
+        +with_objects(identities) Self
         +generate(layers, params) String
     }
     GcodeGenerator --> GcodeDialect
 ```
+
+---
+
+## Object markers (issues #22, #112)
+
+Three trait methods let a firmware attribute every move to a named part and
+cancel one mid-print. The **defaults implement `M486`** — the RepRap standard,
+understood by Marlin 2.0.9.3+, RepRapFirmware and Prusa — and `KlipperDialect`
+overrides them with `EXCLUDE_OBJECT_*`, which also carries the footprint so the
+firmware knows *where* a cancelled object lives.
+
+| Method               | Default (`M486`)         | Klipper                                          |
+| -------------------- | ------------------------ | ------------------------------------------------ |
+| `object_definitions` | `M486 T<n>` + comments   | `EXCLUDE_OBJECT_DEFINE NAME= CENTER= POLYGON=`   |
+| `object_start`       | `M486 S<i> [A"name"]`    | `EXCLUDE_OBJECT_START NAME=`                     |
+| `object_end`         | `M486 S-1`               | `EXCLUDE_OBJECT_END NAME=`                       |
+
+The generator drives them from the per-path tags in `SliceLayer::path_objects`
+(see [src/core/objects.rs](../core/objects.rs)); with no objects attached the
+output is unchanged. Three placement rules matter:
+
+- **Definitions precede the start script.** Klipper's `[exclude_object]` module
+  and Moonraker both expect to meet every object before the print begins.
+- **The block switches before a path's travel**, so the hop between two parts is
+  charged to the one it is heading for — the PrusaSlicer / OrcaSlicer convention,
+  and what lets a firmware skip a cancelled object's approach moves too.
+- **A `None` tag closes the block without opening one.** Bed adhesion belongs to
+  the plate, so it must still print when a single part is cancelled.
+
+In `by_object` (sequential) order the generator additionally hands over between
+objects **before the layer's own Z move**: close the block → retract → lift
+above the tallest thing already printed → travel across → `between_objects_gcode`.
+Doing any of that afterwards would lower the nozzle into the part just finished.
 
 ---
 

--- a/src/gcode/dialect.rs
+++ b/src/gcode/dialect.rs
@@ -340,4 +340,54 @@ pub trait GcodeDialect: Send + Sync {
             ),
         ]
     }
+
+    // ── Object exclusion (issue #22) ─────────────────────────────────────────
+    //
+    // Three commands let a firmware attribute every move to a named object and
+    // cancel one mid-print.  The defaults implement the **`M486`** standard
+    // (Marlin 2.0.9.3+, RepRapFirmware, Prusa); Klipper overrides them with its
+    // `EXCLUDE_OBJECT_*` macros, which additionally carry the footprint so the
+    // firmware knows where a cancelled object lives.
+
+    /// Declare the plate's objects, once, before the first print move.
+    ///
+    /// `objects` are the plate's [`ObjectIdentity`](crate::core::ObjectIdentity)
+    /// records in index order.  Returns the lines to emit; empty for a plate
+    /// with no tracked objects.
+    fn object_definitions(&self, objects: &[crate::core::ObjectIdentity]) -> Vec<String> {
+        if objects.is_empty() {
+            return Vec::new();
+        }
+        // `M486 T<n>` tells the firmware how many objects to expect so its
+        // cancel UI can list them before any has been started.
+        let mut lines = vec![format!("M486 T{} ; object count", objects.len())];
+        for object in objects {
+            lines.push(format!(
+                "; object {} = {} (center {:.3},{:.3})",
+                object.index, object.name, object.center.0, object.center.1
+            ));
+        }
+        lines
+    }
+
+    /// Begin the block of moves belonging to `object`.
+    ///
+    /// `first_use` is `true` the first time this object is started, which is
+    /// where a dialect that names objects inline (`M486 A"…"`) should do so
+    /// instead of repeating the name on every layer.
+    fn object_start(&self, object: &crate::core::ObjectIdentity, first_use: bool) -> String {
+        if first_use {
+            format!("M486 S{} A\"{}\"", object.index, object.name)
+        } else {
+            format!("M486 S{}", object.index)
+        }
+    }
+
+    /// End the block of moves belonging to `object`.
+    ///
+    /// `M486 S-1` marks the following moves as belonging to no object, which is
+    /// how the standard expresses "end of object".
+    fn object_end(&self, _object: &crate::core::ObjectIdentity) -> String {
+        "M486 S-1".to_string()
+    }
 }

--- a/src/gcode/dialects/klipper.rs
+++ b/src/gcode/dialects/klipper.rs
@@ -188,4 +188,49 @@ impl GcodeDialect for KlipperDialect {
             retract_mm, speed_mm_s, restart_extra_mm, speed_mm_s
         )]
     }
+
+    /// Klipper's `[exclude_object]` module is name-based, not index-based, and
+    /// wants the footprint up front: `CENTER` positions the object in the
+    /// front-end's cancel UI and `POLYGON` outlines it.
+    ///
+    /// Moonraker also scans the file for these definitions when it builds the
+    /// object list for Mainsail / Fluidd, which is why they are emitted at the
+    /// top of the program rather than lazily at first use.
+    fn object_definitions(&self, objects: &[crate::core::ObjectIdentity]) -> Vec<String> {
+        if objects.is_empty() {
+            return Vec::new();
+        }
+        let mut lines = vec!["EXCLUDE_OBJECT_DEFINE RESET=1".to_string()];
+        for object in objects {
+            let polygon = object
+                .polygon
+                .iter()
+                .map(|(x, y)| format!("[{:.3},{:.3}]", x, y))
+                .collect::<Vec<_>>()
+                .join(",");
+            if polygon.is_empty() {
+                lines.push(format!(
+                    "EXCLUDE_OBJECT_DEFINE NAME={} CENTER={:.3},{:.3}",
+                    object.name, object.center.0, object.center.1
+                ));
+            } else {
+                lines.push(format!(
+                    "EXCLUDE_OBJECT_DEFINE NAME={} CENTER={:.3},{:.3} POLYGON=[{}]",
+                    object.name, object.center.0, object.center.1, polygon
+                ));
+            }
+        }
+        lines
+    }
+
+    /// `EXCLUDE_OBJECT_START NAME=…` — the name is the whole identity here, so
+    /// it is repeated on every block (there is no index shorthand).
+    fn object_start(&self, object: &crate::core::ObjectIdentity, _first_use: bool) -> String {
+        format!("EXCLUDE_OBJECT_START NAME={}", object.name)
+    }
+
+    /// `EXCLUDE_OBJECT_END NAME=…`.
+    fn object_end(&self, object: &crate::core::ObjectIdentity) -> String {
+        format!("EXCLUDE_OBJECT_END NAME={}", object.name)
+    }
 }

--- a/src/gcode/generator.rs
+++ b/src/gcode/generator.rs
@@ -24,6 +24,15 @@ const WIDTH_EPSILON: f64 = 1e-6;
 /// resolution.
 const WIDTH_SIMPLIFY_TOL_MM: f64 = 0.02;
 
+/// Minimum lift, in mm, above the tallest already-printed object when
+/// sequential printing hands over to the next one.
+///
+/// The nozzle has to reach the far side of a finished part without touching it,
+/// and the layer block that follows will drop straight back down to the new
+/// object's first layer — so the clearance is taken *before* the travel, not
+/// as part of it.  A configured Z-hop larger than this wins.
+const SEQUENTIAL_LIFT_MM: f64 = 1.0;
+
 /// Width step (mm) at which a variable-width bead re-emits a `;WIDTH:` marker
 /// mid-path, so viewers/post-processors render the actual (flow-compensated)
 /// bead width rather than the nominal scalar.  Coarse enough (0.05 mm) to keep
@@ -485,6 +494,12 @@ pub struct GcodeGenerator {
     custom_filament_end_script: Option<Vec<String>>,
     /// Optional source model name, embedded in the metadata header (issue #15).
     model_name: Option<String>,
+    /// Print objects on the plate, in tag order.
+    ///
+    /// Empty for a plate sliced without object identity; non-empty enables the
+    /// firmware object markers (issue #22) and the sequential inter-object move
+    /// (issue #112).
+    objects: Vec<crate::core::ObjectIdentity>,
 }
 
 impl GcodeGenerator {
@@ -504,6 +519,7 @@ impl GcodeGenerator {
             custom_filament_start_script: None,
             custom_filament_end_script: None,
             model_name: None,
+            objects: Vec::new(),
         }
     }
 
@@ -521,6 +537,7 @@ impl GcodeGenerator {
             custom_filament_start_script: None,
             custom_filament_end_script: None,
             model_name: None,
+            objects: Vec::new(),
         }
     }
 
@@ -537,6 +554,18 @@ impl GcodeGenerator {
     /// ```
     pub fn with_warn_fn(mut self, f: impl Fn(&str) + 'static) -> Self {
         self.warn_fn = Some(Box::new(f));
+        self
+    }
+
+    /// Attach the plate's print objects so their moves can be attributed.
+    ///
+    /// With objects attached the generator declares them once at the top of the
+    /// program and wraps each object's moves in the dialect's markers
+    /// (`EXCLUDE_OBJECT_*` / `M486`), driven by the per-path tags in
+    /// [`SliceLayer::path_objects`](crate::core::SliceLayer::path_objects).
+    /// Passing an empty list — the default — leaves the output untouched.
+    pub fn with_objects(mut self, objects: Vec<crate::core::ObjectIdentity>) -> Self {
+        self.objects = objects;
         self
     }
 
@@ -1189,6 +1218,67 @@ impl GcodeGenerator {
             ));
         }
 
+        // ── Print-object runs ─────────────────────────────────────────────────
+        // Who owns each layer, and where that layer sits inside its owner's own
+        // stack. In `by_layer` order there is one run and the two indices are
+        // the same; sequential printing concatenates one stack per object, so
+        // anything that counts "layers so far" — the spiral base, the flow
+        // fade-in/out — has to count *within* the run or it only ever applies
+        // to the first object.
+        let sequential = !self.objects.is_empty()
+            && params.print_sequence == crate::settings::params::PrintSequence::ByObject;
+        let mut layer_owners: Vec<Option<usize>> = layers
+            .iter()
+            .map(|layer| (0..layer.paths.len()).find_map(|i| layer.object_for_path(i)))
+            .collect();
+        if sequential {
+            // A layer with no paths carries no tag, so it would slip past the
+            // hand-over — and its Z move would then descend to the *incoming*
+            // object's first layer while the nozzle is still parked over the
+            // one just finished. Attribute such a layer to the next object that
+            // does have geometry (falling back to the previous one at the end
+            // of the plate), so the hand-over always fires before the descent.
+            // `slice_plate` already filters these out; this keeps a
+            // hand-assembled plate safe too.
+            let mut next: Option<usize> = None;
+            for i in (0..layer_owners.len()).rev() {
+                match layer_owners[i] {
+                    Some(owner) => next = Some(owner),
+                    None => layer_owners[i] = next,
+                }
+            }
+            let mut previous: Option<usize> = None;
+            for owner in layer_owners.iter_mut() {
+                match owner {
+                    Some(o) => previous = Some(*o),
+                    None => *owner = previous,
+                }
+            }
+        }
+        let layer_index_in_run: Vec<usize> = if sequential {
+            let mut indices = Vec::with_capacity(layers.len());
+            let mut run_owner: Option<usize> = None;
+            let mut index_in_run = 0usize;
+            for (i, owner) in layer_owners.iter().enumerate() {
+                // An untagged layer (bed adhesion only) continues the current
+                // run rather than starting a new one.
+                if let Some(owner) = owner {
+                    if i == 0 || run_owner != Some(*owner) {
+                        run_owner = Some(*owner);
+                        index_in_run = 0;
+                    } else {
+                        index_in_run += 1;
+                    }
+                } else if i > 0 {
+                    index_in_run += 1;
+                }
+                indices.push(index_in_run);
+            }
+            indices
+        } else {
+            (0..layers.len()).collect()
+        };
+
         // ── Spiral (vase) mode plan ───────────────────────────────────────────
         // Spiralizable layers are those at or above `spiral_start_layer` that
         // expose exactly one closed outer-wall island. Layers below stay flat
@@ -1202,7 +1292,7 @@ impl GcodeGenerator {
                 .iter()
                 .enumerate()
                 .map(|(i, layer)| {
-                    if i < spiral_start_layer {
+                    if layer_index_in_run[i] < spiral_start_layer {
                         return None;
                     }
                     match detect_spiral_loop(layer) {
@@ -1225,12 +1315,46 @@ impl GcodeGenerator {
         } else {
             Vec::new()
         };
-        let first_spiral_idx = spiral_path_indices.iter().position(Option::is_some);
-        let last_spiral_idx = spiral_path_indices.iter().rposition(Option::is_some);
+        // First / last spiral layer **of each object**, so every vase on a
+        // sequential plate fades its seam in and out — not just the first.
+        let mut first_spiral_of_run: Vec<bool> = vec![false; spiral_path_indices.len()];
+        let mut last_spiral_of_run: Vec<bool> = vec![false; spiral_path_indices.len()];
+        {
+            let mut seen: std::collections::HashMap<Option<usize>, (usize, usize)> =
+                std::collections::HashMap::new();
+            for (i, spiral) in spiral_path_indices.iter().enumerate() {
+                if spiral.is_none() {
+                    continue;
+                }
+                let owner = if sequential { layer_owners[i] } else { None };
+                seen.entry(owner).and_modify(|e| e.1 = i).or_insert((i, i));
+            }
+            for (first, last) in seen.into_values() {
+                first_spiral_of_run[first] = true;
+                last_spiral_of_run[last] = true;
+            }
+        }
 
         // The metadata header is prepended once the filament total and geometry
         // are known (see the end of this method); the body starts here.
         let mut out = String::with_capacity(64 * 1024);
+
+        // ── Object definitions (issue #22) ────────────────────────────────────
+        // Declared before the start script: Klipper's `[exclude_object]` module
+        // and Moonraker both expect to meet every object before the print
+        // begins, so a front-end can list the plate's parts from the moment the
+        // file is loaded rather than discovering them as they are reached.
+        //
+        // Markers are gated on `exclude_object` alone: sequential printing also
+        // needs the plate segmented, but a user who only asked for one part at
+        // a time did not ask for firmware object tracking.
+        let object_markers = !self.objects.is_empty() && params.exclude_object;
+        if object_markers {
+            for line in self.dialect.object_definitions(&self.objects) {
+                out.push_str(&line);
+                out.push('\n');
+            }
+        }
 
         // ── Start script (custom override or flavor default) ──────────────────
         let start_script: Cow<[String]> = match &self.custom_start_script {
@@ -1341,6 +1465,20 @@ impl GcodeGenerator {
         // into each spiral loop from the true previous position and to keep the
         // start line aligned. Updated at the end of every layer.
         let mut cur_xy: Option<(f64, f64)> = None;
+        // ── Object attribution state (issues #22 / #112) ──────────────────────
+        // The object whose marker block is currently open, the set already
+        // introduced to the firmware (so `M486 A"name"` is spent once), and the
+        // highest Z printed so far — the height the nozzle must clear when
+        // sequential printing moves on to the next object.
+        let mut current_object: Option<usize> = None;
+        // Which object the *nozzle* is working on. Distinct from
+        // `current_object` (which marker block is open) because a layer with no
+        // paths never reaches the per-path attribution: tracking the hand-over
+        // on the block state would re-fire it on every such layer.
+        let mut handover_object: Option<usize> = layer_owners.first().copied().flatten();
+        let mut introduced_objects: Vec<bool> = vec![false; self.objects.len()];
+        let mut max_printed_z = 0.0_f64;
+        let between_objects = gcode_block_lines(params.between_objects_gcode.as_deref());
 
         // If a custom start script heats for first layer (e.g.
         // `{nozzle_temp_first_layer}` / `{bed_temp_first_layer}`), restore the
@@ -1362,6 +1500,69 @@ impl GcodeGenerator {
             params.bed_temp_first_layer > 0.0 && (first_bed - params.bed_temp).abs() > 1e-9;
 
         for (layer_index, layer) in layers.iter().enumerate() {
+            // ── Sequential printing: hand over to the next object (#112) ─────
+            // Everything here has to happen *before* the layer's own Z move,
+            // which drops the nozzle to the new object's first layer: doing it
+            // afterwards would lower into the part just finished.  So: close
+            // the outgoing marker block, retract, lift clear of the tallest
+            // thing on the bed, then travel across.
+            let layer_object = layer_owners[layer_index];
+            if sequential
+                && layer_index > 0
+                && layer_object.is_some()
+                && layer_object != handover_object
+            {
+                handover_object = layer_object;
+                if object_markers {
+                    if let Some(previous) = current_object.and_then(|i| self.objects.get(i)) {
+                        out.push_str(&self.dialect.object_end(previous));
+                        out.push('\n');
+                    }
+                }
+                current_object = None;
+
+                self.do_retract(
+                    &mut out,
+                    &mut e_total,
+                    &mut retracted,
+                    last_path_points.as_deref(),
+                    params,
+                );
+                let clearance_z = max_printed_z + params.z_hop_mm.max(SEQUENTIAL_LIFT_MM);
+                out.push_str(&format!(
+                    "{} ; clear the finished object\n",
+                    self.dialect.move_z(clearance_z, params.travel_speed_mm_min)
+                ));
+                // Aim at the incoming object's first path, falling back to its
+                // centre: an empty first layer would otherwise leave the nozzle
+                // parked over the part just finished when the layer block below
+                // drops back down to Z.
+                let entry = layer
+                    .paths
+                    .iter()
+                    .next()
+                    .and_then(|p| p.iter().next())
+                    .map(|p| (p.x(), p.y()))
+                    .or_else(|| {
+                        layer_object
+                            .and_then(|i| self.objects.get(i))
+                            .map(|object| object.center)
+                    });
+                if let Some((ex, ey)) = entry {
+                    out.push_str(&format!(
+                        "{} ; travel to the next object\n",
+                        self.dialect.travel_xy(ex, ey, params.travel_speed_mm_min)
+                    ));
+                    cur_xy = Some((ex, ey));
+                }
+                if let Some(lines) = &between_objects {
+                    for line in lines {
+                        out.push_str(&render_script_placeholders(line, params));
+                        out.push('\n');
+                    }
+                }
+            }
+
             // ── Retract on layer change (opt-in) ─────────────────────────────
             // Retract *before* the layer-change Z move so the nozzle does not
             // ooze while lifting and travelling to the next layer's first path.
@@ -1562,6 +1763,27 @@ impl GcodeGenerator {
             // ── Spiral (vase) mode: emit the single outer contour with a
             //    continuous Z ramp, then move to the next layer ───────────────
             if let Some(idx) = spiral_path_idx {
+                // A spiral layer is one continuous loop rather than a list of
+                // paths, so it never reaches the per-path attribution below —
+                // it has to open its own object's marker block here.
+                if !self.objects.is_empty() && layer_object != current_object {
+                    if object_markers {
+                        if let Some(previous) = current_object.and_then(|i| self.objects.get(i)) {
+                            out.push_str(&self.dialect.object_end(previous));
+                            out.push('\n');
+                        }
+                        if let Some(index) = layer_object {
+                            if let Some(object) = self.objects.get(index) {
+                                let first_use = !introduced_objects[index];
+                                out.push_str(&self.dialect.object_start(object, first_use));
+                                out.push('\n');
+                                introduced_objects[index] = true;
+                            }
+                        }
+                    }
+                    current_object = layer_object;
+                }
+
                 let path = layer
                     .paths
                     .iter()
@@ -1625,11 +1847,22 @@ impl GcodeGenerator {
                 // Ramp from the previous layer's top Z to this layer's Z over
                 // one perimeter. Start the loop nearest the previous nozzle
                 // position to keep the (invisible) start line aligned.
-                let z_bottom = if layer_index > 0 {
-                    layers[layer_index - 1].z
-                } else {
-                    0.0
-                };
+                // Ramp up from the previous layer of **this** object. In
+                // sequential order the layer before an object's first is the
+                // previous object's *top*, and ramping from there would extrude
+                // a continuous descent from that height straight through the
+                // plate.
+                let z_bottom =
+                    if layer_index > 0 && layer_owners[layer_index - 1] == layer_object {
+                        layers[layer_index - 1].z
+                    } else {
+                        (layer.z - params.layer_height).max(0.0)
+                    }
+                    // A spiral ramp only ever climbs. Capping at this layer's own Z
+                    // makes the "descend while extruding" failure unrepresentable,
+                    // whatever the previous layer turns out to be.
+                    .min(layer.z)
+                    .max(0.0);
                 let z_top = layer.z;
                 let target = cur_xy.unwrap_or(pts[0]);
                 let rotated = rotate_loop_nearest(&pts, target);
@@ -1648,8 +1881,8 @@ impl GcodeGenerator {
 
                 // Fade flow in on the first spiral loop and out on the last so
                 // the seam disappears at both ends of the vase.
-                let is_first_spiral = first_spiral_idx == Some(layer_index);
-                let is_last_spiral = last_spiral_idx == Some(layer_index);
+                let is_first_spiral = first_spiral_of_run[layer_index];
+                let is_last_spiral = last_spiral_of_run[layer_index];
                 let flow_start = if is_first_spiral && !is_last_spiral {
                     0.0
                 } else {
@@ -1678,6 +1911,12 @@ impl GcodeGenerator {
                 // The loop closes back to its start vertex; that's where the
                 // next spiral layer begins.
                 cur_xy = Some((sx, sy));
+                // This branch skips the end-of-layer bookkeeping below, so the
+                // clearance lift would otherwise never see a spiralised object
+                // and would travel straight through it.
+                if layer.z > max_printed_z {
+                    max_printed_z = layer.z;
+                }
                 continue;
             }
 
@@ -1685,6 +1924,32 @@ impl GcodeGenerator {
                 let raw_points: Vec<(f64, f64)> = path.iter().map(|p| (p.x(), p.y())).collect();
                 if raw_points.len() < 2 {
                     continue;
+                }
+
+                // ── Object attribution (issue #22) ───────────────────────────
+                // Switch marker blocks *before* this path's travel, so the hop
+                // between two parts is charged to the one it is heading for —
+                // the convention PrusaSlicer and OrcaSlicer both follow, and
+                // the one that lets a firmware skip a cancelled object's
+                // approach moves along with its extrusions.  A `None` tag
+                // (plate-wide adhesion) closes the block without opening one.
+                let path_object = layer.object_for_path(path_idx);
+                if !self.objects.is_empty() && path_object != current_object {
+                    if object_markers {
+                        if let Some(previous) = current_object.and_then(|i| self.objects.get(i)) {
+                            out.push_str(&self.dialect.object_end(previous));
+                            out.push('\n');
+                        }
+                        if let Some(index) = path_object {
+                            if let Some(object) = self.objects.get(index) {
+                                let first_use = !introduced_objects[index];
+                                out.push_str(&self.dialect.object_start(object, first_use));
+                                out.push('\n');
+                                introduced_objects[index] = true;
+                            }
+                        }
+                    }
+                    current_object = path_object;
                 }
 
                 // Fetch the role and resolve the effective extrusion width.
@@ -2279,6 +2544,20 @@ impl GcodeGenerator {
             if last_pos.is_some() {
                 cur_xy = last_pos;
             }
+
+            // Highest material laid down so far — what the next object has to
+            // clear when sequential printing hands over.
+            if layer.z > max_printed_z {
+                max_printed_z = layer.z;
+            }
+        }
+
+        // The last object's marker block stays open until the print ends.
+        if object_markers {
+            if let Some(object) = current_object.and_then(|i| self.objects.get(i)) {
+                out.push_str(&self.dialect.object_end(object));
+                out.push('\n');
+            }
         }
 
         // ── Per-filament end script ───────────────────────────────────────────
@@ -2423,6 +2702,33 @@ pub fn generate_gcode_from_params(layers: &[SliceLayer], params: &SlicingParams)
         generator = generator.with_filament_end_script(lines);
     }
     generator.generate(layers, params)
+}
+
+/// Generate G-code for a whole plate, including its per-object markers.
+///
+/// The object-aware sibling of [`generate_gcode_from_params`]: identical for a
+/// plate sliced without object identity (`plate.objects` empty), and the one
+/// call every runtime should make so exclude-object and sequential printing
+/// work the same everywhere.
+pub fn generate_gcode_for_plate(plate: &crate::core::PlateSlice, params: &SlicingParams) -> String {
+    let mut generator =
+        GcodeGenerator::new(params.gcode_flavor).with_objects(plate.objects.clone());
+    if let Some(lines) = gcode_block_lines(params.start_gcode.as_deref()) {
+        generator = generator.with_start_script(lines);
+    }
+    if let Some(lines) = gcode_block_lines(params.end_gcode.as_deref()) {
+        generator = generator.with_end_script(lines);
+    }
+    if let Some(lines) = gcode_block_lines(params.layer_gcode.as_deref()) {
+        generator = generator.with_layer_script(lines);
+    }
+    if let Some(lines) = gcode_block_lines(params.start_filament_gcode.as_deref()) {
+        generator = generator.with_filament_start_script(lines);
+    }
+    if let Some(lines) = gcode_block_lines(params.end_filament_gcode.as_deref()) {
+        generator = generator.with_filament_end_script(lines);
+    }
+    generator.generate(&plate.layers, params)
 }
 
 /// Split a multi-line custom G-code block into lines, returning `None` when the
@@ -6097,5 +6403,419 @@ CHAMBER={chamber_temp} MATERIAL={filament_type}"
                 .all(|l| !l.contains("; retract") && !l.contains("; z-hop")),
             "spiral vase body must not retract or z-hop:\n{gcode}"
         );
+    }
+}
+
+// ── Object exclusion & sequential printing (issues #22 / #112) ─────────────────
+
+#[cfg(test)]
+mod object_tests {
+    use super::*;
+    use crate::core::{ExtrusionRole, ObjectIdentity, PlateSlice, SliceLayer};
+    use crate::settings::params::PrintSequence;
+
+    fn identity(index: usize, name: &str, x: f64) -> ObjectIdentity {
+        ObjectIdentity {
+            index,
+            name: name.to_string(),
+            center: (x + 5.0, 5.0),
+            polygon: vec![(x, 0.0), (x + 10.0, 0.0), (x + 10.0, 10.0), (x, 10.0)],
+            bbox: (x, 0.0, x + 10.0, 10.0),
+            height_mm: 4.0,
+        }
+    }
+
+    /// One layer holding one square per object, tagged in object order.
+    fn tagged_layer(z: f64, objects: &[usize]) -> SliceLayer {
+        let mut layer = SliceLayer::new(z);
+        for (slot, &object) in objects.iter().enumerate() {
+            let x = slot as f64 * 30.0;
+            let square: clipper2::Path =
+                vec![(x, 0.0), (x + 10.0, 0.0), (x + 10.0, 10.0), (x, 10.0)].into();
+            layer.paths.push(square);
+            layer.path_roles.push(ExtrusionRole::OuterWall);
+            layer.path_widths.push(Some(0.4));
+            layer.path_vertex_widths.push(None);
+            layer.path_is_open.push(false);
+            layer.path_objects.push(Some(object));
+        }
+        layer
+    }
+
+    fn plate(layers: Vec<SliceLayer>, objects: Vec<ObjectIdentity>) -> PlateSlice {
+        PlateSlice { layers, objects }
+    }
+
+    fn klipper_params() -> SlicingParams {
+        SlicingParams {
+            gcode_flavor: crate::gcode::GcodeFlavor::Klipper,
+            exclude_object: true,
+            ..Default::default()
+        }
+    }
+
+    #[test]
+    fn klipper_defines_every_object_before_the_start_script() {
+        let objects = vec![identity(0, "cube_a", 0.0), identity(1, "cube_b", 30.0)];
+        let gcode = generate_gcode_for_plate(
+            &plate(vec![tagged_layer(0.2, &[0, 1])], objects),
+            &klipper_params(),
+        );
+
+        assert!(gcode.contains("EXCLUDE_OBJECT_DEFINE RESET=1"));
+        assert!(
+            gcode.contains(
+                "EXCLUDE_OBJECT_DEFINE NAME=cube_a CENTER=5.000,5.000 POLYGON=[[0.000,0.000],"
+            ),
+            "missing cube_a definition: {gcode}"
+        );
+        assert!(gcode.contains("EXCLUDE_OBJECT_DEFINE NAME=cube_b"));
+
+        // The definitions must precede the start script — Moonraker and the
+        // Klipper module both expect to meet the objects before printing.
+        let define_at = gcode.find("EXCLUDE_OBJECT_DEFINE NAME=cube_a").unwrap();
+        let start_at = gcode.find("START_PRINT").unwrap();
+        assert!(define_at < start_at, "definitions must come first: {gcode}");
+    }
+
+    #[test]
+    fn klipper_wraps_each_object_and_closes_the_last_one() {
+        let objects = vec![identity(0, "cube_a", 0.0), identity(1, "cube_b", 30.0)];
+        let gcode = generate_gcode_for_plate(
+            &plate(
+                vec![tagged_layer(0.2, &[0, 1]), tagged_layer(0.4, &[0, 1])],
+                objects,
+            ),
+            &klipper_params(),
+        );
+
+        let markers: Vec<&str> = gcode
+            .lines()
+            .filter(|l| {
+                l.starts_with("EXCLUDE_OBJECT_START") || l.starts_with("EXCLUDE_OBJECT_END")
+            })
+            .collect();
+        assert_eq!(
+            markers,
+            vec![
+                "EXCLUDE_OBJECT_START NAME=cube_a",
+                "EXCLUDE_OBJECT_END NAME=cube_a",
+                "EXCLUDE_OBJECT_START NAME=cube_b",
+                "EXCLUDE_OBJECT_END NAME=cube_b",
+                "EXCLUDE_OBJECT_START NAME=cube_a",
+                "EXCLUDE_OBJECT_END NAME=cube_a",
+                "EXCLUDE_OBJECT_START NAME=cube_b",
+                "EXCLUDE_OBJECT_END NAME=cube_b",
+            ],
+            "every block must be opened and closed: {gcode}"
+        );
+    }
+
+    #[test]
+    fn marlin_uses_m486_and_names_each_object_once() {
+        let objects = vec![identity(0, "cube_a", 0.0), identity(1, "cube_b", 30.0)];
+        let params = SlicingParams {
+            exclude_object: true,
+            ..Default::default()
+        };
+        let gcode = generate_gcode_for_plate(
+            &plate(
+                vec![tagged_layer(0.2, &[0, 1]), tagged_layer(0.4, &[0, 1])],
+                objects,
+            ),
+            &params,
+        );
+
+        assert!(gcode.contains("M486 T2 ; object count"));
+        // The name rides along the first `S` only; repeating it on every layer
+        // would bloat the file for no gain.
+        assert_eq!(gcode.matches("M486 S0 A\"cube_a\"").count(), 1);
+        assert_eq!(gcode.matches("M486 S1 A\"cube_b\"").count(), 1);
+        assert_eq!(gcode.matches("\nM486 S0\n").count(), 1);
+        assert_eq!(gcode.matches("M486 S-1").count(), 4);
+    }
+
+    #[test]
+    fn untagged_paths_close_the_block_without_opening_one() {
+        // A plate-wide skirt (tag `None`) printed before the objects.
+        let mut layer = tagged_layer(0.2, &[0, 1]);
+        layer.path_objects[0] = None;
+        layer.path_roles[0] = ExtrusionRole::Skirt;
+
+        let gcode = generate_gcode_for_plate(
+            &plate(
+                vec![layer],
+                vec![identity(0, "cube_a", 0.0), identity(1, "cube_b", 30.0)],
+            ),
+            &klipper_params(),
+        );
+        let markers: Vec<&str> = gcode
+            .lines()
+            .filter(|l| l.starts_with("EXCLUDE_OBJECT_"))
+            .filter(|l| !l.starts_with("EXCLUDE_OBJECT_DEFINE"))
+            .collect();
+        assert_eq!(
+            markers,
+            vec![
+                "EXCLUDE_OBJECT_START NAME=cube_b",
+                "EXCLUDE_OBJECT_END NAME=cube_b",
+            ],
+            "the skirt belongs to no object: {gcode}"
+        );
+    }
+
+    #[test]
+    fn sequential_alone_does_not_emit_object_markers() {
+        // Printing one part at a time is a *motion* choice; firmware object
+        // tracking is a separate opt-in and must not ride along with it.
+        let params = SlicingParams {
+            gcode_flavor: crate::gcode::GcodeFlavor::Klipper,
+            print_sequence: PrintSequence::ByObject,
+            exclude_object: false,
+            ..Default::default()
+        };
+        let gcode = generate_gcode_for_plate(
+            &plate(
+                vec![tagged_layer(0.2, &[0]), tagged_layer(0.2, &[1])],
+                vec![identity(0, "cube_a", 0.0), identity(1, "cube_b", 30.0)],
+            ),
+            &params,
+        );
+        assert!(!gcode.contains("EXCLUDE_OBJECT"), "{gcode}");
+        assert!(!gcode.contains("M486"), "{gcode}");
+        // The hand-over itself still happens.
+        assert!(gcode.contains("; clear the finished object"), "{gcode}");
+    }
+
+    /// One object's worth of layers: `flat` solid base layers then `spiral`
+    /// single-loop layers, starting at `z0` and stepping by 0.2 mm.
+    fn spiral_stack(object: usize, x: f64, z0: f64, flat: usize, spiral: usize) -> Vec<SliceLayer> {
+        (0..flat + spiral)
+            .map(|i| {
+                let mut layer = tagged_layer(z0 + i as f64 * 0.2, &[object]);
+                // Re-place the square so each object sits at its own X.
+                layer.paths = clipper2::Paths::new(vec![vec![
+                    (x, 0.0),
+                    (x + 10.0, 0.0),
+                    (x + 10.0, 10.0),
+                    (x, 10.0),
+                ]
+                .into()]);
+                layer
+            })
+            .collect()
+    }
+
+    #[test]
+    fn sequential_spiral_vase_never_ramps_down_into_the_previous_object() {
+        // Two vases, one after the other. The regression: the second object's
+        // first spiral layer used to take its ramp start from the *previous
+        // object's top* — a continuous extruding descent straight through the
+        // plate — and the clearance lift never saw a spiral layer at all, so it
+        // travelled through the finished vase.
+        let mut layers = spiral_stack(0, 0.0, 0.2, 1, 8);
+        layers.extend(spiral_stack(1, 60.0, 0.2, 1, 4));
+        let params = SlicingParams {
+            gcode_flavor: crate::gcode::GcodeFlavor::Klipper,
+            print_sequence: PrintSequence::ByObject,
+            exclude_object: true,
+            spiral_vase: true,
+            bottom_layers: 1,
+            layer_height: 0.2,
+            ..Default::default()
+        };
+        let gcode = generate_gcode_for_plate(
+            &plate(
+                layers,
+                vec![identity(0, "vase_a", 0.0), identity(1, "vase_b", 60.0)],
+            ),
+            &params,
+        );
+
+        // No move may lose height while extruding.
+        let mut z = 0.0_f64;
+        let mut e = 0.0_f64;
+        for line in gcode.lines() {
+            if line.starts_with("G92 E0") {
+                e = 0.0;
+                continue;
+            }
+            if !line.starts_with("G1 ") {
+                continue;
+            }
+            let field = |tag: char| {
+                line.split_whitespace()
+                    .find_map(|t| t.strip_prefix(tag))
+                    .and_then(|v| v.parse::<f64>().ok())
+            };
+            let (nz, ne) = (field('Z'), field('E'));
+            if let (Some(nz), Some(ne)) = (nz, ne) {
+                assert!(
+                    !(nz < z - 1e-9 && ne > e + 1e-9),
+                    "extruding descent from {z} to {nz}: {line}"
+                );
+            }
+            z = nz.unwrap_or(z);
+            e = ne.unwrap_or(e);
+        }
+
+        // Exactly one hand-over, and it clears the finished vase (top 1.6 mm).
+        assert_eq!(
+            gcode.matches("; clear the finished object").count(),
+            1,
+            "{gcode}"
+        );
+        let lift_line = gcode
+            .lines()
+            .find(|l| l.ends_with("; clear the finished object"))
+            .unwrap();
+        let lift_z: f64 = lift_line
+            .split_whitespace()
+            .find_map(|t| t.strip_prefix('Z'))
+            .unwrap()
+            .parse()
+            .unwrap();
+        assert!(
+            lift_z > 1.6,
+            "lift must clear the spiralised object: {lift_line}"
+        );
+
+        assert_eq!(gcode.matches("EXCLUDE_OBJECT_START NAME=vase_b").count(), 1);
+        assert_eq!(gcode.matches("EXCLUDE_OBJECT_END NAME=vase_b").count(), 1);
+
+        // Each vase keeps its own solid base — `bottom_layers` counts within an
+        // object's stack, not from the start of the plate. A flat layer's
+        // extrusions carry no Z; a spiral layer's ramp always does.
+        let vase_b = &gcode[gcode.find("EXCLUDE_OBJECT_START NAME=vase_b").unwrap()..];
+        let first_extrusion = vase_b
+            .lines()
+            .find(|l| l.starts_with("G1 ") && l.contains(" E"))
+            .expect("vase_b prints something");
+        assert!(
+            !first_extrusion.contains(" Z"),
+            "vase_b must start on a flat base layer, not mid-ramp: {first_extrusion}"
+        );
+    }
+
+    #[test]
+    fn an_empty_first_layer_still_triggers_the_hand_over() {
+        // A layer with no paths carries no object tag. If the hand-over keyed
+        // on the tag alone, such a layer would slip through and its Z move
+        // would descend to the new object's first layer while the nozzle was
+        // still over the finished one.
+        let layers = vec![
+            tagged_layer(0.2, &[0]),
+            tagged_layer(4.0, &[0]),
+            SliceLayer::new(0.2),
+            tagged_layer(0.4, &[1]),
+        ];
+        let params = SlicingParams {
+            print_sequence: PrintSequence::ByObject,
+            ..Default::default()
+        };
+        let gcode = generate_gcode_for_plate(
+            &plate(
+                layers,
+                vec![identity(0, "cube_a", 0.0), identity(1, "cube_b", 80.0)],
+            ),
+            &params,
+        );
+
+        let lift = gcode
+            .find("; clear the finished object")
+            .expect("the hand-over must fire before the empty layer's Z move");
+        let descent = gcode[lift..]
+            .find("G1 Z0.200")
+            .expect("the empty layer still moves Z");
+        assert!(descent > 0, "the descent must follow the lift");
+        assert_eq!(gcode.matches("; clear the finished object").count(), 1);
+    }
+
+    #[test]
+    fn no_objects_means_no_markers_at_all() {
+        let mut layer = SliceLayer::new(0.2);
+        let square: clipper2::Path =
+            vec![(0.0, 0.0), (10.0, 0.0), (10.0, 10.0), (0.0, 10.0)].into();
+        layer.paths.push(square);
+        layer.path_roles.push(ExtrusionRole::OuterWall);
+
+        let gcode = generate_gcode_for_plate(
+            &PlateSlice::from_layers(vec![layer.clone()]),
+            &SlicingParams::default(),
+        );
+        assert!(!gcode.contains("M486"));
+        assert_eq!(gcode, generate_gcode(&[layer], &SlicingParams::default()));
+    }
+
+    #[test]
+    fn sequential_lifts_clear_of_the_finished_object_before_travelling() {
+        // Object 0 printed to z=4.0, then object 1 starts again at z=0.2.
+        let layers = vec![
+            tagged_layer(0.2, &[0]),
+            tagged_layer(4.0, &[0]),
+            {
+                let mut l = tagged_layer(0.2, &[1]);
+                // Put object 1 well away from object 0.
+                l.paths = clipper2::Paths::new(vec![vec![
+                    (80.0, 80.0),
+                    (90.0, 80.0),
+                    (90.0, 90.0),
+                    (80.0, 90.0),
+                ]
+                .into()]);
+                l
+            },
+            tagged_layer(2.0, &[1]),
+        ];
+        let params = SlicingParams {
+            gcode_flavor: crate::gcode::GcodeFlavor::Klipper,
+            print_sequence: PrintSequence::ByObject,
+            exclude_object: true,
+            between_objects_gcode: Some("M117 next object".to_string()),
+            ..Default::default()
+        };
+        let gcode = generate_gcode_for_plate(
+            &plate(
+                layers,
+                vec![identity(0, "cube_a", 0.0), identity(1, "cube_b", 80.0)],
+            ),
+            &params,
+        );
+
+        let lift = gcode
+            .find("; clear the finished object")
+            .expect("expected a clearance lift at the object boundary");
+        let travel = gcode
+            .find("; travel to the next object")
+            .expect("expected a travel to the next object");
+        let hook = gcode
+            .find("M117 next object")
+            .expect("between-objects hook");
+        let drop_back = gcode[travel..]
+            .find("G1 Z0.200")
+            .map(|i| i + travel)
+            .expect("the next object's first layer Z move");
+
+        // Order is the whole point: lift → travel → hook → only then descend.
+        assert!(
+            lift < travel && travel < hook && hook < drop_back,
+            "{gcode}"
+        );
+
+        // The lift clears the 4.0 mm object already on the bed.
+        let lift_line = gcode[..lift].lines().last().unwrap();
+        let z: f64 = lift_line
+            .split_whitespace()
+            .find_map(|t| t.strip_prefix('Z'))
+            .unwrap()
+            .parse()
+            .unwrap();
+        assert!(z > 4.0, "lift must clear the finished object: {lift_line}");
+
+        // Each object's block is opened once and closed once.
+        assert_eq!(gcode.matches("EXCLUDE_OBJECT_START NAME=cube_a").count(), 1);
+        assert_eq!(gcode.matches("EXCLUDE_OBJECT_END NAME=cube_a").count(), 1);
+        assert_eq!(gcode.matches("EXCLUDE_OBJECT_START NAME=cube_b").count(), 1);
+        assert_eq!(gcode.matches("EXCLUDE_OBJECT_END NAME=cube_b").count(), 1);
     }
 }

--- a/src/gcode/mod.rs
+++ b/src/gcode/mod.rs
@@ -44,6 +44,8 @@ pub mod travel;
 pub use dialect::{GcodeDialect, WarnFn};
 pub use dialects::{KlipperDialect, MarlinDialect};
 pub use flavor::GcodeFlavor;
-pub use generator::{generate_gcode, generate_gcode_from_params, GcodeGenerator};
+pub use generator::{
+    generate_gcode, generate_gcode_for_plate, generate_gcode_from_params, GcodeGenerator,
+};
 pub use source::resolve_gcode_source;
 pub use stats::SliceStatistics;

--- a/src/logging.rs
+++ b/src/logging.rs
@@ -128,6 +128,25 @@ pub trait ProcessLogger: Send + Sync {
     /// The default implementation is a no-op, preserving backward compatibility.
     fn log_phase_end(&self, _phase: &str, _elapsed_ms: u64) {}
 
+    /// Announce that the phases which follow belong to object `index` of
+    /// `count` on a multi-object plate (both **1-based**).
+    ///
+    /// A plate sliced object-by-object runs the whole pipeline once per object,
+    /// so the same phase names recur. Without this context a progress bar keyed
+    /// on phase names walks *backwards* every time a new object restarts the
+    /// pipeline. Loggers that surface progress record the scope and stamp it
+    /// onto every subsequent phase marker until [`clear_object_scope`] is
+    /// called. The default is a no-op.
+    ///
+    /// [`clear_object_scope`]: ProcessLogger::clear_object_scope
+    fn set_object_scope(&self, _index: usize, _count: usize) {}
+
+    /// Clear the object scope set by [`set_object_scope`], so later phases are
+    /// reported without object context again. The default is a no-op.
+    ///
+    /// [`set_object_scope`]: ProcessLogger::set_object_scope
+    fn clear_object_scope(&self) {}
+
     /// Returns `true` when the pipeline should abort early.
     ///
     /// Checked between major phases in [`crate::core::process_mesh`]. The

--- a/src/scene/wasm.rs
+++ b/src/scene/wasm.rs
@@ -445,29 +445,37 @@ impl SceneHandle {
             ));
         }
 
-        let mut combined = crate::mesh::types::Mesh::new();
-        for object in &self.inner.objects {
-            let baked = crate::scene::apply_transform(object.mesh.as_ref(), &object.transform);
-            combined.vertices.extend(baked.vertices);
-            combined.faces.extend(baked.faces);
-        }
+        // Keep the plate's objects apart and let `slice_plate` decide whether
+        // it can merge them — the browser slicer honours exclude-object and
+        // sequential printing exactly like the CLI and the server do.
+        let plate_objects: Vec<crate::core::ObjectInput> = self
+            .inner
+            .objects
+            .iter()
+            .map(|object| {
+                crate::core::ObjectInput::new(
+                    object.name.clone(),
+                    crate::scene::apply_transform(object.mesh.as_ref(), &object.transform),
+                )
+            })
+            .collect();
 
-        if combined.faces.is_empty() {
+        if plate_objects.iter().all(|o| o.mesh.faces.is_empty()) {
             return Err(JsValue::from_str(
                 "combined scene has no triangles; nothing to slice",
             ));
         }
 
         let logger = WasmSliceLogger::new(callback);
-        let layers = crate::core::process_mesh(&combined, &params, &logger);
-        let layer_count = layers.len();
+        let plate = crate::core::slice_plate(&plate_objects, &params, &logger);
+        let layer_count = plate.layers.len();
         logger.emit_progress(layer_count, layer_count);
 
         let t_gcode =
             crate::logging::PhaseTimer::start(crate::logging::phases::GCODE_GENERATION, &logger);
         let result = SliceResultJs {
             layer_count,
-            gcode: crate::gcode::generate_gcode_from_params(&layers, &params),
+            gcode: crate::gcode::generate_gcode_for_plate(&plate, &params),
         };
         t_gcode.finish();
 

--- a/src/scene/wasm.rs
+++ b/src/scene/wasm.rs
@@ -486,12 +486,19 @@ impl SceneHandle {
 #[cfg(feature = "web-slicer")]
 struct WasmSliceLogger {
     callback: Option<Function>,
+    /// Current object scope `(index, count)`, both 1-based, or `(0, 0)` for a
+    /// single merged slice. `Cell` is enough — the logger runs synchronously on
+    /// one worker thread (see the `unsafe impl Sync` note below).
+    object_scope: std::cell::Cell<(u32, u32)>,
 }
 
 #[cfg(feature = "web-slicer")]
 impl WasmSliceLogger {
     fn new(callback: Option<Function>) -> Self {
-        Self { callback }
+        Self {
+            callback,
+            object_scope: std::cell::Cell::new((0, 0)),
+        }
     }
 
     fn emit_log(&self, level: &str, message: &str) {
@@ -509,6 +516,11 @@ impl WasmSliceLogger {
         set_js_str(&event, "event", event_name);
         if let Some(elapsed_ms) = elapsed_ms {
             set_js_num(&event, "elapsed_ms", elapsed_ms as f64);
+        }
+        let (object, count) = self.object_scope.get();
+        if count > 0 {
+            set_js_num(&event, "object", object as f64);
+            set_js_num(&event, "object_count", count as f64);
         }
         self.emit(event);
     }
@@ -548,6 +560,14 @@ impl crate::logging::ProcessLogger for WasmSliceLogger {
 
     fn log_phase_end(&self, phase: &str, elapsed_ms: u64) {
         self.emit_phase(phase, "end", Some(elapsed_ms));
+    }
+
+    fn set_object_scope(&self, index: usize, count: usize) {
+        self.object_scope.set((index as u32, count as u32));
+    }
+
+    fn clear_object_scope(&self) {
+        self.object_scope.set((0, 0));
     }
 }
 

--- a/src/server/ws_session.rs
+++ b/src/server/ws_session.rs
@@ -17,6 +17,11 @@ use uuid::Uuid;
 struct WsLogger {
     global: StderrLogger,
     tx: tokio::sync::mpsc::Sender<String>,
+    /// Current object scope as `(index, count)`, both 1-based, or `(0, 0)` for
+    /// "no scope" (a single merged slice). Interior-mutable because the logger
+    /// is shared immutably down the pipeline while `slice_plate` updates the
+    /// scope between objects.
+    object_scope: std::sync::atomic::AtomicU64,
 }
 
 impl WsLogger {
@@ -24,7 +29,19 @@ impl WsLogger {
         Self {
             global: StderrLogger,
             tx,
+            object_scope: std::sync::atomic::AtomicU64::new(0),
         }
+    }
+
+    /// Read the current object scope as optional 1-based `(index, count)`.
+    fn scope(&self) -> (Option<u32>, Option<u32>) {
+        let packed = self.object_scope.load(std::sync::atomic::Ordering::Relaxed);
+        if packed == 0 {
+            return (None, None);
+        }
+        let index = (packed >> 32) as u32;
+        let count = (packed & 0xFFFF_FFFF) as u32;
+        (Some(index), Some(count))
     }
 
     fn send_log(&self, level: &str, msg: &str) {
@@ -63,10 +80,13 @@ impl ProcessLogger for WsLogger {
 
     fn log_phase_start(&self, phase: &str) {
         self.global.log_phase_start(phase);
+        let (object, object_count) = self.scope();
         let server_msg = crate::ws_protocol::ServerMessage::PhaseMarker {
             phase: phase.to_string(),
             event: "start".to_string(),
             elapsed_ms: None,
+            object,
+            object_count,
         };
         let json = serde_json::to_string(&server_msg).unwrap_or_else(|_| {
             format!(
@@ -79,10 +99,13 @@ impl ProcessLogger for WsLogger {
 
     fn log_phase_end(&self, phase: &str, elapsed_ms: u64) {
         self.global.log_phase_end(phase, elapsed_ms);
+        let (object, object_count) = self.scope();
         let server_msg = crate::ws_protocol::ServerMessage::PhaseMarker {
             phase: phase.to_string(),
             event: "end".to_string(),
             elapsed_ms: Some(elapsed_ms),
+            object,
+            object_count,
         };
         let json = serde_json::to_string(&server_msg).unwrap_or_else(|_| {
             format!(
@@ -91,6 +114,17 @@ impl ProcessLogger for WsLogger {
             )
         });
         let _ = self.tx.blocking_send(json);
+    }
+
+    fn set_object_scope(&self, index: usize, count: usize) {
+        let packed = ((index as u64) << 32) | (count as u64 & 0xFFFF_FFFF);
+        self.object_scope
+            .store(packed, std::sync::atomic::Ordering::Relaxed);
+    }
+
+    fn clear_object_scope(&self) {
+        self.object_scope
+            .store(0, std::sync::atomic::Ordering::Relaxed);
     }
 }
 

--- a/src/server/ws_session.rs
+++ b/src/server/ws_session.rs
@@ -482,11 +482,12 @@ async fn handle_slice(
         // Start overall timing for the entire process
         let t_total = PhaseTimer::start(phases::TOTAL, &logger);
 
-        // Load each scene object (auto-detecting format from its extension),
-        // bake its transform, and concatenate faces into a single combined
-        // mesh that the slicer pipeline sees.
+        // Load each scene object (auto-detecting format from its extension) and
+        // bake its transform.  The objects stay separate: `slice_plate` decides
+        // whether the plate can be merged into one mesh (the default) or has to
+        // keep per-object identity for exclude-object / sequential printing.
         let t_load = PhaseTimer::start(phases::MESH_LOAD, &logger);
-        let mut combined = crate::mesh::types::Mesh::new();
+        let mut plate_objects: Vec<crate::core::ObjectInput> = Vec::new();
         // A multi-part file (3MF) backs several plate objects, so cache its
         // parsed parts: re-reading and re-parsing the archive once per part
         // would cost the same work N times for no gain.
@@ -526,10 +527,19 @@ async fn handle_slice(
             // Bake the per-object transform exactly once, at the slicer
             // boundary — see the SSOT contract in src/scene/README.md.
             let baked = crate::scene::apply_transform(&part.mesh, transform);
-            combined.vertices.extend(baked.vertices);
-            combined.faces.extend(baked.faces);
+            // Name the object after the part inside its file, falling back to
+            // the file stem — this is what the firmware's cancel UI shows.
+            let name = part
+                .name
+                .as_deref()
+                .map(str::trim)
+                .filter(|n| !n.is_empty())
+                .map(str::to_string)
+                .or_else(|| path.file_stem().map(|s| s.to_string_lossy().into_owned()))
+                .unwrap_or_else(|| format!("object_{}", plate_objects.len()));
+            plate_objects.push(crate::core::ObjectInput::new(name, baked));
         }
-        if combined.faces.is_empty() {
+        if plate_objects.iter().all(|o| o.mesh.faces.is_empty()) {
             let msg = ServerMessage::error(
                 "Combined scene has no triangles — nothing to slice".to_string(),
             );
@@ -542,8 +552,8 @@ async fn handle_slice(
             logger.log_warn(&format!("[slice] {warning}"));
         }
 
-        let layers = crate::core::process_mesh(&combined, &params, &logger);
-        let layer_count = layers.len();
+        let plate = crate::core::slice_plate(&plate_objects, &params, &logger);
+        let layer_count = plate.layers.len();
 
         let progress = ServerMessage::Progress {
             current_layer: layer_count,
@@ -552,7 +562,7 @@ async fn handle_slice(
         let _ = tx.blocking_send(to_json(&progress));
 
         let t_gcode = PhaseTimer::start(phases::GCODE_GENERATION, &logger);
-        let gcode = crate::gcode::generate_gcode_from_params(&layers, &params);
+        let gcode = crate::gcode::generate_gcode_for_plate(&plate, &params);
         t_gcode.finish();
 
         // Write G-code to disk

--- a/src/settings/params.rs
+++ b/src/settings/params.rs
@@ -443,24 +443,25 @@ pub enum BrimType {
     Ears,
 }
 
-/// The order in which a multi-object plate is printed.
+/// How a plate holding several objects is printed.
 ///
-/// Consumed by [`crate::core::slice_plate`] (which decides whether the plate
-/// has to be sliced object-by-object) and by
-/// [`crate::gcode::GcodeGenerator`] (which emits the inter-object move).
+/// The developer-facing rationale (how each order flows through the slicing
+/// pipeline and the G-code generator) lives in the object-identity section of
+/// AGENTS.md; the doc text here stays user-facing because it becomes the
+/// setting's on-screen description.
 #[derive(Debug, Clone, Copy, PartialEq, Eq, Default, Serialize, Deserialize, JsonSchema)]
 #[serde(rename_all = "snake_case")]
 pub enum PrintSequence {
-    /// Every object advances one layer at a time — the standard FFF order.
+    /// Print every object together, rising one layer at a time.
     #[default]
     ByLayer,
-    /// Each object is finished completely before the next one starts.
+    /// Finish each object completely before starting the next.
     ///
-    /// Reduces the blemishes and stringing of plate-wide travels and lets a
-    /// finished part be removed mid-print, at the cost of requiring the
-    /// gantry to clear everything already on the bed (see
-    /// [`SlicingParams::extruder_clearance_height_mm`] /
-    /// [`SlicingParams::extruder_clearance_radius_mm`]).
+    /// Cuts the stringing and scars that plate-wide travel moves leave on
+    /// finished surfaces, and lets a completed part be lifted off before the
+    /// rest of the plate is done. In return the printhead has to clear whatever
+    /// is already on the bed, so parts that are too tall or too close together
+    /// are flagged before printing.
     ByObject,
 }
 
@@ -1900,35 +1901,35 @@ Caps print speed so the hotend can keep up with the flow.
     pub thumbnail_png_base64: Option<String>,
 
     #[schemars(
-        description = "Print order for a plate holding several objects: `by_layer` (every object advances one layer at a time) or `by_object` (each object is finished before the next one starts).",
+        description = "How a plate with several objects is printed: all objects together, rising one layer at a time — or each object finished completely before the next begins.",
         extend("x-group" = "Objects")
     )]
     #[serde(default)]
     pub print_sequence: PrintSequence,
 
     #[schemars(
-        description = "Wrap each object's moves in firmware object markers (Klipper `EXCLUDE_OBJECT_*`, Marlin/RepRap `M486`) so a single failed object can be cancelled mid-print without aborting the whole plate.",
-        extend("x-group" = "Objects")
+        description = "Let a single object be cancelled while the print continues, if it fails or lifts off the bed — without losing the rest of the plate. Needs a printer that supports skipping objects.",
+        extend("x-group" = "Hardware")
     )]
     #[serde(default)]
     pub exclude_object: bool,
 
     #[schemars(
-        description = "Gantry/X-carriage clearance height in mm: an object shorter than this passes under the moving gantry. A machine property. Used by sequential (`by_object`) printing to warn when a part is too tall to print before another.",
+        description = "Clearance height in mm: an object shorter than this fits under the printhead as it moves. Used when printing objects one at a time to warn before a tall part is left in the printhead's path.",
         extend("x-group" = "Hardware")
     )]
     #[serde(default = "SlicingParams::default_extruder_clearance_height")]
     pub extruder_clearance_height_mm: f64,
 
     #[schemars(
-        description = "Radius in mm the hotend and its fan duct sweep around the nozzle. A machine property. Used by sequential (`by_object`) printing to warn when two parts are too close to print one at a time.",
+        description = "How far the printhead and its fan shroud reach out around the nozzle, in mm. Used when printing objects one at a time to warn before two parts are placed too close to reach safely.",
         extend("x-group" = "Hardware")
     )]
     #[serde(default = "SlicingParams::default_extruder_clearance_radius")]
     pub extruder_clearance_radius_mm: f64,
 
     #[schemars(
-        description = "Custom G-code inserted between two objects in `by_object` order, after the nozzle has lifted clear and travelled to the next object. `null` = nothing.",
+        description = "Custom G-code to run after one object is finished and before the next one starts, when printing objects one at a time. Leave empty for none.",
         extend("x-group" = "Objects", "x-widget" = "gcode", "x-relevant-when" = serde_json::json!({"field": "print_sequence", "equals": "by_object"}))
     )]
     #[serde(default, skip_serializing_if = "Option::is_none")]

--- a/src/settings/params.rs
+++ b/src/settings/params.rs
@@ -443,6 +443,47 @@ pub enum BrimType {
     Ears,
 }
 
+/// The order in which a multi-object plate is printed.
+///
+/// Consumed by [`crate::core::slice_plate`] (which decides whether the plate
+/// has to be sliced object-by-object) and by
+/// [`crate::gcode::GcodeGenerator`] (which emits the inter-object move).
+#[derive(Debug, Clone, Copy, PartialEq, Eq, Default, Serialize, Deserialize, JsonSchema)]
+#[serde(rename_all = "snake_case")]
+pub enum PrintSequence {
+    /// Every object advances one layer at a time — the standard FFF order.
+    #[default]
+    ByLayer,
+    /// Each object is finished completely before the next one starts.
+    ///
+    /// Reduces the blemishes and stringing of plate-wide travels and lets a
+    /// finished part be removed mid-print, at the cost of requiring the
+    /// gantry to clear everything already on the bed (see
+    /// [`SlicingParams::extruder_clearance_height_mm`] /
+    /// [`SlicingParams::extruder_clearance_radius_mm`]).
+    ByObject,
+}
+
+impl PrintSequence {
+    /// Parse a sequence name from a CLI argument or config string
+    /// (case-insensitive, hyphens and underscores both accepted).
+    pub fn parse(s: &str) -> Option<Self> {
+        match s.to_lowercase().replace('-', "_").as_str() {
+            "by_layer" | "layer" => Some(Self::ByLayer),
+            "by_object" | "object" | "sequential" => Some(Self::ByObject),
+            _ => None,
+        }
+    }
+
+    /// Canonical name for emitting back into config / G-code comments.
+    pub fn name(self) -> &'static str {
+        match self {
+            Self::ByLayer => "by_layer",
+            Self::ByObject => "by_object",
+        }
+    }
+}
+
 /// Camera angle used when the UI renders the embedded G-code thumbnail.
 ///
 /// The thumbnail is produced from a fixed, repeatable viewpoint (not the
@@ -1857,6 +1898,41 @@ Caps print speed so the hotend can keep up with the flow.
     #[schemars(skip)]
     #[serde(default, skip_serializing_if = "Option::is_none")]
     pub thumbnail_png_base64: Option<String>,
+
+    #[schemars(
+        description = "Print order for a plate holding several objects: `by_layer` (every object advances one layer at a time) or `by_object` (each object is finished before the next one starts).",
+        extend("x-group" = "Objects")
+    )]
+    #[serde(default)]
+    pub print_sequence: PrintSequence,
+
+    #[schemars(
+        description = "Wrap each object's moves in firmware object markers (Klipper `EXCLUDE_OBJECT_*`, Marlin/RepRap `M486`) so a single failed object can be cancelled mid-print without aborting the whole plate.",
+        extend("x-group" = "Objects")
+    )]
+    #[serde(default)]
+    pub exclude_object: bool,
+
+    #[schemars(
+        description = "Height in mm below which the gantry/X-carriage clears an already-printed object. Objects taller than this cannot be safely printed before another one in `by_object` order.",
+        extend("x-group" = "Objects", "x-relevant-when" = serde_json::json!({"field": "print_sequence", "equals": "by_object"}))
+    )]
+    #[serde(default = "SlicingParams::default_extruder_clearance_height")]
+    pub extruder_clearance_height_mm: f64,
+
+    #[schemars(
+        description = "Radius in mm around the nozzle that the hotend/fan duct sweeps. Objects closer together than this cannot be safely printed one at a time.",
+        extend("x-group" = "Objects", "x-relevant-when" = serde_json::json!({"field": "print_sequence", "equals": "by_object"}))
+    )]
+    #[serde(default = "SlicingParams::default_extruder_clearance_radius")]
+    pub extruder_clearance_radius_mm: f64,
+
+    #[schemars(
+        description = "Custom G-code inserted between two objects in `by_object` order, after the nozzle has lifted clear and travelled to the next object. `null` = nothing.",
+        extend("x-group" = "Objects", "x-widget" = "gcode", "x-relevant-when" = serde_json::json!({"field": "print_sequence", "equals": "by_object"}))
+    )]
+    #[serde(default, skip_serializing_if = "Option::is_none")]
+    pub between_objects_gcode: Option<String>,
 }
 
 /// Schema helper: emit the full [`SlicingParams`] schema for a
@@ -2004,11 +2080,27 @@ impl Default for SlicingParams {
             thumbnail_color_mode: ThumbnailColorMode::default(),
             thumbnail_custom_color: Self::default_thumbnail_custom_color(),
             thumbnail_png_base64: None,
+            print_sequence: PrintSequence::default(),
+            exclude_object: false,
+            extruder_clearance_height_mm: Self::default_extruder_clearance_height(),
+            extruder_clearance_radius_mm: Self::default_extruder_clearance_radius(),
+            between_objects_gcode: None,
         }
     }
 }
 
 impl SlicingParams {
+    /// Does this configuration need the plate sliced **object by object**?
+    ///
+    /// Object identity survives slicing only when something downstream needs
+    /// it: firmware object markers ([`Self::exclude_object`]) or sequential
+    /// printing ([`Self::print_sequence`]). When neither is on, the plate is
+    /// merged into one mesh and sliced exactly as it always was, so the default
+    /// configuration produces byte-identical G-code.
+    pub fn object_aware(&self) -> bool {
+        self.exclude_object || self.print_sequence == PrintSequence::ByObject
+    }
+
     /// Serialize these params into a stable string for the G-code content cache
     /// key, **excluding the ephemeral thumbnail image payload**
     /// (`thumbnail_png_base64`).
@@ -2026,16 +2118,37 @@ impl SlicingParams {
     ///
     /// See the "G-code result cache" contract in AGENTS.md.
     pub fn cache_fingerprint(&self) -> String {
-        let mut value = serde_json::to_value(self).unwrap_or(serde_json::Value::Null);
-        if let Some(obj) = value.as_object_mut() {
-            obj.remove("thumbnail_png_base64");
-        }
-        value.to_string()
+        let value = serde_json::to_value(self).unwrap_or(serde_json::Value::Null);
+        let Some(object) = value.as_object() else {
+            return value.to_string();
+        };
+        // Rebuild the map instead of `Map::remove`: with serde_json's
+        // preserve-order backing, removing a key that is not the last one
+        // *swaps the last entry into its slot*, so the surviving fields would
+        // be ordered differently depending on whether the thumbnail was
+        // present — two identical requests, two different cache keys.
+        let filtered: serde_json::Map<String, serde_json::Value> = object
+            .iter()
+            .filter(|(key, _)| key.as_str() != "thumbnail_png_base64")
+            .map(|(key, value)| (key.clone(), value.clone()))
+            .collect();
+        serde_json::Value::Object(filtered).to_string()
     }
 
     fn default_first_layer_height() -> f64 {
         0.0
     }
+    /// Typical FFF gantry clearance — a 25 mm tall part passes under most
+    /// X-carriages. Matches PrusaSlicer's `extruder_clearance_height` default.
+    fn default_extruder_clearance_height() -> f64 {
+        25.0
+    }
+    /// Radius swept by the hotend and its fan duct. Matches PrusaSlicer's
+    /// `extruder_clearance_radius` default.
+    fn default_extruder_clearance_radius() -> f64 {
+        45.0
+    }
+
     fn default_line_width() -> f64 {
         0.0
     }

--- a/src/settings/params.rs
+++ b/src/settings/params.rs
@@ -1914,15 +1914,15 @@ Caps print speed so the hotend can keep up with the flow.
     pub exclude_object: bool,
 
     #[schemars(
-        description = "Height in mm below which the gantry/X-carriage clears an already-printed object. Objects taller than this cannot be safely printed before another one in `by_object` order.",
-        extend("x-group" = "Objects", "x-relevant-when" = serde_json::json!({"field": "print_sequence", "equals": "by_object"}))
+        description = "Gantry/X-carriage clearance height in mm: an object shorter than this passes under the moving gantry. A machine property. Used by sequential (`by_object`) printing to warn when a part is too tall to print before another.",
+        extend("x-group" = "Hardware")
     )]
     #[serde(default = "SlicingParams::default_extruder_clearance_height")]
     pub extruder_clearance_height_mm: f64,
 
     #[schemars(
-        description = "Radius in mm around the nozzle that the hotend/fan duct sweeps. Objects closer together than this cannot be safely printed one at a time.",
-        extend("x-group" = "Objects", "x-relevant-when" = serde_json::json!({"field": "print_sequence", "equals": "by_object"}))
+        description = "Radius in mm the hotend and its fan duct sweep around the nozzle. A machine property. Used by sequential (`by_object`) printing to warn when two parts are too close to print one at a time.",
+        extend("x-group" = "Hardware")
     )]
     #[serde(default = "SlicingParams::default_extruder_clearance_radius")]
     pub extruder_clearance_radius_mm: f64,

--- a/src/ws_protocol.rs
+++ b/src/ws_protocol.rs
@@ -306,6 +306,15 @@ pub enum ServerMessage {
         /// Elapsed time in milliseconds. Only present when `event` is `"end"`.
         #[serde(skip_serializing_if = "Option::is_none")]
         elapsed_ms: Option<u64>,
+        /// 1-based index of the object this phase belongs to, on a plate sliced
+        /// object-by-object. Absent for a single merged slice.
+        #[serde(skip_serializing_if = "Option::is_none")]
+        object: Option<u32>,
+        /// Total number of objects being sliced individually. Absent for a
+        /// single merged slice. Lets the UI show "(2 of 3)" and keep progress
+        /// moving forward across per-object pipeline restarts.
+        #[serde(skip_serializing_if = "Option::is_none")]
+        object_count: Option<u32>,
     },
     /// Incremental slicing progress.
     Progress {

--- a/ui-desktop/src-tauri/src/bridge/runtime_bridge.rs
+++ b/ui-desktop/src-tauri/src/bridge/runtime_bridge.rs
@@ -168,15 +168,25 @@ pub async fn slice_start(
         }
 
         logger.log_info(&format!("slicing {} faces\u{2026}", combined.faces.len()));
-        let layers = slicer_engine::core::process_mesh(&combined, &params, &logger);
-        logger.log_info(&format!("{} layers produced", layers.len()));
+        // One object per plate here (see `bake_scene`), but it still goes
+        // through `slice_plate` so the desktop honours exclude-object exactly
+        // like the CLI and the server.
+        let object_name = original_filename
+            .clone()
+            .unwrap_or_else(|| "object".to_string());
+        let plate = slicer_engine::core::slice_plate(
+            &[slicer_engine::core::ObjectInput::new(object_name, combined)],
+            &params,
+            &logger,
+        );
+        logger.log_info(&format!("{} layers produced", plate.layers.len()));
 
         if cancel_flag.load(Ordering::SeqCst) {
             return Err("Slice cancelled by user".to_string());
         }
 
-        let gcode = slicer_engine::gcode::generate_gcode_from_params(&layers, &params);
-        let layer_count = layers.len();
+        let gcode = slicer_engine::gcode::generate_gcode_for_plate(&plate, &params);
+        let layer_count = plate.layers.len();
         logger.log_info(&format!("GCode generated ({} chars)", gcode.len()));
 
         // Write GCode to the app cache directory. This avoids returning a

--- a/ui/src/app/models/setting-contract.ts
+++ b/ui/src/app/models/setting-contract.ts
@@ -64,6 +64,7 @@ export const SETTING_CONTRACTS: readonly SettingContract[] = [
       'Quality',
       'Surfaces',
       'Adhesion',
+      'Objects',
       'Thumbnail',
       'Mesh',
     ],
@@ -91,6 +92,7 @@ export const GROUP_ICONS: Record<string, string> = {
   Extrusion: 'extrude',
   Support: 'view-structure-down',
   Adhesion: 'magnet-energy',
+  Objects: 'packages',
   Thumbnail: 'media-image',
 };
 

--- a/ui/src/app/nexus/slice-control/slice-control.ts
+++ b/ui/src/app/nexus/slice-control/slice-control.ts
@@ -12,7 +12,7 @@ import { GcodePreview } from '../../services/gcode-preview';
 import { PrinterConnectionService } from '../../services/printer-connection';
 import { ActiveSelection } from '../../services/profiles/active-selection';
 import { BrowserStorage } from '../../services/browser-storage';
-import { formatDuration, PHASE_LABELS, Slicer } from '../../services/slicer';
+import { formatDuration, Slicer } from '../../services/slicer';
 import { FloatingService } from '../../shared/floating';
 import type { FloatingRef } from '../../shared/floating';
 import { Icon } from '../../shared/icon/icon';
@@ -108,8 +108,7 @@ export class SliceControl {
     if (s === 'error') return 'Slice failed — check the status panel';
     if (s === 'uploading') return 'Uploading model…';
     if (s === 'slicing') {
-      const phase = this.slicer.currentPhase();
-      return phase ? (PHASE_LABELS[phase] ?? phase) : 'Preparing…';
+      return this.slicer.currentPhaseLabel() ?? 'Preparing…';
     }
     if (this.isStale()) return 'Scene changed — re-slice to update';
     if (s === 'done') {

--- a/ui/src/app/runtime/adapters/cloud/cloud-runtime.ts
+++ b/ui/src/app/runtime/adapters/cloud/cloud-runtime.ts
@@ -280,6 +280,8 @@ export class CloudRuntime implements RuntimePort {
             type: 'phase-start',
             sliceId: this.pendingSliceId,
             phase: msg.phase,
+            object: msg.object ?? undefined,
+            objectCount: msg.object_count ?? undefined,
           });
         }
         if (msg.event === 'end') {
@@ -288,6 +290,8 @@ export class CloudRuntime implements RuntimePort {
             sliceId: this.pendingSliceId,
             phase: msg.phase,
             elapsedMs: msg.elapsed_ms ?? undefined,
+            object: msg.object ?? undefined,
+            objectCount: msg.object_count ?? undefined,
           });
         }
         break;

--- a/ui/src/app/runtime/adapters/web/slicer-worker-protocol.ts
+++ b/ui/src/app/runtime/adapters/web/slicer-worker-protocol.ts
@@ -26,14 +26,30 @@ export type SlicerWorkerRequest =
 
 export type WasmSliceEvent =
   | { type: 'log'; level: 'debug' | 'info' | 'warn' | 'error'; message: string }
-  | { type: 'phase'; phase: string; event: 'start' | 'end'; elapsed_ms?: number }
+  | {
+      type: 'phase';
+      phase: string;
+      event: 'start' | 'end';
+      elapsed_ms?: number;
+      /** 1-based object index when slicing a plate object-by-object. */
+      object?: number;
+      /** Total objects sliced individually. */
+      object_count?: number;
+    }
   | { type: 'progress'; current_layer: number; total_layers: number };
 
 export type SlicerWorkerResponse =
   | { type: 'ready' }
   | { type: 'log'; sliceId?: string; level: 'debug' | 'info' | 'warn' | 'error'; message: string }
-  | { type: 'phase-start'; sliceId: string; phase: string }
-  | { type: 'phase-end'; sliceId: string; phase: string; elapsedMs?: number }
+  | { type: 'phase-start'; sliceId: string; phase: string; object?: number; objectCount?: number }
+  | {
+      type: 'phase-end';
+      sliceId: string;
+      phase: string;
+      elapsedMs?: number;
+      object?: number;
+      objectCount?: number;
+    }
   | { type: 'progress'; sliceId: string; currentLayer: number; totalLayers: number }
   | { type: 'slice-complete'; sliceId: string; layerCount: number; gcode: string }
   | { type: 'error'; sliceId?: string; message: string };

--- a/ui/src/app/runtime/adapters/web/slicer.worker.ts
+++ b/ui/src/app/runtime/adapters/web/slicer.worker.ts
@@ -153,9 +153,9 @@ function forwardWasmEvent(sliceId: string, event: WasmSliceEvent): void {
       break;
     case 'phase':
       if (event.event === 'start') {
-        emitPhaseStart(sliceId, event.phase);
+        emitPhaseStart(sliceId, event.phase, event.object, event.object_count);
       } else {
-        emitPhaseEnd(sliceId, event.phase, event.elapsed_ms ?? 0);
+        emitPhaseEnd(sliceId, event.phase, event.elapsed_ms ?? 0, event.object, event.object_count);
       }
       break;
     case 'progress':
@@ -169,12 +169,23 @@ function forwardWasmEvent(sliceId: string, event: WasmSliceEvent): void {
   }
 }
 
-function emitPhaseStart(sliceId: string, phase: string): void {
-  self.postMessage({ type: 'phase-start', sliceId, phase });
+function emitPhaseStart(
+  sliceId: string,
+  phase: string,
+  object?: number,
+  objectCount?: number,
+): void {
+  self.postMessage({ type: 'phase-start', sliceId, phase, object, objectCount });
 }
 
-function emitPhaseEnd(sliceId: string, phase: string, elapsedMs: number): void {
-  self.postMessage({ type: 'phase-end', sliceId, phase, elapsedMs });
+function emitPhaseEnd(
+  sliceId: string,
+  phase: string,
+  elapsedMs: number,
+  object?: number,
+  objectCount?: number,
+): void {
+  self.postMessage({ type: 'phase-end', sliceId, phase, elapsedMs, object, objectCount });
 }
 
 function elapsedSince(start: number): number {

--- a/ui/src/app/runtime/adapters/web/wasm-runtime.ts
+++ b/ui/src/app/runtime/adapters/web/wasm-runtime.ts
@@ -288,7 +288,13 @@ export class WasmRuntime implements RuntimePort {
         });
         break;
       case 'phase-start':
-        this.bus.emit({ type: 'phase-start', sliceId: message.sliceId, phase: message.phase });
+        this.bus.emit({
+          type: 'phase-start',
+          sliceId: message.sliceId,
+          phase: message.phase,
+          object: message.object,
+          objectCount: message.objectCount,
+        });
         break;
       case 'phase-end':
         this.bus.emit({
@@ -296,6 +302,8 @@ export class WasmRuntime implements RuntimePort {
           sliceId: message.sliceId,
           phase: message.phase,
           elapsedMs: message.elapsedMs,
+          object: message.object,
+          objectCount: message.objectCount,
         });
         break;
       case 'progress':

--- a/ui/src/app/runtime/ports/runtime-events.ts
+++ b/ui/src/app/runtime/ports/runtime-events.ts
@@ -2,8 +2,15 @@ import { RuntimeError } from './runtime-errors';
 
 export type RuntimeEvent =
   | { type: 'connected'; mode: 'native' | 'cloud' | 'web'; serverVersion?: string }
-  | { type: 'phase-start'; sliceId: string; phase: string }
-  | { type: 'phase-end'; sliceId: string; phase: string; elapsedMs?: number }
+  | { type: 'phase-start'; sliceId: string; phase: string; object?: number; objectCount?: number }
+  | {
+      type: 'phase-end';
+      sliceId: string;
+      phase: string;
+      elapsedMs?: number;
+      object?: number;
+      objectCount?: number;
+    }
   | { type: 'progress'; sliceId: string; currentLayer: number; totalLayers: number }
   | { type: 'log'; level: 'debug' | 'info' | 'warn' | 'error'; message: string }
   | { type: 'slice-complete'; sliceId: string; layerCount: number; downloadUrl?: string }

--- a/ui/src/app/schema-form/field-exceptions/field-exceptions.spec.ts
+++ b/ui/src/app/schema-form/field-exceptions/field-exceptions.spec.ts
@@ -1,0 +1,39 @@
+import { describe, expect, it } from 'vitest';
+import { noticeForField } from './field-exceptions';
+import type { FieldDef } from '../models/field-def';
+
+/**
+ * The field notices are the "transparent and honest" layer: a control whose
+ * effect depends on something the user cannot see from here gets a caution and
+ * a link to where that something lives. These pin the two that matter — a raft
+ * changing the preview, and sequential printing depending on the printer — so a
+ * refactor of the exceptions map cannot quietly drop them.
+ */
+function field(key: string): FieldDef {
+  return { key, type: 'string', required: false };
+}
+
+describe('noticeForField', () => {
+  it('warns and links to printer settings when sequential printing is chosen', () => {
+    const notice = noticeForField(field('print_sequence'), 'by_object');
+    expect(notice).not.toBeNull();
+    expect(notice?.tone).toBe('warning');
+    expect(notice?.link?.routerLink).toBe('/settings/printers');
+    // The message must name the actual failure mode, not just say "be careful".
+    expect(notice?.text).toMatch(/clearance/i);
+  });
+
+  it('stays silent for layer-by-layer printing', () => {
+    expect(noticeForField(field('print_sequence'), 'by_layer')).toBeNull();
+  });
+
+  it('warns that a raft shifts the preview', () => {
+    const notice = noticeForField(field('adhesion_type'), 'raft');
+    expect(notice?.tone).toBe('warning');
+    expect(notice?.link).toBeUndefined();
+  });
+
+  it('returns null for a field with no exception', () => {
+    expect(noticeForField(field('layer_height'), 0.2)).toBeNull();
+  });
+});

--- a/ui/src/app/schema-form/field-exceptions/field-exceptions.ts
+++ b/ui/src/app/schema-form/field-exceptions/field-exceptions.ts
@@ -2,6 +2,18 @@ import type { InlineNoticeTone } from '../../ui/inline-notice/inline-notice';
 import type { FieldDef } from '../models/field-def';
 
 /**
+ * An in-app link rendered at the end of a {@link FieldNotice}, for pointing the
+ * user at the place that fixes what the notice is about (e.g. a setting that
+ * lives on a different profile / tab).
+ */
+export interface FieldNoticeLink {
+  /** Visible link text. */
+  text: string;
+  /** Angular router path, e.g. `'/settings/printers'`. */
+  routerLink: string;
+}
+
+/**
  * A contextual notice rendered directly beneath a single field's control.
  */
 export interface FieldNotice {
@@ -13,6 +25,8 @@ export interface FieldNotice {
   title?: string;
   /** Body text. */
   text: string;
+  /** Optional trailing link to wherever the notice can be acted on. */
+  link?: FieldNoticeLink;
 }
 
 /**
@@ -52,6 +66,32 @@ export const FIELD_EXCEPTIONS: Record<string, FieldException> = {
               'A raft prints a sacrificial base under the model and lifts it by the raft ' +
               'height plus the air gap, so the model sits higher in the sliced G-code ' +
               'preview than it does in the object view.',
+          }
+        : null,
+  },
+
+  // Printing objects one at a time is only safe if the printhead can clear
+  // everything already on the bed — which is a property of the *machine*, not
+  // this process. Be honest that the guarantee lives elsewhere and link the
+  // user straight to where the clearances are set, rather than letting them
+  // discover the dependency only when the slicer warns (or the gantry hits a
+  // finished part). See the extruder-clearance settings on the printer profile.
+  print_sequence: {
+    notice: (value) =>
+      value === 'by_object'
+        ? {
+            tone: 'warning',
+            title: 'Sequential printing depends on your printer',
+            text:
+              'Each object is printed to completion before the next begins, so the printhead ' +
+              'must clear every finished part. A part taller than the gantry clearance, or two ' +
+              'parts closer than the extruder-clearance radius, can collide. The slicer warns ' +
+              'you before slicing, but those clearances describe your machine and have to be ' +
+              'set for it first.',
+            link: {
+              text: 'Set extruder clearances in printer settings',
+              routerLink: '/settings/printers',
+            },
           }
         : null,
   },

--- a/ui/src/app/schema-form/field-host/field-host.ts
+++ b/ui/src/app/schema-form/field-host/field-host.ts
@@ -13,6 +13,7 @@ import {
   ViewContainerRef,
 } from '@angular/core';
 import { Subscription } from 'rxjs';
+import { RouterLink } from '@angular/router';
 import { InlineNotice } from '../../ui/inline-notice/inline-notice';
 import { noticeForField } from '../field-exceptions/field-exceptions';
 import { resolveWidget } from '../field-registry/field-registry';
@@ -33,7 +34,7 @@ import { FieldWidget } from '../widgets/base-field';
 @Component({
   selector: 'se-field-host',
   standalone: true,
-  imports: [InlineNotice],
+  imports: [InlineNotice, RouterLink],
   changeDetection: ChangeDetectionStrategy.OnPush,
   template: `
     <ng-container #host />
@@ -45,12 +46,32 @@ import { FieldWidget } from '../widgets/base-field';
         [title]="n.title"
       >
         {{ n.text }}
+        @if (n.link; as link) {
+          <a class="field-notice-link" [routerLink]="link.routerLink">{{ link.text }}</a>
+        }
       </nexus-inline-notice>
     }
   `,
   styles: `
     .field-notice {
       margin-top: var(--spacing-sm);
+    }
+
+    .field-notice-link {
+      display: inline-block;
+      margin-top: 2px;
+      color: var(--accent);
+      text-decoration: none;
+
+      &:hover {
+        text-decoration: underline;
+      }
+
+      &:focus-visible {
+        outline: 2px solid var(--color-focus-ring);
+        outline-offset: 2px;
+        border-radius: var(--radius-sm);
+      }
     }
   `,
 })

--- a/ui/src/app/services/slicer-progress.spec.ts
+++ b/ui/src/app/services/slicer-progress.spec.ts
@@ -1,0 +1,75 @@
+import { describe, expect, it } from 'vitest';
+import { sliceProgressPercent, type ObjectScope, type PhaseTimingData } from './slicer-progress';
+
+/**
+ * The multi-object progress bug: slicing a plate object-by-object runs the whole
+ * pipeline once per object, so a bar summing completed phase weights across all
+ * objects walked *backwards* every time a new object restarted the pipeline.
+ * These pin that (a) a single object is unchanged, (b) progress only ever climbs
+ * as objects and phases complete, and (c) it reaches ~100% at the end.
+ */
+const done = (phase: string, object?: number): PhaseTimingData => ({
+  phase,
+  endTime: 1,
+  elapsedMs: 1,
+  object,
+});
+
+const scope = (current: number, count: number): ObjectScope => ({ current, count });
+
+// A representative slice of the real phase weights (values need not match, only
+// that these keys carry weight in PHASE_WEIGHTS).
+const EARLY = 'slicing';
+const MID = 'wall_generation';
+const LATE = 'gcode_generation';
+
+describe('sliceProgressPercent', () => {
+  it('is 0 before any phase completes', () => {
+    expect(sliceProgressPercent([], scope(1, 1))).toBe(0);
+  });
+
+  it('grows monotonically for a single (merged) slice', () => {
+    const a = sliceProgressPercent([done(EARLY)], scope(1, 1));
+    const b = sliceProgressPercent([done(EARLY), done(MID)], scope(1, 1));
+    const c = sliceProgressPercent([done(EARLY), done(MID), done(LATE)], scope(1, 1));
+    expect(a).toBeGreaterThan(0);
+    expect(b).toBeGreaterThan(a);
+    expect(c).toBeGreaterThan(b);
+  });
+
+  it('never goes backwards when a second object restarts the pipeline', () => {
+    // Object 1 finished several phases…
+    const object1Mid = [done(EARLY, 1), done(MID, 1), done(LATE, 1)];
+    const atObject1 = sliceProgressPercent(object1Mid, scope(1, 2));
+
+    // …then object 2 begins: its own phases are back to zero, but the scope
+    // advanced. Progress must be at least where object 1 left off, not reset.
+    const atObject2Start = sliceProgressPercent(object1Mid, scope(2, 2));
+    expect(atObject2Start).toBeGreaterThanOrEqual(atObject1);
+
+    // And it keeps climbing as object 2's phases complete.
+    const atObject2Mid = sliceProgressPercent(
+      [...object1Mid, done(EARLY, 2), done(MID, 2)],
+      scope(2, 2),
+    );
+    expect(atObject2Mid).toBeGreaterThan(atObject2Start);
+  });
+
+  it('only counts the current object, so object 2 does not double-count object 1', () => {
+    const object1Done = [done(EARLY, 1), done(MID, 1), done(LATE, 1)];
+    // At the very start of object 2, only object 1 is fully done → ~50% of a
+    // two-object plate, regardless of how many phases object 1 logged.
+    const pct = sliceProgressPercent(object1Done, scope(2, 2));
+    expect(pct).toBeGreaterThanOrEqual(45);
+    expect(pct).toBeLessThanOrEqual(55);
+  });
+
+  it('reaches past the halfway plateau once the last object is doing work', () => {
+    const object1 = [done(EARLY, 1), done(MID, 1), done(LATE, 1)];
+    const object2 = [done(EARLY, 2), done(MID, 2), done(LATE, 2)];
+    const pct = sliceProgressPercent([...object1, ...object2], scope(2, 2));
+    // The representative phases are a subset of the full weight table, so this
+    // won't hit exactly 100; assert it is comfortably past the object-1 plateau.
+    expect(pct).toBeGreaterThan(50);
+  });
+});

--- a/ui/src/app/services/slicer-progress.ts
+++ b/ui/src/app/services/slicer-progress.ts
@@ -1,0 +1,78 @@
+/**
+ * Pure, dependency-free slice-progress math — kept out of `slicer.ts` so it can
+ * be unit-tested without dragging in Angular or the runtime environment (which
+ * touches `window`).
+ */
+
+/** One pipeline phase's timing, optionally scoped to an object on the plate. */
+export interface PhaseTimingData {
+  phase: string;
+  startTime?: number;
+  endTime?: number;
+  elapsedMs?: number;
+  /**
+   * 1-based object this phase belongs to on a plate sliced object-by-object.
+   * Undefined for a single merged slice. Timings are keyed by (phase, object)
+   * so object 2 restarting a phase never overwrites object 1's completed entry.
+   */
+  object?: number;
+}
+
+/** Object scope of the current slice: which object of how many is running. */
+export interface ObjectScope {
+  current: number;
+  count: number;
+}
+
+/**
+ * Proportional weights per phase derived from typical Benchy timings.
+ * `total` is the outer span and excluded from progress accumulation.
+ */
+export const PHASE_WEIGHTS: Record<string, number> = {
+  mesh_load: 6,
+  mesh_analysis: 1,
+  slicing: 46,
+  wall_generation: 11,
+  infill_region_snapshot: 4,
+  wall_restrictions: 7,
+  interior_regions: 4,
+  surfaces: 8,
+  infill: 2,
+  gcode_generation: 13,
+  file_write: 1,
+};
+
+export const PHASE_TOTAL_WEIGHT = Object.values(PHASE_WEIGHTS).reduce((a, b) => a + b, 0);
+
+/**
+ * Weighted slice progress (0–100) for a set of phase timings and the current
+ * object scope.
+ *
+ * On a plate sliced object-by-object the pipeline runs once per object, so the
+ * result is the fraction of objects already finished plus the weighted fraction
+ * of the *current* object's completed phases — never the raw cross-object sum,
+ * which jumps backwards each time a new object restarts the pipeline. A merged
+ * slice (`count === 1`) reduces to the plain weighted fraction.
+ */
+export function sliceProgressPercent(timings: PhaseTimingData[], scope: ObjectScope): number {
+  const { current, count } = scope;
+  const objects = Math.max(1, count);
+
+  let completedWeight = 0;
+  for (const t of timings) {
+    const belongsToCurrent = (t.object ?? current) === current;
+    if (
+      t.endTime != null &&
+      t.phase !== 'total' &&
+      PHASE_WEIGHTS[t.phase] != null &&
+      belongsToCurrent
+    ) {
+      completedWeight += PHASE_WEIGHTS[t.phase];
+    }
+  }
+
+  const withinObject = completedWeight / PHASE_TOTAL_WEIGHT; // 0..1
+  const objectsDone = Math.max(0, current - 1);
+  const fraction = (objectsDone + withinObject) / objects;
+  return Math.round(fraction * 100);
+}

--- a/ui/src/app/services/slicer.ts
+++ b/ui/src/app/services/slicer.ts
@@ -564,6 +564,8 @@ export class Slicer {
     // Reset phase state for fresh run
     this.phaseTimings.set([]);
     this.currentPhase.set(null);
+    this.objectScope.set({ current: 1, count: 1 });
+    this.progressFloor.set(0);
     this.lastSliceElapsedMs.set(null);
     this.sliceStartedAt = null;
     this.setDownloadUrl(null);

--- a/ui/src/app/services/slicer.ts
+++ b/ui/src/app/services/slicer.ts
@@ -25,6 +25,7 @@ import {
   type ThumbnailView,
 } from './viewer-control';
 import { WorkplateNames } from './workplate-names';
+import { sliceProgressPercent, type ObjectScope, type PhaseTimingData } from './slicer-progress';
 
 /** Human-readable label for each pipeline phase. */
 export const PHASE_LABELS: Record<string, string> = {
@@ -65,33 +66,12 @@ export function formatDuration(ms: number): string {
  * Proportional weights per phase derived from typical Benchy timings.
  * `total` is the outer span and excluded from progress accumulation.
  */
-const PHASE_WEIGHTS: Record<string, number> = {
-  mesh_load: 6,
-  mesh_analysis: 1,
-  slicing: 46,
-  wall_generation: 11,
-  infill_region_snapshot: 4,
-  wall_restrictions: 7,
-  interior_regions: 4,
-  surfaces: 8,
-  infill: 2,
-  gcode_generation: 13,
-  file_write: 1,
-};
-const PHASE_TOTAL_WEIGHT = Object.values(PHASE_WEIGHTS).reduce((a, b) => a + b, 0);
 
 /** Maximum time (ms) to wait for a slice operation before timing out. */
 const SLICE_TIMEOUT_MS = 30 * 60 * 1000; // 30 minutes
 const DEFAULT_THUMBNAIL_SIZE_PX = 320;
 
 export type SlicerStatus = 'idle' | 'ready' | 'uploading' | 'slicing' | 'done' | 'error';
-
-export interface PhaseTimingData {
-  phase: string;
-  startTime?: number;
-  endTime?: number;
-  elapsedMs?: number;
-}
 
 export interface WorkplateStart {
   requestUuid: string;
@@ -206,6 +186,28 @@ export class Slicer {
 
   /** Name of the pipeline phase currently executing, or `null` when idle. */
   readonly currentPhase = signal<string | null>(null);
+
+  /**
+   * Object scope of the running slice. `{ current: 1, count: 1 }` for a single
+   * merged slice; on a plate sliced object-by-object the engine reports which
+   * object of how many each phase belongs to.
+   */
+  readonly objectScope = signal<ObjectScope>({ current: 1, count: 1 });
+
+  /**
+   * Phase label for the status line, suffixed with "(i of N)" while a
+   * multi-object plate is being sliced object-by-object so the user sees the
+   * pipeline advance through each part instead of the same phase name
+   * apparently repeating.
+   */
+  readonly currentPhaseLabel = computed(() => {
+    const phase = this.currentPhase();
+    if (!phase) return null;
+    const label = PHASE_LABELS[phase] ?? phase;
+    const { current, count } = this.objectScope();
+    return count > 1 ? `${label} (${current} of ${count})` : label;
+  });
+
   private objectUrl: string | null = null;
 
   /**
@@ -221,24 +223,29 @@ export class Slicer {
    * Overall slice progress 0–100.
    *
    * - When `status === 'done'`, always returns 100.
-   * - Each phase has a known proportional weight. Completed phases (those with
-   *   an `endTime`) are stacked in order; their cumulative weight over the
-   *   total determines the percentage.
+   * - Each phase has a known proportional weight. On a plate sliced
+   *   object-by-object the pipeline runs once per object, so progress is the
+   *   fraction of objects already finished plus the weighted fraction of the
+   *   current object's phases — never the raw sum, which would jump backwards
+   *   every time a new object restarts the pipeline.
+   * - Wrapped in a monotonic floor ({@link progressFloor}) so a late-arriving
+   *   or out-of-order marker can never make the bar retreat mid-slice.
    * - Capped at 99 until `SliceComplete` arrives to avoid a premature 100%.
    */
+  private readonly progressCandidate = computed(() =>
+    sliceProgressPercent(this.phaseTimings(), this.objectScope()),
+  );
+
+  /**
+   * High-water mark of {@link progressCandidate} for the running slice, reset
+   * to 0 when the slice state is cleared. This is what guarantees the bar only
+   * ever moves forward, whatever order the phase markers arrive in.
+   */
+  private readonly progressFloor = signal(0);
+
   readonly sliceProgress = computed(() => {
     if (this.status() === 'done') return 100;
-
-    const timings = this.phaseTimings();
-    let completedWeight = 0;
-
-    for (const t of timings) {
-      if (t.endTime != null && t.phase !== 'total' && PHASE_WEIGHTS[t.phase] != null) {
-        completedWeight += PHASE_WEIGHTS[t.phase];
-      }
-    }
-
-    return Math.min(99, Math.round((completedWeight / PHASE_TOTAL_WEIGHT) * 100));
+    return Math.min(99, Math.max(this.progressCandidate(), this.progressFloor()));
   });
 
   /**
@@ -266,6 +273,18 @@ export class Slicer {
 
   constructor() {
     this.orchestrator.onEvent((event) => this.handleRuntimeEvent(event));
+
+    // Raise the monotonic progress floor whenever the candidate advances, so
+    // the bar never retreats even as the per-object pipeline restarts.
+    effect(() => {
+      const candidate = this.progressCandidate();
+      untracked(() => {
+        if (candidate > this.progressFloor()) {
+          this.progressFloor.set(candidate);
+        }
+      });
+    });
+
     this.orchestrator.init().catch((error) => {
       this.runtimeConnected.set(false);
       this.status.set('error');
@@ -303,8 +322,20 @@ export class Slicer {
     phase: string;
     event: string;
     elapsed_ms?: number | null;
+    object?: number | null;
+    objectCount?: number | null;
   }): void {
     const now = Date.now();
+    const object = msg.object ?? undefined;
+
+    // Adopt the object scope reported alongside the marker. A merged slice
+    // reports none, which resolves to the default single-object scope.
+    if (msg.objectCount != null && msg.objectCount > 0) {
+      this.objectScope.set({ current: msg.object ?? 1, count: msg.objectCount });
+    }
+
+    const sameEntry = (t: PhaseTimingData): boolean =>
+      t.phase === msg.phase && (t.object ?? undefined) === object;
 
     if (msg.event === 'start') {
       // Phase started - track as the current active phase and add timing entry
@@ -312,21 +343,21 @@ export class Slicer {
         this.currentPhase.set(msg.phase);
       }
       this.phaseTimings.update((timings) => {
-        const existing = timings.find((t) => t.phase === msg.phase);
+        const existing = timings.find(sameEntry);
         if (existing) {
           existing.startTime = now;
           existing.endTime = undefined;
           existing.elapsedMs = undefined;
           return [...timings];
         } else {
-          return [...timings, { phase: msg.phase, startTime: now }];
+          return [...timings, { phase: msg.phase, startTime: now, object }];
         }
       });
       this.outputLog.update((l) => [...l, `[phase] ${msg.phase} → start`]);
     } else if (msg.event === 'end' && msg.elapsed_ms != null) {
       // Phase ended - update with elapsed time
       this.phaseTimings.update((timings) => {
-        const existing = timings.find((t) => t.phase === msg.phase);
+        const existing = timings.find(sameEntry);
         if (existing) {
           existing.endTime = now;
           existing.elapsedMs = msg.elapsed_ms ?? undefined;
@@ -335,7 +366,7 @@ export class Slicer {
           // Phase end without start (shouldn't happen, but handle it)
           return [
             ...timings,
-            { phase: msg.phase, endTime: now, elapsedMs: msg.elapsed_ms ?? undefined },
+            { phase: msg.phase, endTime: now, elapsedMs: msg.elapsed_ms ?? undefined, object },
           ];
         }
       });
@@ -358,13 +389,20 @@ export class Slicer {
         this.outputLog.update((log) => [...log, `[${event.level}] ${event.message}`]);
         break;
       case 'phase-start':
-        this.handlePhaseMarker({ phase: event.phase, event: 'start' });
+        this.handlePhaseMarker({
+          phase: event.phase,
+          event: 'start',
+          object: event.object ?? null,
+          objectCount: event.objectCount ?? null,
+        });
         break;
       case 'phase-end':
         this.handlePhaseMarker({
           phase: event.phase,
           event: 'end',
           elapsed_ms: event.elapsedMs ?? null,
+          object: event.object ?? null,
+          objectCount: event.objectCount ?? null,
         });
         break;
       case 'progress':
@@ -685,6 +723,8 @@ export class Slicer {
     this.outputLog.set([]);
     this.phaseTimings.set([]);
     this.currentPhase.set(null);
+    this.objectScope.set({ current: 1, count: 1 });
+    this.progressFloor.set(0);
     this.sliceStartedAt = null;
     this.lastSliceElapsedMs.set(null);
     this.setDownloadUrl(null);


### PR DESCRIPTION
Follow-up to the multi-object workplate work. That change made a workplate hold several objects; this one makes the **slicer** keep track of which one is which — and spends that on the two features that need it: cancelling one object mid-print, and printing objects one at a time.

## The problem

The scene engine tracks discrete objects, but they were merged into a single mesh before slicing. By the time layers existed, every trace of "which part is this?" was gone — so a plate was one indivisible print. If one part failed halfway through a six-hour job, the whole plate died with it.

Cancelling one object mid-print and printing objects sequentially are usually treated as separate features. They are not: both need exactly one thing — per-object identity surviving the pipeline — so it is built once, in [`src/core/objects.rs`](src/core/objects.rs).

## `slice_plate` is the single entry point

Four runtimes were each concatenating faces and calling `process_mesh` themselves — the CLI, the WS server, the wasm `web-slicer` and the Tauri desktop bridge. All four now hand `slice_plate` a list of placed objects and let it decide.

**The merged fast path is not optional.** With neither feature on, `slice_plate` merges and calls `process_mesh` exactly as before, so the default configuration produces **byte-identical G-code**. Object-aware slicing runs the pipeline once *per object*, which is **not** output-equivalent: `calculate_interior_region` averages the wall-bead count across a layer's islands, so an island's interior estimate depends on what else shares its layer. Slicing a part alone is the more faithful result, but it is still a change and must only happen when the user asked for a feature that requires it. `merged_path_matches_a_plain_process_mesh` pins it.

Three details that are easy to get wrong:

- **Adhesion belongs to the plate, not the part.** In `by_layer` order the skirt/brim is generated **once on the merged stack** and tagged as belonging to no object — cancelling one part must not take the plate's skirt with it. In `by_object` order each object is a self-contained print and owns its own.
- **Layers merge by Z *slot*, not by index.** Two parts resting on the bed slice onto the same grid, but a part lifted off it keeps its own — its bottom layers are *its* bottom layers, not the plate's. Emitted Z is always strictly ascending.
- **`SliceLayer::path_objects` follows the `path_overhang` sentinel convention** — empty means "not sliced object-aware", `None` means "belongs to no object". Every helper that rebuilds a layer's parallel arrays (notably `adhesion::prepend`) carries it, or tags silently shift onto the wrong paths.

## Exclude object

Three new `GcodeDialect` methods. The **defaults implement `M486`** — the RepRap standard understood by Marlin 2.0.9.3+, RepRapFirmware and Prusa — and `KlipperDialect` overrides them with `EXCLUDE_OBJECT_*`, which also carries the footprint so the firmware knows *where* a cancelled object lives:

```gcode
EXCLUDE_OBJECT_DEFINE RESET=1
EXCLUDE_OBJECT_DEFINE NAME=cube_a CENTER=79.500,110.000 POLYGON=[[79.000,109.500],…]
…
EXCLUDE_OBJECT_START NAME=cube_a
…
EXCLUDE_OBJECT_END NAME=cube_a
```

- **Definitions precede the start script.** Klipper's `[exclude_object]` module and Moonraker both expect to meet every object before the print begins, so Mainsail/Fluidd can list the plate's parts the moment the file loads.
- **The marker block switches *before* a path's travel**, so the hop between two parts is charged to the one it is heading for — the PrusaSlicer/OrcaSlicer convention, and what lets a firmware skip a cancelled object's approach moves along with its extrusions.
- **`M486 A"name"` is spent once per object**; repeating it every layer would bloat the file for nothing.
- **Object names are sanitised and de-duplicated in the engine.** Klipper parses `NAME=` as a G-code parameter, so a space splits the token, and two parts sharing a name would cancel together. Every runtime feeds user-chosen filenames straight in, so this is fixed centrally rather than four times.

## Sequential printing

`print_sequence = by_object` finishes each part before starting the next, **front to back** (`min_y`, then `min_x`) — a cartesian gantry sweeps from behind, so finishing the nearest part first keeps the carriage away from finished work longest.

**The hand-over order is the whole feature**, and it happens before the layer's own Z move: close the marker block → retract → lift above the tallest thing already printed → travel across → `between_objects_gcode`. Doing any of it afterwards lowers the nozzle straight into the part just finished.

Clearance problems are **warnings, not errors** — the clearances are machine estimates, and refusing to slice would be worse than saying what to check:

```
[warn] sequential printing: 'cube_a' and 'cube_b' are 5.0 mm apart, closer than the
       45.0 mm extruder clearance radius — space them further apart
```

Only objects printed *before* another are height-checked; the last one has nothing reaching over it.

**Markers are gated on `exclude_object` alone.** Printing one part at a time is a *motion* choice; firmware object tracking is a separate opt-in and must not ride along with it.

## Spiral vase, sequentially

Two crash-class bugs surfaced in `spiral_vase` × `by_object` during review, both from global layer indices leaking across object boundaries:

- The spiral branch `continue`s past the end-of-layer bookkeeping, so `max_printed_z` never saw a spiral layer — the clearance lift travelled **11 mm below** the finished vase's top — and `current_object` never advanced, re-emitting the whole hand-over before *every* layer of the second object.
- `spiral_start_layer` was a global index, so every object after the first lost its solid base and started spiralling on layer 0, ramping from the **previous object's top down to Z 0.1 while extruding** — a continuous descent straight through the plate.

Both are fixed by counting within each object's own run (`layer_index_in_run`, per-run seam fade), and the ramp start is now clamped to the layer's own Z so "descend while extruding" is unrepresentable regardless of what precedes it.

## Settings

New **Objects** group (schema-driven, so it surfaces in the UI automatically): `print_sequence`, `exclude_object`, `extruder_clearance_height_mm`, `extruder_clearance_radius_mm`, `between_objects_gcode`. CLI gains `--exclude-object` and `--print-sequence by-object`.

## Also fixed

`SlicingParams::cache_fingerprint` used `Map::remove`, which **swap-removes** under serde_json's preserve-order backing. Harmless while `thumbnail_png_base64` happened to be the last field; the moment anything followed it, two identical requests produced two different cache keys. It now rebuilds the map in order.

## Verification

- **712 Rust tests**, `cargo fmt` clean, **clippy clean with `-D warnings`** on all targets, prettier clean.
- **The pinned slicing-quality gate passes with no baseline drift** (`cargo test --release --test slicing_quality -- --ignored`).
- **Default output is unchanged**: a Benchy sliced by this branch vs. `main` differs by 806 diff lines, against **709 for `main` compared with itself** — i.e. entirely the gap-fill run-to-run non-determinism AGENTS.md already documents, not a change from this work.
- **End to end on a real two-Benchy plate**, measuring balanced markers, hand-overs, and any G1 that loses Z while E increases:

  | Configuration | `START`/`END` | Hand-overs | Extruding descents |
  |---|---|---|---|
  | `--exclude-object` | 320 / 320 | 0 | 0 |
  | `--print-sequence by-object` | 0 / 0 | 1 | 0 |
  | `--print-sequence by-object --spiral-vase --exclude-object` | 2 / 2 | 1 | 0 |

  In the sequential runs the lift clears the finished object (`Z48.850` over a `47.850` top), and each vase keeps its own solid base.
