### PR TITLE
dev: start the stack on a random seeded port pair

### DIFF
--- a/.github/skills/test-changes/SKILL.md
+++ b/.github/skills/test-changes/SKILL.md
@@ -17,22 +17,44 @@ Start the pieces the chosen platform needs as **background/detached** processes,
 then hand the user the access details. Never block or poll waiting on a dev
 server — start it, do a quick liveness check, and move on.
 
-| Platform            | Start (background)                                                                     | Give the user            |
-| ------------------- | ------------------------------------------------------------------------------------- | ------------------------ |
-| Remote + web        | `cargo run -- serve` (backend, :5201) **and** `pnpm run ui:dev` (:4213)                | **http://localhost:4213** |
-| Wasm browser slicer | `pnpm run hydrate:web-slicer` first, then `pnpm run ui:dev:web-slicer` (:4213)         | **http://localhost:4213** (no backend) |
-| Tauri desktop       | `pnpm run desktop:dev`                                                                 | The app window opens — no URL |
-| iOS / iPadOS        | `pnpm run ios:dev`                                                                     | The iPad simulator opens — no URL |
-| CLI                 | Nothing to serve — give the exact command to run                                      | The command line          |
+**Every dev server runs on a random seed.** `pnpm run dev` rolls a three-digit
+seed (200–999) and derives every port from it — UI on `4<seed>`, engine on
+`5<seed>`, work directory `slicer-engine-dev-<seed>` — then checks they are
+free. That is what keeps this session off the ports of the other checkout,
+worktree or teammate already running on this host. **Never hardcode 4213/5201.**
 
-- **Reuse, don't stack.** If a dev server is already up on that port, say so and
-  reuse it instead of starting a second.
+| Platform            | Start (background)                                                              | Give the user                          |
+| ------------------- | ------------------------------------------------------------------------------- | -------------------------------------- |
+| Remote + web        | `pnpm run dev`                                                                  | **http://localhost:4\<seed\>/**        |
+| Wasm browser slicer | `pnpm run hydrate:web-slicer` first, then `pnpm run dev:web-slicer`             | **http://localhost:4\<seed\>/** (no backend) |
+| Tauri desktop       | `pnpm run dev:desktop`                                                          | The app window opens — no URL          |
+| iOS / iPadOS        | `pnpm run ios:dev`                                                              | The iPad simulator opens — no URL      |
+| CLI                 | Nothing to serve — give the exact command to run                                | The command line                       |
+
+- **Read the seed back, don't guess it.** The launcher prints its banner first:
+
+  ```
+  Seed 742
+    UI      http://localhost:4742/   <- open this
+    Engine  http://127.0.0.1:5742/  (proxied at /api and /ws)
+  ```
+
+  Give the user **that** URL. `node scripts/dev.mjs --print` resolves a free
+  seed and prints the ports as JSON without starting anything, and
+  `pnpm run dev -- --seed 742` pins one when you need it stable across restarts.
+- **One URL is all they need.** The dev server proxies `/api` and `/ws` to the
+  engine, so the engine's port is an internal detail — never ask the user to
+  open it.
+- **Reuse your own, never someone else's.** If *this* session already has a
+  stack up, reuse it. A server on some other port belongs to another instance —
+  leave it alone and roll a fresh seed instead of killing it.
+- **iOS is the one fixed-port flow.** `pnpm run ios:dev` uses the port pinned in
+  `tauri.conf.json` because the generated Xcode project builds against it. If it
+  is busy, that is the one case worth sorting out by hand.
 - **Rebuild first when the change isn't live yet.** Wasm changes need
-  `hydrate:web-slicer` (or `build:wasm`); a backend change needs the `serve`
-  process (re)started. Make that the first thing you do, not a checklist bullet.
-- **Report the real access detail.** On web, the UI dev server is on **:4213**
-  and talks to the backend on **:5201** — the user opens :4213. On desktop/iOS
-  the shell opens its own window, so there's no URL to give.
+  `hydrate:web-slicer` (or `build:wasm`); a backend change needs the launcher
+  restarted so `cargo run` picks it up. Make that the first thing you do, not a
+  checklist bullet.
 - Keep the startup note to a line or two, then go straight to the checklist.
 
 ## Write the checklist

--- a/AGENTS.md
+++ b/AGENTS.md
@@ -1448,5 +1448,5 @@ infill within the ring.
 
 ---
 
-**Last Updated**: 2026-08-30 (advanced infill options + Orca-accurate fill density)  
+**Last Updated**: 2026-08-31 (seeded dev-server ports + same-origin dev proxy)  
 **Maintainer Guidance**: Keep this file in sync with project structure changes, new conventions, or significant architectural decisions.

--- a/AGENTS.md
+++ b/AGENTS.md
@@ -26,6 +26,24 @@ Or use **Makefile targets** (Linux/macOS):
 make build-release build-windows build-macos build-wasm test lint fmt
 ```
 
+### Dev servers run on a random seed — never a fixed port
+
+`pnpm run dev` ([scripts/dev.mjs](scripts/dev.mjs)) rolls a three-digit **seed**
+(200–999) and derives everything from it: the UI dev server on `4<seed>`, the
+engine on `5<seed>`, and a work directory (SQLite DB + uploads) of its own. It
+verifies the ports are free before starting, so a second worktree, a colleague
+on the same box, or a parallel agent session never collides with yours. `--seed`
+pins one, `--print` resolves ports without starting anything, and
+`dev:web-slicer` / `dev:desktop` cover the other runtimes.
+
+**The engine's port is an internal detail.** The dev server proxies `/api` and
+`/ws` to it ([ui/proxy.conf.mjs](ui/proxy.conf.mjs)), so the browser addresses a
+single origin in development exactly as it does in production — which is why
+[environment.ts](ui/src/environments/environment.ts) carries no port at all.
+Never reintroduce one there: it would pin the UI to one instance of the engine
+and break every seeded run but the first. Report the URL the launcher prints,
+never a hardcoded `:4213`.
+
 ## Architecture & Design
 
 ### Core Components

--- a/DEVELOPMENT.md
+++ b/DEVELOPMENT.md
@@ -6,9 +6,19 @@
 cargo build                                                 # fast iteration (debug)
 cargo test
 cargo fmt && cargo clippy --all-targets --all-features -- -D warnings
+pnpm run dev                                                # engine + UI on a random seeded port pair
 pnpm --filter slicer-engine-docs docs:dev                   # live docs site
 sea-orm-cli migrate generate "my_migration" -d src/db       # scaffold DB migration
 ```
+
+**Dev servers run on a seeded port pair.** `pnpm run dev` rolls a three-digit
+seed and serves the UI on `4<seed>` and the engine on `5<seed>`, with a work
+directory of its own — so a second worktree, a colleague on the same box, or an
+agent session never collides with yours. It prints the URL to open; the UI dev
+server proxies `/api` and `/ws` to the engine, so that one URL is all you need.
+Add `-- --seed 742` to pin it, `-- --ui-only` / `-- --backend-only` for half the
+stack, and use `pnpm run dev:web-slicer` or `pnpm run dev:desktop` for the other
+runtimes.
 
 **Git hooks (autoformat on commit):** `pnpm install` sets up [Lefthook](https://lefthook.dev)
 via the `prepare` script. On every commit it formats just the **staged** files so they already

--- a/Makefile
+++ b/Makefile
@@ -1,4 +1,4 @@
-.PHONY: build build-release build-windows build-macos build-wasm clean test fmt lint help changelog-draft ios-doctor ios-setup ios-init ios-simulator ios-dev ios-build
+.PHONY: build build-release build-windows build-macos build-wasm clean test fmt lint help dev changelog-draft ios-doctor ios-setup ios-init ios-simulator ios-dev ios-build
 
 help:
 	@echo "Slicer Engine - Build Targets"
@@ -11,6 +11,7 @@ help:
 	@echo "  build-windows      - Build for Windows (x86_64)"
 	@echo "  build-macos        - Build for macOS (x86_64 and ARM64)"
 	@echo "  build-wasm         - Build for WebAssembly"
+	@echo "  dev                - Engine + UI dev server on a random seeded port pair"
 	@echo "  test               - Run tests"
 	@echo "  fmt                - Format code"
 	@echo "  lint               - Run clippy linter"
@@ -27,6 +28,9 @@ help:
 
 build:
 	cargo build --verbose
+
+dev:
+	@node scripts/dev.mjs
 
 build-release:
 	cargo build --release --verbose

--- a/SETUP.md
+++ b/SETUP.md
@@ -210,7 +210,7 @@ cargo install tauri-cli --version "^2"
 # or: pnpm add -g @tauri-apps/cli
 
 # Dev mode (hot-reloads Angular, rebuilds Rust on change)
-pnpm run desktop:dev
+pnpm run dev:desktop
 
 # Production build (outputs a platform installer)
 pnpm run desktop:build

--- a/SETUP.md
+++ b/SETUP.md
@@ -149,15 +149,35 @@ pnpm run ui:build            # once (or after UI changes)
 cargo run --release -- serve # http://localhost:5201/
 ```
 
-Dev flow (Angular hot-reload, backend runs separately — both must be running):
+Dev flow (Angular hot-reload, engine runs alongside it):
 
 ```bash
 pnpm run hydrate             # once (or when Rust bindings/schemas change)
-pnpm run ui:dev              # Angular dev server → http://localhost:4200
-cargo run -- serve           # WebSocket/HTTP server  → http://localhost:5201
+pnpm run dev                 # engine + UI on a seeded pair of ports
 ```
 
-The UI sends slicing jobs to the local server. Scene management runs in the browser for instant feedback.
+`pnpm run dev` rolls a random three-digit **seed** and derives every port from
+it — the UI on `4<seed>`, the engine on `5<seed>` — so several checkouts (or
+several people on one box) can run at the same time without colliding. It prints
+the URL to open:
+
+```
+Seed 742
+  UI      http://localhost:4742/   <- open this
+  Engine  http://127.0.0.1:5742/  (proxied at /api and /ws)
+```
+
+Open the UI URL only: the dev server proxies `/api` and `/ws` to the engine, so
+the browser talks to a single origin (as it does in production). Pass
+`--seed 742` to pin one, `--ui-only` / `--backend-only` to start half the stack,
+or `--print` to see the ports without starting anything:
+
+```bash
+pnpm run dev -- --seed 742
+```
+
+The UI sends slicing jobs to the local engine. Scene management runs in the
+browser for instant feedback.
 
 ---
 
@@ -171,8 +191,8 @@ The full slicing pipeline runs in-browser. Building this locally requires a wasm
 # Build the full WASM bundle (scene + slicer)
 pnpm run hydrate:web-slicer
 
-# Dev server — no backend required
-pnpm run ui:dev:web-slicer   # http://localhost:4200
+# Dev server — no backend required (seeded port, printed on start)
+pnpm run dev:web-slicer
 
 # Production build
 pnpm run ui:build:web-slicer

--- a/package.json
+++ b/package.json
@@ -6,6 +6,9 @@
   "scripts": {
     "hydrate": "pnpm run build:wasm && pnpm run gen",
     "hydrate:web-slicer": "pnpm run build:wasm:web-slicer && pnpm run gen",
+    "dev": "node scripts/dev.mjs",
+    "dev:web-slicer": "node scripts/dev.mjs --web-slicer",
+    "dev:desktop": "node scripts/dev.mjs --desktop",
     "ui:dev": "pnpm --filter slicer-ui start",
     "ui:dev:web-slicer": "pnpm --filter slicer-ui start:web-slicer",
     "ui:build": "pnpm --filter slicer-ui build",

--- a/scripts/dev.mjs
+++ b/scripts/dev.mjs
@@ -1,0 +1,344 @@
+#!/usr/bin/env node
+//
+// dev.mjs — start the dev stack on a seeded, conflict-free set of ports.
+//
+// One host often runs several checkouts at once (a worktree per branch, an
+// agent session, a colleague over SSH). Fixed ports make those instances fight
+// over :4213/:5201 and, worse, over the engine's work directory. A *seed* gives
+// each instance its own lane:
+//
+//     UI   http://localhost:4<seed>      Angular dev server
+//     API  http://127.0.0.1:5<seed>      engine (serve)
+//     work $TMPDIR/slicer-engine-dev-<seed>
+//
+// The seed is a three-digit number (200-999); pick one at random and every port
+// follows from it. The browser never needs the API port: the dev server proxies
+// /api and /ws to it (see ui/proxy.conf.mjs), so the UI URL is the only thing
+// worth reporting.
+//
+// Usage:
+//   pnpm run dev                     # random seed, engine + UI
+//   pnpm run dev -- --seed 742       # exact seed (fails if it is taken)
+//   pnpm run dev -- --ui-only        # UI alone
+//   pnpm run dev -- --backend-only   # engine alone
+//   pnpm run dev:web-slicer          # wasm slicer, no engine
+//   pnpm run dev:desktop             # Tauri shell + seeded UI dev server
+//   pnpm run dev -- --print          # resolve ports, print JSON, start nothing
+//
+// SLICER_DEV_SEED is honoured as the default for --seed.
+
+import { spawn } from 'node:child_process';
+import net from 'node:net';
+import fs from 'node:fs';
+import os from 'node:os';
+import path from 'node:path';
+import { fileURLToPath } from 'node:url';
+
+const repoRoot = path.resolve(path.dirname(fileURLToPath(import.meta.url)), '..');
+
+const SEED_MIN = 200;
+const SEED_MAX = 999;
+const UI_BASE = 4000;
+const API_BASE = 5000;
+
+// ---------------------------------------------------------------- arguments
+
+function parseArgs(argv) {
+  const opts = {
+    seed: process.env.SLICER_DEV_SEED ?? null,
+    seedExplicit: process.env.SLICER_DEV_SEED != null,
+    backend: true,
+    ui: true,
+    webSlicer: false,
+    desktop: false,
+    print: false,
+  };
+
+  for (let i = 0; i < argv.length; i++) {
+    const arg = argv[i];
+    switch (arg) {
+      case '--seed':
+        opts.seed = argv[++i];
+        opts.seedExplicit = true;
+        break;
+      case '--ui-only':
+      case '--no-backend':
+        opts.backend = false;
+        break;
+      case '--backend-only':
+        opts.ui = false;
+        break;
+      case '--web-slicer':
+        opts.webSlicer = true;
+        opts.backend = false;
+        break;
+      case '--desktop':
+        opts.desktop = true;
+        opts.backend = false;
+        break;
+      case '--print':
+        opts.print = true;
+        break;
+      case '-h':
+      case '--help':
+        opts.help = true;
+        break;
+      default:
+        if (arg.startsWith('--seed=')) {
+          opts.seed = arg.slice('--seed='.length);
+          opts.seedExplicit = true;
+        } else {
+          die(`unknown argument: ${arg}\nRun with --help for usage.`);
+        }
+    }
+  }
+
+  if (opts.seed != null) {
+    const parsed = Number(opts.seed);
+    if (!Number.isInteger(parsed) || parsed < SEED_MIN || parsed > SEED_MAX) {
+      die(`--seed must be an integer between ${SEED_MIN} and ${SEED_MAX} (got "${opts.seed}")`);
+    }
+    opts.seed = parsed;
+  }
+
+  return opts;
+}
+
+function die(message) {
+  console.error(`dev: ${message}`);
+  process.exit(1);
+}
+
+const HELP = `Start the dev stack on a seeded, conflict-free set of ports.
+
+  pnpm run dev [-- <options>]
+
+Options:
+  --seed <200-999>   Use this seed instead of a random one (fails if taken).
+  --ui-only          Angular dev server only.
+  --backend-only     Engine (serve) only.
+  --web-slicer       Wasm browser slicer; implies --ui-only.
+  --desktop          Tauri desktop shell against a seeded UI dev server.
+  --print            Print the resolved ports as JSON and exit.
+
+Ports follow the seed: UI on 4<seed>, engine on 5<seed>.`;
+
+// -------------------------------------------------------------------- ports
+
+function portFree(port) {
+  const tryHost = (host) =>
+    new Promise((resolve) => {
+      const server = net.createServer();
+      server.once('error', () => resolve(false));
+      server.once('listening', () => server.close(() => resolve(true)));
+      server.listen(port, host);
+    });
+  // Check both: a process bound to one of them still blocks the other in
+  // practice, and different tools bind differently.
+  return Promise.all([tryHost('0.0.0.0'), tryHost('127.0.0.1')]).then((r) => r.every(Boolean));
+}
+
+const portsOf = (seed) => ({ seed, ui: UI_BASE + seed, api: API_BASE + seed });
+
+async function seedIsFree(seed, opts) {
+  const { ui, api } = portsOf(seed);
+  const needed = [];
+  if (opts.ui || opts.desktop) needed.push(ui);
+  if (opts.backend) needed.push(api);
+  for (const port of needed) {
+    if (!(await portFree(port))) return false;
+  }
+  return true;
+}
+
+async function resolveSeed(opts) {
+  if (opts.seedExplicit) {
+    if (!(await seedIsFree(opts.seed, opts))) {
+      const { ui, api } = portsOf(opts.seed);
+      die(
+        `seed ${opts.seed} is already in use (UI ${ui} / engine ${api}).\n` +
+          `Another instance is probably running — drop --seed to roll a free one.`,
+      );
+    }
+    return opts.seed;
+  }
+
+  for (let attempt = 0; attempt < 100; attempt++) {
+    const seed = SEED_MIN + Math.floor(Math.random() * (SEED_MAX - SEED_MIN + 1));
+    if (await seedIsFree(seed, opts)) return seed;
+  }
+  die('could not find a free seed after 100 attempts — is something binding every port?');
+}
+
+// ------------------------------------------------------------------ helpers
+
+// `cargo run -- serve` refuses to start without a UI directory, but in dev the
+// Angular dev server is the UI. Hand the engine a stub so the check passes and
+// a stray hit on the API port explains where the real UI lives.
+function ensurePlaceholderUiDir(uiPort) {
+  const dir = path.join(repoRoot, 'target', 'dev-ui');
+  fs.mkdirSync(dir, { recursive: true });
+  fs.writeFileSync(
+    path.join(dir, 'index.html'),
+    `<!doctype html>
+<meta charset="utf-8">
+<title>Cold Crabby — engine only</title>
+<p>This is the engine's API/WebSocket port. The dev UI is at
+<a href="http://localhost:${uiPort}/">http://localhost:${uiPort}/</a>.</p>
+`,
+  );
+  return dir;
+}
+
+const COLORS = { api: '\u001b[36m', ui: '\u001b[35m', app: '\u001b[33m', reset: '\u001b[0m' };
+
+const children = [];
+let shuttingDown = false;
+
+// Windows cannot spawn `pnpm`/`cargo` (shim .cmd files) without a shell, and a
+// shell does not quote arguments for us — so quote anything with a space.
+const onWindows = process.platform === 'win32';
+const quote = (arg) => (onWindows && /\s/.test(arg) ? `"${arg}"` : arg);
+
+function start(name, command, args, env = {}) {
+  const child = spawn(command, onWindows ? args.map(quote) : args, {
+    cwd: repoRoot,
+    env: { ...process.env, ...env },
+    stdio: ['inherit', 'pipe', 'pipe'],
+    shell: onWindows,
+  });
+  children.push({ name, child });
+
+  const prefix = `${COLORS[name] ?? ''}[${name}]${COLORS.reset} `;
+  const pipe = (stream, sink) => {
+    let buffered = '';
+    stream.setEncoding('utf8');
+    stream.on('data', (chunk) => {
+      buffered += chunk;
+      const lines = buffered.split('\n');
+      buffered = lines.pop() ?? '';
+      for (const line of lines) sink.write(`${prefix}${line}\n`);
+    });
+    stream.on('end', () => {
+      if (buffered) sink.write(`${prefix}${buffered}\n`);
+    });
+  };
+  pipe(child.stdout, process.stdout);
+  pipe(child.stderr, process.stderr);
+
+  child.on('exit', (code, signal) => {
+    if (shuttingDown) return;
+    console.error(`\n${prefix}exited (${signal ?? `code ${code}`}) — stopping the rest.`);
+    shutdown(code ?? 1);
+  });
+  child.on('error', (error) => {
+    console.error(`${prefix}failed to start: ${error.message}`);
+    shutdown(1);
+  });
+
+  return child;
+}
+
+function shutdown(code) {
+  if (shuttingDown) return;
+  shuttingDown = true;
+  // Set it up front: once the children are gone the event loop drains and the
+  // process exits on its own, before the SIGKILL sweep below ever fires.
+  process.exitCode = code;
+  for (const { child } of children) {
+    if (child.exitCode === null && child.signalCode === null) child.kill('SIGTERM');
+  }
+  // Give them a moment to go down cleanly, then leave.
+  setTimeout(() => {
+    for (const { child } of children) {
+      if (child.exitCode === null && child.signalCode === null) child.kill('SIGKILL');
+    }
+    process.exit(code);
+  }, 2000).unref();
+}
+
+// --------------------------------------------------------------------- main
+
+const opts = parseArgs(process.argv.slice(2));
+if (opts.help) {
+  console.log(HELP);
+  process.exit(0);
+}
+
+const seed = await resolveSeed(opts);
+const { ui: uiPort, api: apiPort } = portsOf(seed);
+const workDir = path.join(os.tmpdir(), `slicer-engine-dev-${seed}`);
+
+if (opts.print) {
+  console.log(
+    JSON.stringify(
+      { seed, uiPort, apiPort, uiUrl: `http://localhost:${uiPort}/`, workDir },
+      null,
+      2,
+    ),
+  );
+  process.exit(0);
+}
+
+const lines = [`Seed ${seed}`];
+if (opts.ui && !opts.desktop) lines.push(`  UI      http://localhost:${uiPort}/   <- open this`);
+if (opts.desktop) lines.push(`  UI      http://localhost:${uiPort}/   (Tauri window)`);
+if (opts.backend) {
+  lines.push(`  Engine  http://127.0.0.1:${apiPort}/  (proxied at /api and /ws)`);
+  lines.push(`  Work    ${workDir}`);
+}
+console.log(`${lines.join('\n')}\n`);
+
+if (opts.backend) {
+  fs.mkdirSync(workDir, { recursive: true });
+  start(
+    'api',
+    'cargo',
+    [
+      'run',
+      '--',
+      'serve',
+      '--port',
+      String(apiPort),
+      '--ui-dir',
+      ensurePlaceholderUiDir(uiPort),
+      '--work-dir',
+      workDir,
+    ],
+    { SLICER_DEV_SEED: String(seed) },
+  );
+}
+
+if (opts.ui || opts.desktop) {
+  const script = opts.webSlicer ? 'start:web-slicer' : 'start';
+  start('ui', 'pnpm', ['--filter', 'slicer-ui', 'run', script, '--port', String(uiPort)], {
+    SLICER_API_PORT: String(apiPort),
+    SLICER_DEV_SEED: String(seed),
+  });
+}
+
+if (opts.desktop) {
+  // The Tauri config pins devUrl to the default port and starts a UI dev server
+  // of its own; override both so the shell attaches to the seeded one above.
+  // Written to a file rather than passed inline — the JSON's quotes do not
+  // survive a Windows shell.
+  const overrides = path.join(repoRoot, 'target', `tauri.dev.${seed}.json`);
+  fs.mkdirSync(path.dirname(overrides), { recursive: true });
+  fs.writeFileSync(
+    overrides,
+    JSON.stringify({ build: { devUrl: `http://localhost:${uiPort}`, beforeDevCommand: '' } }),
+  );
+  start(
+    'app',
+    'pnpm',
+    ['--filter', 'slicer-ui-desktop', 'exec', 'tauri', 'dev', '--config', overrides],
+    { SLICER_DEV_SEED: String(seed) },
+  );
+}
+
+for (const signal of ['SIGINT', 'SIGTERM']) {
+  process.on(signal, () => {
+    console.log('\nStopping…');
+    shutdown(0);
+  });
+}

--- a/src/server/mod.rs
+++ b/src/server/mod.rs
@@ -151,9 +151,10 @@ async fn run_server(
                 http::header::AUTHORIZATION,
             ])
             // `Content-Disposition` is not CORS-safelisted, so a cross-origin
-            // client (the dev server, or any UI served from another origin)
-            // cannot read the filename the engine chose for a download unless
-            // it is explicitly exposed.
+            // client — any UI served from another origin — cannot read the
+            // filename the engine chose for a download unless it is explicitly
+            // exposed. (The Angular dev server proxies `/api`, so it is
+            // same-origin and does not rely on this.)
             .expose_headers(vec![http::header::CONTENT_DISPOSITION])
             .supports_credentials();
 

--- a/ui-desktop/README.md
+++ b/ui-desktop/README.md
@@ -65,6 +65,18 @@ depend on it like any other crate.
 | `capabilities/`         | Permission grants, split by platform (see below).                       |
 | `gen/apple/`            | **Generated, but committed** Xcode project. Created by `ios:init`.      |
 
+### `dev:desktop` overrides `devUrl` at launch
+
+`tauri.conf.json` pins `build.devUrl` to the default UI port and names a
+`beforeDevCommand` that starts a dev server of its own. That is right for a
+lone checkout and wrong the moment two run at once, so
+[`scripts/dev.mjs`](../scripts/dev.mjs) starts the seeded dev server itself and
+passes Tauri a generated config that **blanks `beforeDevCommand` and repoints
+`devUrl`** at it. Expect the window to load a port other than the one in
+`tauri.conf.json` — that is the seed, not a bug. The override is written to a
+file rather than passed as an inline JSON string, whose quotes do not survive a
+Windows shell.
+
 ### App icons
 
 Every platform's icon set is generated from one master,
@@ -299,7 +311,13 @@ pnpm run ios:dev
 
 This picks an iPad simulator, boots it, starts the Angular dev server, builds
 the Rust static library, and installs the app — with live reload on the web
-side, exactly like `pnpm run desktop:dev`.
+side, much like `pnpm run dev:desktop`.
+
+> **This is the one dev flow still on a fixed port.** Everywhere else
+> `pnpm run dev` seeds the ports so parallel checkouts don't collide, but the
+> generated Xcode project builds against the `devUrl` pinned in
+> `tauri.conf.json`, so seeding it would mean regenerating the project on every
+> run. If `:4213` is busy, stop whatever holds it before starting.
 
 > The first run cross-compiles the whole engine for `aarch64-apple-ios-sim` and
 > takes several minutes; the resulting `libapp.a` is ~500 MB in debug. Later

--- a/ui/README.md
+++ b/ui/README.md
@@ -265,13 +265,18 @@ The `postinstall` script in [package.json](package.json) wires this up: cloning 
 # From the repo root, build the WASM scene engine first
 make build-wasm                                  # writes ui/src/generated/scene-wasm/
 
-# Then, in this folder:
-pnpm install                                     # also runs `pnpm run gen`
-pnpm start                                       # ng serve --host 0.0.0.0 → http://localhost:4200
-
-# In a second terminal, run the slicer-engine server (UI talks to this)
-cargo run --release -- serve                     # default http://localhost:5201
+# Then, from the repo root, start the engine + dev server together
+pnpm run dev                                     # seeded ports: UI 4<seed>, engine 5<seed>
 ```
+
+`pnpm run dev` ([scripts/dev.mjs](../scripts/dev.mjs)) picks a random seed so
+parallel checkouts never fight over a port, and prints the UI URL to open. The
+dev server proxies `/api` and `/ws` to the engine
+([proxy.conf.mjs](proxy.conf.mjs)), so the app addresses one origin in
+development exactly as it does in production.
+
+Running this folder's `pnpm start` on its own is still fine — it serves on the
+default `:4213` and proxies to an engine on its default `:5201`.
 
 Reset the generated folder anytime with `pnpm run gen`. If types or schemas look stale after editing Rust, run `pnpm run gen` — never edit `src/generated/` by hand.
 
@@ -281,6 +286,7 @@ Reset the generated folder anytime with `pnpm run gen`. If types or schemas look
 
 | Task                            | Command                                 |
 | ------------------------------- | --------------------------------------- |
+| Engine + dev server (seeded)    | `pnpm run dev` (repo root)              |
 | Dev server with HMR             | `pnpm start`                            |
 | Production build                | `pnpm build`                            |
 | Watch incremental dev build     | `pnpm watch`                            |

--- a/ui/README.md
+++ b/ui/README.md
@@ -265,6 +265,8 @@ The `postinstall` script in [package.json](package.json) wires this up: cloning 
 # From the repo root, build the WASM scene engine first
 make build-wasm                                  # writes ui/src/generated/scene-wasm/
 
+pnpm install                                     # also runs `pnpm run gen`
+
 # Then, from the repo root, start the engine + dev server together
 pnpm run dev                                     # seeded ports: UI 4<seed>, engine 5<seed>
 ```

--- a/ui/angular.json
+++ b/ui/angular.json
@@ -125,7 +125,8 @@
         "serve": {
           "builder": "@angular/build:dev-server",
           "options": {
-            "port": 4213
+            "port": 4213,
+            "proxyConfig": "proxy.conf.mjs"
           },
           "configurations": {
             "production": {

--- a/ui/proxy.conf.mjs
+++ b/ui/proxy.conf.mjs
@@ -1,0 +1,18 @@
+// Dev-server proxy: the browser talks only to the origin it was loaded from.
+//
+// scripts/dev.mjs picks the engine's port from a seed, so hardcoding it in the
+// UI would defeat the point. Instead the dev server forwards /api and /ws to
+// wherever the engine is listening (SLICER_API_PORT), which also mirrors
+// production — where one origin serves both the app and the API — and keeps CORS
+// out of the picture.
+//
+// Without the launcher this falls back to the engine's own default port, so
+// `pnpm run ui:dev` + `cargo run -- serve` still works.
+
+const port = process.env.SLICER_API_PORT || '5201';
+const target = `http://127.0.0.1:${port}`;
+
+export default {
+  '/api': { target, changeOrigin: true },
+  '/ws': { target, ws: true },
+};

--- a/ui/src/environments/environment.ts
+++ b/ui/src/environments/environment.ts
@@ -1,4 +1,11 @@
-const BACKEND_PORT = 5201;
+// Development environment — same-origin, like production.
+//
+// The Angular dev server proxies `/api` and `/ws` to the engine (see
+// ui/proxy.conf.mjs), so the engine's port is an internal detail:
+// scripts/dev.mjs derives it from a seed so several checkouts can run side by
+// side. The browser only ever addresses the origin it was loaded from, which
+// also means a phone or an iPad on the LAN needs one URL, not two.
+
 // Local cloud-presets API (`pnpm sample-api` in the cloud-presets repo, or its
 // unified `pnpm dev` proxied at /v1). Point the catalog at the local instance
 // during development instead of the deployed cloud.
@@ -18,8 +25,8 @@ type Environment = {
 
 export const environment: Environment = {
   production: false,
-  apiUrl: `${httpProtocol}//${host}:${BACKEND_PORT}/api`,
-  wsUrl: `${wsProtocol}//${host}:${BACKEND_PORT}/ws`,
+  apiUrl: `${httpProtocol}//${window.location.host}/api`,
+  wsUrl: `${wsProtocol}//${window.location.host}/ws`,
   runtimeMode: 'cloud',
   catalogApiUrl: `${httpProtocol}//${host}:${CATALOG_PORT}`,
 };


### PR DESCRIPTION
Fixed ports made two checkouts on one host fight over `:4213`/`:5201` and, worse, over the engine's work directory — so a second worktree, a colleague on the same box, or a parallel agent session clobbered the first.

## The seed

`pnpm run dev` rolls a three-digit seed (200–999) and derives everything from it:

| | |
| --- | --- |
| UI dev server | `4<seed>` |
| Engine | `5<seed>` |
| Work dir (SQLite + uploads) | `$TMPDIR/slicer-engine-dev-<seed>` |

It checks the ports are free before starting — rerolling if not, failing loudly when `--seed` was explicit — prefixes and interleaves both logs, and tears the whole stack down on Ctrl-C or if either half dies.

```
Seed 742
  UI      http://localhost:4742/   <- open this
  Engine  http://127.0.0.1:5742/  (proxied at /api and /ws)
```

Flags: `--seed` pins one, `--print` resolves ports without starting anything, `--ui-only` / `--backend-only` start half the stack. `pnpm run dev:web-slicer` and `pnpm run dev:desktop` cover the other runtimes; `make dev` is there too.

## The seed stays invisible to the browser

The dev server proxies `/api` and `/ws` to the engine (`ui/proxy.conf.mjs`), so `environment.ts` now carries **no port at all** — same-origin, exactly like production. That means one URL for the user, no CORS in dev, and a LAN device or iPad needs one address instead of two. Without the launcher the proxy falls back to the engine's default port, so the old `ui:dev` + `cargo run -- serve` flow still works.

Desktop overrides Tauri's `devUrl`/`beforeDevCommand` through a written config file rather than an inline JSON string, since that string does not survive a Windows shell.

Also hands the engine a stub `--ui-dir`, so `cargo run -- serve` no longer refuses to start before `ui:build` has ever run.

## Instructions

The `test-changes` skill is the main one — new launch table, "read the seed back, don't guess it", "reuse your own, never someone else's", and iOS flagged as the one remaining fixed-port flow. `AGENTS.md` gets the contract (never reintroduce a port in `environment.ts`), plus `SETUP.md`, `DEVELOPMENT.md`, `ui/README.md`.

## Verified

- Full slice through the proxy: upload → WS `Connected` → **Sliced · 243 layers**.
- WebSocket handshake both direct and proxied; `/api/config` both ways.
- `--seed` collision refused with a useful message; SIGINT leaves no orphaned engine or listener.
- `--desktop`: Tauri accepted the config override, skipped its own dev server, and the window came up against the seeded port.

No CHANGELOG entry — contributor tooling, nothing user-visible.
