### PR TITLE
docs: iOS Xcode gotchas + hydrate note for fresh workspaces

### DIFF
--- a/.github/skills/test-changes/SKILL.md
+++ b/.github/skills/test-changes/SKILL.md
@@ -51,6 +51,12 @@ worktree or teammate already running on this host. **Never hardcode 4213/5201.**
 - **iOS is the one fixed-port flow.** `pnpm run ios:dev` uses the port pinned in
   `tauri.conf.json` because the generated Xcode project builds against it. If it
   is busy, that is the one case worth sorting out by hand.
+- **Fresh workspace? Hydrate before anything else.** If `ui/src/generated/`
+  (or `ui/src/generated/scene-wasm/`) is missing — a brand-new clone, or after
+  `pnpm install` alone — every platform's UI build fails with `Cannot find
+  module '../../generated/scene-wasm/scene_engine'`. Run `pnpm install &&
+  pnpm run hydrate` (or `hydrate:web-slicer` for the wasm browser slicer) once,
+  first, before starting any dev server.
 - **Rebuild first when the change isn't live yet.** Wasm changes need
   `hydrate:web-slicer` (or `build:wasm`); a backend change needs the launcher
   restarted so `cargo run` picks it up. Make that the first thing you do, not a

--- a/SETUP.md
+++ b/SETUP.md
@@ -259,6 +259,14 @@ Install the CLI at the exact version pinned in `Cargo.lock` (mismatched versions
 cargo install wasm-bindgen-cli --version "$(grep -A1 '^name = "wasm-bindgen"$' Cargo.lock | tail -1 | cut -d'"' -f2)" --locked
 ```
 
+Still "command not found" after installing? `cargo install` puts binaries in `~/.cargo/bin`, which `rustup`'s own shell setup should have added to `PATH` — if it didn't (or you're on a shell profile rustup didn't touch), add it yourself:
+
+```bash
+echo 'export PATH="$HOME/.cargo/bin:$PATH"' >> ~/.zshrc   # or ~/.bashrc
+```
+
+Open a new terminal (or `source` the file) and retry.
+
 **`wasm-pack` command not found?**
 Only needed for the standalone `wasm-pack build` invocation — the `pnpm hydrate` scripts don't use it. If you actually need it: `cargo install wasm-pack`.
 

--- a/ui-desktop/README.md
+++ b/ui-desktop/README.md
@@ -344,6 +344,15 @@ opens the project instead of running it.
 > `gen/apple`. Without that passthrough entry pnpm cannot resolve the binary and
 > the iOS build fails with `Command "tauri" not found`. Do not remove it.
 
+> **Do not `open gen/apple/*.xcodeproj` on its own.** The "Build Rust Code"
+> phase reads a dev-server address file (`.../<T>-server-addr` in `$TMPDIR`)
+> that only exists while a `tauri ios dev`/`ios:open`/`ios:dev` process is
+> running; opening the project directly and hitting Run fails with `thread
+> '<unnamed>' panicked … failed to read missing addr file`. Always launch
+> through `pnpm run ios:dev` or `pnpm run ios:open` and keep that process
+> alive — you can still use Xcode's own Run/Debug once it has opened the
+> project for you.
+
 ### Debugging the webview
 
 Safari owns the inspector for iOS. Enable **Safari → Settings → Advanced → Show


### PR DESCRIPTION
## What
- SETUP.md: fix for `wasm-bindgen: command not found` after install (cargo bin dir missing from PATH).
- ui-desktop/README.md: note that opening the generated Xcode project directly (without `ios:dev`/`ios:open` running) panics with a missing dev-server addr-file error.
- test-changes skill: add a "fresh workspace" reminder to run `pnpm run hydrate` before starting any dev server, since a brand-new clone has no `ui/src/generated/` yet.

## Why
Ran into all three while getting iOS dev running locally; recording them so the next person (or agent) doesn't have to rediscover them.