### PR TITLE
ui: undo/redo history buttons on the 3D view toolbar

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -27,6 +27,20 @@ issue/PR numbers or repo links in the notes. See the tone rules in
 
 ## [Unreleased]
 
+### Added
+
+- **Undo / redo buttons in the 3D view** — forward and backward history buttons
+  on the plate toolbar for touch devices where the ⌘/Ctrl+Z shortcut can't be
+  reached. Shown automatically on keyboard-less tablets and phones; force them on
+  or off in Settings → General → Controls. Auto by default.
+
+### Fixed
+
+- **Undo no longer wipes the plate after navigating** — dip into Settings and
+  back, or use the browser's back button, and your objects keep their positions
+  and undo history instead of being deleted by the next undo. History now resets
+  only when the workplate is genuinely replaced.
+
 ## [0.2.0] - 2026-08-30
 
 The build plate grows up. What used to be one model on a plate is now a real

--- a/docs/use/interface.md
+++ b/docs/use/interface.md
@@ -106,6 +106,11 @@ turns into a notification when it's done.
 what you do to the plate — moving, rotating, scaling, adding, deleting,
 arranging.
 
+On a touch device without a keyboard, undo and redo buttons appear in the 3D
+view toolbar so you can step through history without a shortcut. They show up
+automatically on touch tablets and phones; force them on or off any device in
+**Settings → General → Controls**.
+
 Settings and profile edits are **not** undoable. They're saved deliberately, and
 changing a value back is the undo.
 

--- a/docs/use/shortcuts.md
+++ b/docs/use/shortcuts.md
@@ -79,5 +79,9 @@ Hover-scrolling is the fast one — you don't have to click into the field first
 stops moving the camera. Turn it off in **Settings → General** if you don't use
 a pen.
 
+Without a keyboard, undo and redo appear as buttons in the 3D view toolbar
+instead of shortcuts. They show automatically on touch devices; you can force
+them on or off in **Settings → General → Controls**.
+
 On iPad, long-press opens the system action sheet rather than an in-app menu —
 it's the OS's own control, so it behaves the way the rest of iPadOS does.

--- a/ui/src/app/components/3d-view-toolbar/3d-view-toolbar.html
+++ b/ui/src/app/components/3d-view-toolbar/3d-view-toolbar.html
@@ -55,6 +55,33 @@
     </button>
   }
 
+  <!-- Undo / redo as on-canvas buttons for keyboard-less devices, where the
+       ⌘/Ctrl+Z shortcut is unreachable. Visibility is auto-detected but can be
+       forced on or off from Settings → General → Controls. -->
+  @if (showHistoryButtons()) {
+    <button
+      class="reset-view-button"
+      type="button"
+      [disabled]="!canUndo()"
+      [tooltip]="'Undo the last change'"
+      [tooltipShortcut]="keyboardShortcuts.shortcutFor('undo')"
+      (click)="undo()"
+    >
+      <nexus-icon name="undo"></nexus-icon>
+    </button>
+
+    <button
+      class="reset-view-button"
+      type="button"
+      [disabled]="!canRedo()"
+      [tooltip]="'Redo the last undone change'"
+      [tooltipShortcut]="keyboardShortcuts.shortcutFor('redo')"
+      (click)="redo()"
+    >
+      <nexus-icon name="redo"></nexus-icon>
+    </button>
+  }
+
   <!-- Multiple selection so a whole batch of parts can be plated at once. -->
   <input
     #addObjectInput

--- a/ui/src/app/components/3d-view-toolbar/3d-view-toolbar.ts
+++ b/ui/src/app/components/3d-view-toolbar/3d-view-toolbar.ts
@@ -10,8 +10,10 @@ import type { ElementRef } from '@angular/core';
 import { Arrange } from '../../services/arrange';
 import { Dialog } from '../../services/dialog';
 import { GcodePreview } from '../../services/gcode-preview';
+import { HistoryControlsPreference } from '../../services/history-controls-preference';
 import { KeyboardShortcuts } from '../../services/keyboard-shortcuts/keyboard-shortcuts';
 import { NotificationService } from '../../services/notifications';
+import { SceneHistory } from '../../services/scene-history/scene-history';
 import { Slicer } from '../../services/slicer';
 import { ViewerControl } from '../../services/viewer-control';
 import { WorkplateObjects } from '../../services/workplate-objects';
@@ -49,6 +51,8 @@ export class ThreeDViewToolbar {
   private readonly workplate = inject(WorkplateObjects);
   private readonly notifications = inject(NotificationService);
   private readonly arrange = inject(Arrange);
+  private readonly history = inject(SceneHistory);
+  protected readonly historyControls = inject(HistoryControlsPreference);
   protected readonly keyboardShortcuts = inject(KeyboardShortcuts);
 
   private readonly addInput = viewChild<ElementRef<HTMLInputElement>>('addObjectInput');
@@ -65,6 +69,27 @@ export class ThreeDViewToolbar {
    * cannot see — the same reason the objects list hides.
    */
   protected readonly editingPlate = computed(() => this.viewMode() === 'model');
+
+  /**
+   * Whether to show the on-canvas undo/redo buttons. They exist for
+   * keyboard-less devices where the ⌘/Ctrl+Z shortcut is unreachable, so they
+   * only appear while editing the plate and when the history preference allows.
+   */
+  protected readonly showHistoryButtons = computed(
+    () => this.editingPlate() && this.historyControls.visible(),
+  );
+
+  /** Whether stepping back/forward through scene history is possible. */
+  protected readonly canUndo = this.history.canUndo;
+  protected readonly canRedo = this.history.canRedo;
+
+  protected undo(): void {
+    this.history.undo();
+  }
+
+  protected redo(): void {
+    this.history.redo();
+  }
 
   /** True while models are being added, so the button can show progress. */
   protected readonly addingObjects = signal(false);

--- a/ui/src/app/components/viewer/viewer.ts
+++ b/ui/src/app/components/viewer/viewer.ts
@@ -1173,6 +1173,12 @@ export class Viewer {
       this.sceneEngine.apply({ op: 'AutoOrient', args: { id } });
       this.sceneEngine.apply({ op: 'DropToFloor', args: { id } });
     }
+    // A freshly loaded primary model gets brand-new object ids, so any undo
+    // history from a previous load now references objects that no longer
+    // exist. Restoring one of those snapshots would delete this new object
+    // instead of reverting an edit (the "everything vanished after browser
+    // back" bug). Void the history here — the load establishes a new baseline.
+    this.sceneCommand.reset();
     // Build the display node from the engine's object list rather than by
     // hand, so this path and every other add share one code path.
     this.syncWasmMeshes();

--- a/ui/src/app/components/viewer/viewer.ts
+++ b/ui/src/app/components/viewer/viewer.ts
@@ -943,6 +943,20 @@ export class Viewer {
 
     const modelChanged = model !== this.activeModelSource;
 
+    // When the viewer is re-created after navigating away and back to the same
+    // workplate (e.g. dipping into Settings and returning), `activeModelSource`
+    // resets to null so `modelChanged` is true — yet the singleton scene engine
+    // still holds this plate's objects. Recognise that by matching the model's
+    // source id against the engine, so we adopt the existing objects (keeping
+    // their ids — hence the undo/redo history — and their transforms) instead
+    // of evicting and re-parsing them.
+    const sourceId = untracked(() => this.modelSourceId());
+    const reopeningSamePlate =
+      modelChanged &&
+      model !== null &&
+      sourceId != null &&
+      untracked(() => this.sceneEngine.objects()).some((o) => o.source_id === sourceId);
+
     // Always tear down the G-code orchestrator and clear Three.js content —
     // the display layer is rebuilt for every mode/source transition.
     this.gcode?.dispose();
@@ -950,9 +964,10 @@ export class Viewer {
     this.progressSegments.set(0);
     this.errorMessage.set('');
 
-    if (modelChanged) {
-      // New model source — full teardown of WASM engine objects so ids do
-      // not accumulate and the old mesh's transforms are discarded cleanly.
+    if (modelChanged && !reopeningSamePlate) {
+      // New/different model source — full teardown of WASM engine objects so
+      // ids do not accumulate and the old mesh's transforms are discarded
+      // cleanly.
       for (const id of this.trackedObjectIds) {
         this.printArea.forgetObject(id);
         this.objectTracker.remove(id);
@@ -979,6 +994,23 @@ export class Viewer {
       }
       this.handleClearSelection();
       this.dragApplied.clear();
+      // The plate's objects are being replaced with new ids, so the previous
+      // undo/redo history now points at objects that will no longer exist —
+      // restoring one would delete the new plate's objects instead of
+      // reverting an edit. This eviction is the one place identities actually
+      // change, so void the history exactly here.
+      this.sceneCommand.reset();
+      this.activeModelSource = model;
+    } else if (reopeningSamePlate) {
+      // Returning to a plate the engine already holds. Keep its objects (and
+      // the history that references them) intact; only this fresh component's
+      // stale Three.js mirror and selection need clearing before it re-mirrors
+      // the engine below.
+      for (const id of this.wasmMeshes.keys()) {
+        this.scene?.unregisterSelectable(String(id));
+      }
+      this.wasmMeshes.clear();
+      this.handleClearSelection();
       this.activeModelSource = model;
     } else {
       // Mode switch only (e.g. model → gcode → model). The WASM scene engine
@@ -998,10 +1030,10 @@ export class Viewer {
         return;
       }
       // If the WASM engine already holds objects for this source (mode switch,
-      // not a new file), re-render directly from engine state so transforms
-      // are preserved without a second parse round-trip.
+      // or returning to the same plate), re-render directly from engine state
+      // so transforms are preserved without a second parse round-trip.
       const existingObjects = untracked(() => this.sceneEngine.objects());
-      if (!modelChanged && existingObjects.length > 0) {
+      if ((!modelChanged || reopeningSamePlate) && existingObjects.length > 0) {
         void this.rebuildThreeJsMeshes();
       } else {
         this.startModelLoad(model);
@@ -1173,12 +1205,6 @@ export class Viewer {
       this.sceneEngine.apply({ op: 'AutoOrient', args: { id } });
       this.sceneEngine.apply({ op: 'DropToFloor', args: { id } });
     }
-    // A freshly loaded primary model gets brand-new object ids, so any undo
-    // history from a previous load now references objects that no longer
-    // exist. Restoring one of those snapshots would delete this new object
-    // instead of reverting an edit (the "everything vanished after browser
-    // back" bug). Void the history here — the load establishes a new baseline.
-    this.sceneCommand.reset();
     // Build the display node from the engine's object list rather than by
     // hand, so this path and every other add share one code path.
     this.syncWasmMeshes();

--- a/ui/src/app/pages/settings/general.html
+++ b/ui/src/app/pages/settings/general.html
@@ -128,6 +128,45 @@
         </button>
       </div>
     </div>
+
+    <div class="settings-field">
+      <span class="settings-field-label">
+        <span class="settings-field-title">Undo / redo buttons</span>
+        <span class="settings-field-desc">
+          Show forward and backward history buttons in the 3D view toolbar. Auto shows them only on
+          touch devices without a keyboard, where the ⌘/Ctrl+Z shortcut is unavailable.
+        </span>
+      </span>
+      <div class="segmented" role="group" aria-label="Undo and redo buttons">
+        <button
+          type="button"
+          class="segmented-btn"
+          [class.is-active]="historyControls.mode() === 'auto'"
+          [attr.aria-pressed]="historyControls.mode() === 'auto'"
+          (click)="setHistoryControls('auto')"
+        >
+          Auto
+        </button>
+        <button
+          type="button"
+          class="segmented-btn"
+          [class.is-active]="historyControls.mode() === 'always'"
+          [attr.aria-pressed]="historyControls.mode() === 'always'"
+          (click)="setHistoryControls('always')"
+        >
+          Always
+        </button>
+        <button
+          type="button"
+          class="segmented-btn"
+          [class.is-active]="historyControls.mode() === 'never'"
+          [attr.aria-pressed]="historyControls.mode() === 'never'"
+          (click)="setHistoryControls('never')"
+        >
+          Never
+        </button>
+      </div>
+    </div>
   </div>
 
   <h2 class="subhead">Backup &amp; Export</h2>

--- a/ui/src/app/pages/settings/general.ts
+++ b/ui/src/app/pages/settings/general.ts
@@ -12,6 +12,10 @@ import {
 import { ProfileExportButton } from '../../components/profiles/profile-export-button';
 import { resolveRuntimeMode } from '../../runtime/domain/runtime-mode.util';
 import { AppVersion } from '../../services/app-version';
+import {
+  HistoryControlsPreference,
+  type HistoryControlsMode,
+} from '../../services/history-controls-preference';
 import { Button, SectionHeader, Slider } from '@coldcrabby/ui';
 import { FovCube } from '../../ui/fov-cube/fov-cube';
 
@@ -25,6 +29,7 @@ import { FovCube } from '../../ui/fov-cube/fov-cube';
 export class GeneralSettings implements OnInit {
   protected readonly viewer = inject(ViewerControl);
   private readonly appVersion = inject(AppVersion);
+  protected readonly historyControls = inject(HistoryControlsPreference);
   protected readonly gesture = this.viewer.trackpadTwoFingerGesture;
   protected readonly statsVisible = this.viewer.statsVisible;
   protected readonly palmRejection = this.viewer.palmRejection;
@@ -99,5 +104,9 @@ export class GeneralSettings implements OnInit {
 
   setUseFilamentColor(value: boolean): void {
     this.viewer.setUseFilamentColor(value);
+  }
+
+  setHistoryControls(mode: HistoryControlsMode): void {
+    this.historyControls.setMode(mode);
   }
 }

--- a/ui/src/app/services/history-controls-preference.ts
+++ b/ui/src/app/services/history-controls-preference.ts
@@ -58,8 +58,7 @@ export class HistoryControlsPreference {
   constructor() {
     if (typeof window !== 'undefined' && typeof window.matchMedia === 'function') {
       const query = window.matchMedia('(pointer: coarse)');
-      const onChange = (event: MediaQueryListEvent) =>
-        this.coarsePrimaryPointer.set(event.matches);
+      const onChange = (event: MediaQueryListEvent) => this.coarsePrimaryPointer.set(event.matches);
       query.addEventListener('change', onChange);
       inject(DestroyRef).onDestroy(() => query.removeEventListener('change', onChange));
     }

--- a/ui/src/app/services/history-controls-preference.ts
+++ b/ui/src/app/services/history-controls-preference.ts
@@ -1,0 +1,78 @@
+import { computed, DestroyRef, inject, Injectable, signal } from '@angular/core';
+import { BrowserStorage } from './browser-storage';
+
+/**
+ * When the on-canvas undo/redo buttons are shown in the 3D-view toolbar.
+ *
+ * - `auto` — show them only on devices that are unlikely to have a physical
+ *   keyboard (touch-primary tablets and phones), where the ⌘/Ctrl+Z shortcut
+ *   is unreachable. Hidden on desktops/laptops, where the shortcut is faster.
+ * - `always` / `never` — force the buttons on or off regardless of device.
+ */
+export type HistoryControlsMode = 'auto' | 'always' | 'never';
+
+const HISTORY_CONTROLS_KEY = 'general.historyControls';
+
+/**
+ * Owns the app-wide policy for the toolbar's undo/redo buttons.
+ *
+ * Undo and redo already have keyboard shortcuts (⌘/Ctrl+Z and friends), so on a
+ * desktop the on-canvas buttons are redundant. On a keyboard-less touch device
+ * they are the *only* way to step through history, so `auto` reveals them there
+ * and hides them elsewhere. The user can override with `always`/`never`.
+ *
+ * The `auto` detection keys off the primary pointer being coarse
+ * (`(pointer: coarse)`), which is what distinguishes a touch tablet/phone from a
+ * mouse- or trackpad-driven desktop. It is reactive: plugging in or removing a
+ * pointing device flips the media query, and with it the buttons.
+ */
+@Injectable({ providedIn: 'root' })
+export class HistoryControlsPreference {
+  private readonly storage = inject(BrowserStorage);
+  private readonly stored = this.storage.get(HISTORY_CONTROLS_KEY, 'local');
+
+  /**
+   * True when the device is likely keyboard-less — the primary pointer is
+   * coarse (touch), as on an iPad or phone. Reactive to device changes.
+   */
+  private readonly coarsePrimaryPointer = signal(this.detectCoarsePointer());
+
+  /** The user's chosen mode; defaults to `auto`. */
+  readonly mode = computed<HistoryControlsMode>(() => {
+    const raw = this.stored();
+    return raw === 'always' || raw === 'never' || raw === 'auto' ? raw : 'auto';
+  });
+
+  /** Whether the toolbar should currently show the undo/redo buttons. */
+  readonly visible = computed<boolean>(() => {
+    switch (this.mode()) {
+      case 'always':
+        return true;
+      case 'never':
+        return false;
+      default:
+        return this.coarsePrimaryPointer();
+    }
+  });
+
+  constructor() {
+    if (typeof window !== 'undefined' && typeof window.matchMedia === 'function') {
+      const query = window.matchMedia('(pointer: coarse)');
+      const onChange = (event: MediaQueryListEvent) =>
+        this.coarsePrimaryPointer.set(event.matches);
+      query.addEventListener('change', onChange);
+      inject(DestroyRef).onDestroy(() => query.removeEventListener('change', onChange));
+    }
+  }
+
+  setMode(mode: HistoryControlsMode): void {
+    this.storage.write(HISTORY_CONTROLS_KEY, mode, 'local');
+  }
+
+  private detectCoarsePointer(): boolean {
+    if (typeof window === 'undefined' || typeof window.matchMedia !== 'function') {
+      return false;
+    }
+    return window.matchMedia('(pointer: coarse)').matches;
+  }
+}

--- a/ui/src/app/services/scene-command/scene-command.ts
+++ b/ui/src/app/services/scene-command/scene-command.ts
@@ -61,6 +61,24 @@ export class SceneCommand {
     this.commitGesture();
   }
 
+  /**
+   * Abort any in-flight gesture and clear the undo/redo history.
+   *
+   * Called when the scene is torn down (opening a new or empty plate) so that:
+   *
+   * - a pending debounce commit cannot fire afterwards and push a snapshot of
+   *   the *old* plate onto the fresh history, and
+   * - undo never restores objects from a previous plate. Object ids are never
+   *   reused, so a snapshot from the old plate shares no ids with the new one;
+   *   restoring it would remove every new object (as "not in the snapshot")
+   *   rather than revert an edit — silently wiping the freshly loaded model.
+   */
+  reset(): void {
+    this.cancelTimer();
+    this.gestureStart = null;
+    this.history.clear();
+  }
+
   private scheduleCommit(): void {
     this.cancelTimer();
     this.debounceTimer = setTimeout(() => {

--- a/ui/src/app/services/slicer.ts
+++ b/ui/src/app/services/slicer.ts
@@ -14,6 +14,7 @@ import { FileExport } from './file-export';
 import { NotificationService } from './notifications';
 import { ActiveSelection } from './profiles/active-selection';
 import { SceneEngine } from './scene-engine';
+import { SceneCommand } from './scene-command/scene-command';
 import { AppVersion } from './app-version';
 import { ConnectionStatus, SlicerConnection } from './slicer-connection';
 import { SlicerFile, UploadResponse } from './slicer-file';
@@ -84,6 +85,7 @@ export class Slicer {
   private readonly slicerFile = inject(SlicerFile);
   private readonly notifications = inject(NotificationService);
   private readonly sceneEngine = inject(SceneEngine);
+  private readonly sceneCommand = inject(SceneCommand);
   private readonly workplateObjects = inject(WorkplateObjects);
   private readonly activeSelection = inject(ActiveSelection);
   private readonly appVersion = inject(AppVersion);
@@ -752,6 +754,10 @@ export class Slicer {
     this.reset();
     this.workplateObjects.clearPending();
     await this.sceneEngine.clear();
+    // Drop the undo/redo stack with the scene it described: its snapshots
+    // reference objects from the old plate, and undoing across the reset would
+    // delete the new plate's objects instead of reverting an edit.
+    this.sceneCommand.reset();
   }
 
   getHistory(): Promise<RuntimeHistorySession[]> {


### PR DESCRIPTION
## What

Adds forward/backward (undo/redo) history buttons to the top action bar of the main scene, aimed at devices without a physical keyboard — plus two related history-integrity fixes found while testing.

### Feature
- **New buttons** in the 3D view toolbar wired to the existing `SceneHistory` service. Disabled when there's nothing to undo/redo; tooltips carry the ⌘/Ctrl shortcut.
- **Auto-detection**: a new `HistoryControlsPreference` resolves visibility from `(pointer: coarse)` — shown on touch tablets/phones, hidden on mouse/trackpad desktops. Reactive to attaching/removing a pointing device.
- **Override**: a three-way *Auto / Always / Never* control under **Settings → General → Controls**, persisted to `localStorage`.
- Buttons only show while editing the plate (model view) and hide in G-code preview, matching the other plate-editing controls.

### Bug fixes (history integrity)
The undo/redo stack is a root singleton whose snapshots reference scene objects by id, and ids are never reused. When the scene was rebuilt with fresh ids, stale snapshots survived — and restoring one removed every current object as "not in the snapshot", **wiping the plate instead of reverting an edit**. Two rebuild boundaries were leaking:

- Opening a new/empty plate (`resetWorkplate`) cleared the scene but not the history.
- Browser-back, deep-links and opening a recent project re-add the plate's model through the viewer with new ids, so the first undo deleted the just-restored model ("everything vanished after browser back").

Fix: added `SceneCommand.reset()` (abort any in-flight gesture + clear history) and call it from both boundaries — `Slicer.resetWorkplate` and the viewer's `loadModelViaSceneEngine` (the single funnel where a fresh mesh is minted). In-session undo/redo is unchanged.

## Why

Undo/redo already have keyboard shortcuts, but on a keyboard-less touch device they're unreachable — the buttons surface the capability where it's needed. The history fixes prevent undo from destroying the plate after any scene rebuild.

## Testing

Verified end-to-end in the browser against the running app:
- Buttons appear (Always) / hide (Auto on desktop, Never); disabled states correct; undo/redo revert transforms; hidden in G-code preview.
- Reproduced the "objects vanish" bug (scene id `2`, stale history referencing id `1`, undo → empty scene), applied the fix, and confirmed history is cleared on restore while in-session undo still reverts (never deletes).

No engine/slicing logic changed.
