### PR TITLE
desktop: fix Windows launch hang by revealing the window after first paint

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -55,6 +55,11 @@ issue/PR numbers or repo links in the notes. See the tone rules in
   waits for the OS to signal a change instead of polling, so the flickering after
   login is gone and macOS stops re-checking on a timer too.
 
+- **No more launch hang on Windows** — the desktop app used to open a blank,
+  unresponsive window for a moment on Windows before it became usable. Its window
+  now stays hidden until the interface has actually drawn, so the app appears
+  fully rendered and ready the instant you see it.
+
 ### Changed
 
 - **Live accent tracking is event-driven** — the desktop app now updates its

--- a/ui-desktop/README.md
+++ b/ui-desktop/README.md
@@ -172,6 +172,36 @@ filesystem). `capabilities/desktop.json` is fenced with
 minimize, maximize, close, drag. Mobile has no window to minimize, so granting
 those there would hand the webview commands the platform cannot honour.
 
+### The window is frameless and hidden on Windows/Linux — by config, not at runtime
+
+macOS keeps native decorations (`titleBarStyle: Overlay`, so the traffic lights
+overlay our custom title bar) and is visible from the first frame — WKWebView
+paints fast enough that there is nothing to hide. Windows and Linux instead
+create the window **frameless and hidden** in
+[`tauri.windows.conf.json`](src-tauri/tauri.windows.conf.json) /
+[`tauri.linux.conf.json`](src-tauri/tauri.linux.conf.json) (platform overrides
+that RFC 7386-merge over [`tauri.conf.json`](src-tauri/tauri.conf.json), so their
+`app.windows` array replaces the base one wholesale — hence the full window
+object is duplicated there).
+
+Both settings fix a Windows launch hang:
+
+- **Frameless at creation, never a runtime `set_decorations(false)`.** Toggling
+  decorations after the window exists forces a WebView2 relayout that visibly
+  froze the app for a moment on launch. Creating it frameless avoids the toggle
+  entirely.
+- **Hidden until the UI paints.** WebView2's cold start is slow, so a
+  visible-from-creation window sat blank and unresponsive first. The frontend
+  reveals it with `getCurrentWindow().show()` from `afterNextRender`
+  ([`app.ts`](../ui/src/app/app.ts)) — gated on `isTauriDesktop()`, so it is a
+  no-op on the web and on mobile. A Rust safety-net timer in
+  [`lib.rs`](src-tauri/src/lib.rs) shows the window anyway if that call never
+  arrives, so a frontend failure can never leave it permanently invisible. This
+  is why `desktop.json` grants `core:window:allow-show` / `allow-set-focus`.
+
+Do **not** re-add a runtime decoration toggle, and do **not** drop `visible: false`
+from the desktop platform configs — either one brings the launch hang back.
+
 ---
 
 ## What the engine looks like on iOS

--- a/ui-desktop/src-tauri/capabilities/desktop.json
+++ b/ui-desktop/src-tauri/capabilities/desktop.json
@@ -7,6 +7,8 @@
   "permissions": [
     "core:menu:default",
     "core:window:allow-start-dragging",
+    "core:window:allow-show",
+    "core:window:allow-set-focus",
     "core:window:allow-minimize",
     "core:window:allow-maximize",
     "core:window:allow-unmaximize",

--- a/ui-desktop/src-tauri/src/lib.rs
+++ b/ui-desktop/src-tauri/src/lib.rs
@@ -31,18 +31,37 @@ pub fn run() {
             // decorated window to correct.
             #[cfg(desktop)]
             {
-                // The window is configured with `decorations: true` +
-                // `titleBarStyle: Overlay` so macOS keeps its native traffic
-                // lights overlaid on our custom title bar. On Windows/Linux there
-                // is no overlay style, so native decorations would draw a second
-                // title bar on top of ours — strip them here so those platforms
-                // stay frameless and use the custom min/max/close controls.
+                // macOS keeps native decorations (`titleBarStyle: Overlay`, so
+                // the traffic lights overlay our custom title bar) and shows the
+                // window from the start — WKWebView paints fast enough that there
+                // is nothing to hide. Windows and Linux instead create the window
+                // frameless *and* hidden (see tauri.windows.conf.json /
+                // tauri.linux.conf.json):
+                //
+                //  - Frameless at creation avoids a runtime `set_decorations(false)`,
+                //    whose window-style change forced a WebView2 relayout on
+                //    Windows that visibly froze the app for a moment on launch.
+                //  - Staying hidden until the web UI paints its first frame hides
+                //    WebView2's slow cold start, which otherwise left a blank,
+                //    unresponsive window on screen.
+                //
+                // Together those were the "app hangs for a bit before it works"
+                // report. The frontend calls `getCurrentWindow().show()` once it
+                // has rendered; this timer is a safety net so a frontend failure
+                // can never leave the window permanently invisible.
                 #[cfg(not(target_os = "macos"))]
                 {
                     use tauri::Manager;
-                    if let Some(window) = _app.get_webview_window("main") {
-                        let _ = window.set_decorations(false);
-                    }
+                    let handle = _app.handle().clone();
+                    std::thread::spawn(move || {
+                        std::thread::sleep(std::time::Duration::from_secs(5));
+                        if let Some(window) = handle.get_webview_window("main") {
+                            if !window.is_visible().unwrap_or(true) {
+                                let _ = window.show();
+                                let _ = window.set_focus();
+                            }
+                        }
+                    });
                 }
 
                 // Track live OS accent changes and push them to the UI.

--- a/ui-desktop/src-tauri/tauri.linux.conf.json
+++ b/ui-desktop/src-tauri/tauri.linux.conf.json
@@ -1,0 +1,18 @@
+{
+  "$schema": "https://schema.tauri.app/config/2",
+  "app": {
+    "windows": [
+      {
+        "label": "main",
+        "title": "Cold Crabby",
+        "width": 1400,
+        "height": 900,
+        "minWidth": 900,
+        "minHeight": 600,
+        "decorations": false,
+        "visible": false,
+        "dragDropEnabled": false
+      }
+    ]
+  }
+}

--- a/ui-desktop/src-tauri/tauri.windows.conf.json
+++ b/ui-desktop/src-tauri/tauri.windows.conf.json
@@ -1,0 +1,18 @@
+{
+  "$schema": "https://schema.tauri.app/config/2",
+  "app": {
+    "windows": [
+      {
+        "label": "main",
+        "title": "Cold Crabby",
+        "width": 1400,
+        "height": 900,
+        "minWidth": 900,
+        "minHeight": 600,
+        "decorations": false,
+        "visible": false,
+        "dragDropEnabled": false
+      }
+    ]
+  }
+}

--- a/ui/src/app/app.ts
+++ b/ui/src/app/app.ts
@@ -1,8 +1,9 @@
-import { Component, inject } from '@angular/core';
+import { afterNextRender, Component, inject } from '@angular/core';
 import { RouterOutlet } from '@angular/router';
 import { CelebrationOverlay } from './components/celebration-overlay/celebration-overlay';
 import { NotificationCenter } from './components/notification-center/notification-center';
 import { UpdateBanner } from './components/update-banner/update-banner';
+import { isTauriDesktop } from './runtime/domain/runtime-mode.util';
 import { AppVersion } from './services/app-version';
 import { WasmPerformanceNotice } from './services/wasm-performance-notice';
 import { DialogOutlet } from './shared/dialog/dialog-outlet';
@@ -30,5 +31,28 @@ export class App {
     // Watch for a newer static deployment (Pages/web runtime) so a stale tab
     // gets a reload prompt even though there's no server to announce a version.
     this.appVersion.startUpdateWatch();
+
+    // The Windows/Linux desktop window is created hidden so the user never sees
+    // WebView2's blank, unresponsive cold-start frame (the "app hangs before it
+    // works" symptom). Reveal it now that the shell has painted its first frame.
+    // No-op on the web (no window) and on macOS/mobile, which stay visible from
+    // the start; the desktop shell also arms a Rust-side fallback in case this
+    // never runs.
+    afterNextRender(() => void this.revealDesktopWindow());
+  }
+
+  private async revealDesktopWindow(): Promise<void> {
+    if (!isTauriDesktop()) {
+      return;
+    }
+    try {
+      const { getCurrentWindow } = await import('@tauri-apps/api/window');
+      const window = getCurrentWindow();
+      await window.show();
+      await window.setFocus();
+    } catch {
+      // Window API unavailable or the call was rejected — the Rust safety-net
+      // timer will still reveal the window.
+    }
   }
 }


### PR DESCRIPTION
## What

On Windows the desktop shell hung for a moment on launch before becoming usable. This fixes it by creating the window frameless-and-hidden via platform config and only revealing it once the UI has painted.

## Why

Two WebView2 cold-start problems (absent on macOS/WKWebView) caused the hang:

- **Runtime decoration toggle.** The window was created *with* native decorations, then stripped with `set_decorations(false)` in `setup()`. That window-style change forces a WebView2 relayout that visibly froze the app.
- **Blank cold-start window.** The window was visible from creation, so WebView2's slow cold start left a blank, unresponsive window on screen until the UI painted.

## Changes

- **New platform config** `tauri.windows.conf.json` / `tauri.linux.conf.json`: create the window `decorations: false` **and** `visible: false`, replacing the runtime decoration toggle (removed from `lib.rs`). These RFC 7386-merge over the base `tauri.conf.json`, so their `app.windows` array replaces the base one wholesale — hence the full window object is duplicated.
- **Reveal after paint** (`ui/src/app/app.ts`): the frontend calls `getCurrentWindow().show()` from `afterNextRender`, gated on `isTauriDesktop()` so it's a no-op on web and mobile.
- **Rust safety-net timer** (`lib.rs`): shows the window anyway after 5s if the frontend call never arrives, so a frontend failure can't leave it permanently invisible.
- Added `core:window:allow-show` / `allow-set-focus` to `capabilities/desktop.json`.
- Documented the contract in `ui-desktop/README.md`.

## Deliberately untouched

- **macOS** keeps native Overlay decorations and stays visible from the first frame (no hang there); the base `tauri.conf.json` is unchanged.
- **iOS/mobile** use the base config and the `isTauriDesktop()` guard, so they never call the desktop-only window API.

## Testing

- `cargo check` and `cargo clippy` on the desktop crate pass; `cargo fmt --check` and prettier are clean.
- Cross-building/running for Windows isn't possible in this environment, so the meaningful check is a real Windows launch: verify the window appears fully-rendered with no native title-bar flash and no blank freeze.