### PR TITLE
docs: dress the site in the app's design language, from the app's own tokens

### DIFF
--- a/AGENTS.md
+++ b/AGENTS.md
@@ -188,6 +188,34 @@ and tone settle. It is a `layout-top` slot in
 it. `--vp-layout-top-height` in `banner.css` is what reserves its space — drop
 that with it, or the nav keeps a gap above it.
 
+#### The docs wear the app's design language, from the app's own tokens
+
+[docs/.vitepress/theme/styles/\_tokens.scss](docs/.vitepress/theme/styles/_tokens.scss)
+`@use`s the **real** theme partials from the shared UI library (`ColdCrabby/ui`,
+vendored into `ui/vendor/coldcrabby-ui` by `ui`'s postinstall) through the Sass
+`loadPaths` in [docs/.vitepress/config.ts](docs/.vitepress/config.ts) — the same
+idiom `ui/angular.json` uses — and maps them onto VitePress's `--vp-*`
+variables. **Never write a colour, radius, duration or font literal into the
+docs theme.** Add a mapping in `_tokens.scss` instead, so changing the accent in
+the library recolours the docs with it and the two cannot drift.
+
+The rest of `styles/` applies the same rules the app follows: chrome separated
+by surface tone rather than hairlines, custom blocks shaped like
+`nexus-inline-notice` (one `--notice-tone` per severity), cards as islands at
+`--radius-lg`, focus as a 2px outline. Two things to know before editing it:
+
+- **The docs build depends on the vendored UI checkout.** A `docs:build` in a
+  tree that never ran `ui`'s postinstall fails with "Can't find stylesheet to
+  import" — run `pnpm --filter slicer-ui vendor:ui` first.
+- **VitePress's component styles are scoped**, so `.VPButton.medium[data-v-…]`
+  outranks a plain `.VPButton.medium`. Doubling the class is how the theme wins
+  that without reaching for `!important`.
+
+Where the docs need a live piece of the design language rather than a
+description of it, use a Vue component under `theme/components/` — `Swatches`
+prints each chip's *resolved* colour, so the brand page cannot quote a hex the
+product no longer uses.
+
 #### Module READMEs — house style
 
 Long-form module docs (`src/<module>/README.md`) follow the
@@ -1448,5 +1476,5 @@ infill within the ring.
 
 ---
 
-**Last Updated**: 2026-08-31 (seeded dev-server ports + same-origin dev proxy)  
+**Last Updated**: 2026-08-31 (docs site consumes the shared UI design tokens)  
 **Maintainer Guidance**: Keep this file in sync with project structure changes, new conventions, or significant architectural decisions.

--- a/docs/.vitepress/config.ts
+++ b/docs/.vitepress/config.ts
@@ -135,7 +135,7 @@ function writeWrapper(source: string) {
 editLink: false
 ---
 
-> **Source:** [\`${source}\`](${githubUrl}) — this page is rendered directly from the file in the repository. Edit it there.
+<div class="doc-source">Rendered from <a href="${githubUrl}"><code>${source}</code></a> in the repository — edit it there.</div>
 
 <!--@include: ${includePath}-->
 `;
@@ -152,6 +152,13 @@ for (const source of discovered.keys()) {
   writeWrapper(source);
 }
 
+// The shared Cold Crabby design language (ColdCrabby/ui). The Angular app
+// resolves it through Sass `includePaths`; the docs use the same idiom via
+// Vite's `loadPaths` below, so both sites read one set of token files and
+// cannot drift. The checkout is git-ignored and created by `ui`'s postinstall
+// (`pnpm --filter slicer-ui vendor:ui` to refresh it by hand).
+const uiStyles = path.join(repoRoot, "ui/vendor/coldcrabby-ui/src/styles");
+
 // https://vitepress.dev/reference/site-config
 export default withMermaid(
   defineConfig({
@@ -161,6 +168,28 @@ export default withMermaid(
     lastUpdated: true,
     cleanUrls: true,
     base: "/docs/",
+
+    // Same typeface pairing the app loads in `ui/src/index.html` — Plus
+    // Jakarta Sans over IBM Plex Mono, both variable so the theme's non-step
+    // weights (462 / 536 / 614) render as intended.
+    head: [
+      ["link", { rel: "preconnect", href: "https://fonts.googleapis.com" }],
+      [
+        "link",
+        {
+          rel: "preconnect",
+          href: "https://fonts.gstatic.com",
+          crossorigin: "",
+        },
+      ],
+      [
+        "link",
+        {
+          rel: "stylesheet",
+          href: "https://fonts.googleapis.com/css2?family=Plus+Jakarta+Sans:wght@200..800&family=IBM+Plex+Mono:wght@400;500;600&display=swap",
+        },
+      ],
+    ],
 
     themeConfig: {
       search: {
@@ -331,6 +360,18 @@ export default withMermaid(
     },
 
     vite: {
+      css: {
+        preprocessorOptions: {
+          scss: {
+            // `loadPaths` is the modern-API spelling of the `includePaths`
+            // that `ui/angular.json` uses, so `@use 'theme/light'` resolves
+            // to the shared library in both builds. Vite 5 still defaults to
+            // the deprecated legacy API, which would ignore it.
+            api: "modern",
+            loadPaths: [uiStyles],
+          },
+        },
+      },
       optimizeDeps: {
         include: ["mermaid"],
       },

--- a/docs/.vitepress/theme/Banner.vue
+++ b/docs/.vitepress/theme/Banner.vue
@@ -25,12 +25,13 @@
 
   box-sizing: border-box;
   height: var(--vp-layout-top-height);
-  padding: 0 24px;
+  padding: 0 var(--spacing-xl);
 
   background: var(--cc-banner-bg);
   color: var(--cc-banner-fg);
-  font-size: 13px;
-  font-weight: 500;
+  font-size: var(--font-size-sm);
+  font-weight: var(--font-weight-medium);
+  font-variation-settings: "wght" var(--font-weight-medium);
   line-height: 1.4;
   text-align: center;
 }
@@ -38,11 +39,12 @@
 .cc-banner-tag {
   flex: none;
   padding: 2px 8px;
-  border-radius: 10px;
+  border-radius: var(--radius-sm);
   background: rgb(0 0 0 / 0.18);
-  font-size: 11px;
+  font-size: var(--font-size-2xs);
   font-weight: 700;
-  letter-spacing: 0.02em;
+  font-variation-settings: "wght" 700;
+  letter-spacing: 0.04em;
   text-transform: uppercase;
 }
 
@@ -50,9 +52,9 @@
   .cc-banner {
     flex-direction: column;
     justify-content: center;
-    gap: 4px;
-    padding: 0 16px;
-    font-size: 12px;
+    gap: var(--spacing-xs);
+    padding: 0 var(--spacing-lg);
+    font-size: var(--font-size-xs);
   }
 }
 </style>

--- a/docs/.vitepress/theme/banner.css
+++ b/docs/.vitepress/theme/banner.css
@@ -6,19 +6,24 @@
  * length on :root; a scoped style inside Banner.vue cannot define it. Keep the
  * two values in sync with Banner.vue's own breakpoint.
  *
- * The fill is the brand's molten amber (see brand.md) rather than VitePress's
- * yellow scale, which inverts between modes and lands on a muddy dark gold in
- * light mode.
+ * The fill is the accent itself (`styles/_tokens.scss` brings the token in
+ * from the shared UI library) rather than VitePress's yellow scale, which
+ * inverts between modes and lands on a muddy dark gold in light mode.
  */
 :root {
   --vp-layout-top-height: 40px;
 
-  --cc-banner-bg: #e0730f;
-  --cc-banner-fg: #1c1204;
+  --cc-banner-bg: var(--accent);
+  --cc-banner-fg: var(--accent-contrast);
 }
 
-.dark {
-  --cc-banner-bg: #f5883a;
+/*
+ * Light mode's `--accent-contrast` is white, which has too little contrast on
+ * the amber fill for a whole sentence. Dark mode's is already a deep brown, so
+ * it inherits from :root above.
+ */
+:root:not(.dark) {
+  --cc-banner-fg: #1c1204;
 }
 
 @media (max-width: 719px) {

--- a/docs/.vitepress/theme/components/Swatches.vue
+++ b/docs/.vitepress/theme/components/Swatches.vue
@@ -1,0 +1,125 @@
+<script setup lang="ts">
+import { onBeforeUnmount, onMounted, ref } from "vue";
+
+/**
+ * A row of colour chips rendered from live theme tokens.
+ *
+ * Pass `value` as a token (`var(--accent)`) rather than a hex and the chip
+ * follows the theme — including the light/dark switch — because the value it
+ * prints is read back off the element with `getComputedStyle`. The brand page
+ * therefore cannot quote a colour the product no longer uses.
+ */
+type Swatch = {
+  /** Label under the chip. */
+  name: string;
+  /** Any CSS colour. Prefer a token so the docs track the library. */
+  value: string;
+  /** Optional second line, for a note the colour itself cannot say. */
+  note?: string;
+};
+
+const props = defineProps<{ items: Swatch[] }>();
+
+const chips = ref<HTMLElement[]>([]);
+const resolved = ref<string[]>([]);
+let observer: MutationObserver | undefined;
+
+function toHex(color: string): string {
+  const match = color.match(/\d+(\.\d+)?/g);
+  if (!match || match.length < 3) {
+    return color;
+  }
+  const [r, g, b] = match.slice(0, 3).map((n) => Math.round(Number(n)));
+  return (
+    "#" +
+    [r, g, b]
+      .map((n) => n.toString(16).padStart(2, "0"))
+      .join("")
+      .toUpperCase()
+  );
+}
+
+function read() {
+  resolved.value = chips.value.map((el) =>
+    el ? toHex(getComputedStyle(el).backgroundColor) : "",
+  );
+}
+
+onMounted(() => {
+  read();
+  // The theme toggle swaps a class on <html>; re-read so the printed hex never
+  // disagrees with the chip beside it.
+  observer = new MutationObserver(read);
+  observer.observe(document.documentElement, {
+    attributes: true,
+    attributeFilter: ["class"],
+  });
+});
+
+onBeforeUnmount(() => observer?.disconnect());
+</script>
+
+<template>
+  <ul class="cc-swatches">
+    <li v-for="(item, i) in props.items" :key="item.name" class="cc-swatch">
+      <span
+        class="cc-swatch-chip"
+        :ref="(el) => (chips[i] = el as HTMLElement)"
+        :style="{ background: item.value }"
+      />
+      <span class="cc-swatch-name">{{ item.name }}</span>
+      <span class="cc-swatch-value">{{ resolved[i] ?? "" }}</span>
+      <span v-if="item.note" class="cc-swatch-note">{{ item.note }}</span>
+    </li>
+  </ul>
+</template>
+
+<style scoped>
+.cc-swatches {
+  display: grid;
+  grid-template-columns: repeat(auto-fill, minmax(112px, 1fr));
+  gap: var(--spacing-md);
+  margin: var(--spacing-xl) 0;
+  padding: 0;
+  list-style: none;
+}
+
+.cc-swatch {
+  display: flex;
+  flex-direction: column;
+  gap: 2px;
+  margin: 0;
+  padding: var(--spacing-sm);
+  border-radius: var(--radius-lg);
+  background: var(--color-bg-primary);
+}
+
+.cc-swatch-chip {
+  height: 52px;
+  margin-bottom: var(--spacing-xs);
+  border-radius: var(--radius-md);
+  /* The one place a hairline earns its keep: without it a near-white swatch
+     is invisible against the card. */
+  box-shadow: inset 0 0 0 1px
+    color-mix(in oklab, var(--color-text-primary) 12%, transparent);
+}
+
+.cc-swatch-name {
+  color: var(--color-text-primary);
+  font-size: var(--font-size-sm);
+  font-weight: var(--font-weight-medium);
+  font-variation-settings: "wght" var(--font-weight-medium);
+}
+
+.cc-swatch-value {
+  min-height: 1.4em;
+  color: var(--color-text-tertiary);
+  font-family: var(--font-family-mono);
+  font-size: var(--font-size-2xs);
+}
+
+.cc-swatch-note {
+  color: var(--color-text-tertiary);
+  font-size: var(--font-size-2xs);
+}
+</style>

--- a/docs/.vitepress/theme/index.ts
+++ b/docs/.vitepress/theme/index.ts
@@ -2,6 +2,10 @@ import { h } from "vue";
 import type { Theme } from "vitepress";
 import DefaultTheme from "vitepress/theme";
 import Banner from "./Banner.vue";
+import Swatches from "./components/Swatches.vue";
+// The Cold Crabby design language, bridged onto VitePress's own variables.
+// Imported after the default theme so its `:root` block wins on order.
+import "./styles/index.scss";
 import "./banner.css";
 
 export default {
@@ -10,5 +14,9 @@ export default {
     return h(DefaultTheme.Layout, null, {
       "layout-top": () => h(Banner),
     });
+  },
+  enhanceApp({ app }) {
+    // Usable in any markdown page without an import.
+    app.component("Swatches", Swatches);
   },
 } satisfies Theme;

--- a/docs/.vitepress/theme/styles/_base.scss
+++ b/docs/.vitepress/theme/styles/_base.scss
@@ -1,0 +1,96 @@
+/// Base treatments shared with the app.
+/// @group docs-theme
+///
+/// Typography weights, the focus ring, scrollbars and selection — the small
+/// things that make the site feel like the same product as the slicer window.
+
+/* ── Variable-font weights ────────────────────────────────────────────────
+   Plus Jakarta Sans is a variable face, and the app leans on non-step weights
+   (462 / 536 / 614) for smoother emphasis than 400/500/600 give. Match them
+   so a heading here weighs the same as a heading in the app. */
+body {
+  font-weight: var(--font-weight-normal);
+  font-variation-settings: "wght" var(--font-weight-normal);
+  font-optical-sizing: auto;
+  -webkit-font-smoothing: antialiased;
+  -moz-osx-font-smoothing: grayscale;
+}
+
+h1,
+h2,
+h3,
+h4,
+h5,
+h6,
+.VPNavBarTitle .title,
+.VPSidebarItem .text,
+.VPButton {
+  font-variation-settings: "wght" var(--font-weight-semibold);
+}
+
+strong,
+b {
+  font-weight: var(--font-weight-semibold);
+  font-variation-settings: "wght" var(--font-weight-semibold);
+}
+
+code,
+kbd,
+pre,
+samp {
+  font-variation-settings: "wght" var(--font-weight-mono-normal);
+}
+
+/* ── Focus reads as a shape change, not a colour flood ────────────────────
+   Same 2px outline + offset the app applies globally, animated with the
+   standard easing. Anything that opts out must replace it with something
+   equally legible.
+
+   The interactive elements are named as well as matched by `*` because
+   VitePress's bundled DocSearch styles ship `button:focus-visible { outline:
+   -webkit-focus-ring-color auto 4px }`, which outranks a bare
+   `*:focus-visible` and would leave every button on the browser's own ring. */
+*:focus {
+  outline: none;
+}
+
+*:focus-visible,
+a:focus-visible,
+button:focus-visible,
+input:focus-visible,
+select:focus-visible,
+summary:focus-visible {
+  outline: 2px solid var(--color-focus-ring);
+  outline-offset: 1px;
+  transition:
+    outline-color var(--duration-fast) var(--ease-standard),
+    outline-offset var(--duration-fast) var(--ease-standard);
+}
+
+/* ── Scrollbars ───────────────────────────────────────────────────────────*/
+::-webkit-scrollbar {
+  width: 8px;
+  height: 8px;
+}
+
+::-webkit-scrollbar-track {
+  background: var(--color-scrollbar-track);
+}
+
+::-webkit-scrollbar-thumb {
+  border-radius: var(--radius-sm);
+  background: var(--color-scrollbar-thumb);
+
+  &:hover {
+    background: var(--color-scrollbar-thumb-hover);
+  }
+}
+
+* {
+  scrollbar-color: var(--color-scrollbar-thumb) var(--color-scrollbar-track);
+  scrollbar-width: thin;
+}
+
+::selection {
+  background: var(--accent-soft);
+}

--- a/docs/.vitepress/theme/styles/_content.scss
+++ b/docs/.vitepress/theme/styles/_content.scss
@@ -1,0 +1,215 @@
+/// Prose — headings, tables, code, and the rest of the reading column.
+/// @group docs-theme
+
+.vp-doc {
+  h1,
+  h2,
+  h3,
+  h4 {
+    letter-spacing: -0.011em;
+  }
+
+  h1 {
+    font-size: var(--font-size-3xl);
+    line-height: var(--line-height-tight);
+  }
+
+  h2 {
+    /* Spacing does the separating; the rule is a whisper, not a divider. */
+    margin-top: 44px;
+    padding-top: 22px;
+    border-top: 1px solid var(--color-border-lighter);
+    font-size: var(--font-size-2xl);
+    letter-spacing: -0.014em;
+  }
+
+  h3 {
+    margin-top: 30px;
+    font-size: var(--font-size-xl);
+  }
+
+  h4 {
+    font-size: var(--font-size-lg);
+  }
+
+  p,
+  li {
+    color: var(--color-text-secondary);
+  }
+
+  a {
+    font-weight: var(--font-weight-medium);
+    font-variation-settings: "wght" var(--font-weight-medium);
+    text-decoration: none;
+    text-underline-offset: 3px;
+    transition: color var(--duration-fast) var(--ease-standard);
+
+    &:hover {
+      color: var(--vp-c-brand-2);
+      text-decoration: underline;
+      text-decoration-color: var(--accent-border);
+    }
+  }
+
+  hr {
+    border-top-color: var(--color-border-lighter);
+  }
+
+  /* ── Inline code ────────────────────────────────────────────────────
+     Also carries every keyboard shortcut in the docs, so it has to read as
+     a discrete chip at a glance. */
+  code {
+    padding: 2px 6px;
+    border-radius: var(--radius-sm);
+    font-size: var(--font-size-sm);
+    font-variation-settings: "wght" var(--font-weight-mono-emphasis);
+  }
+
+  a > code {
+    color: var(--vp-c-brand-1);
+  }
+
+  /* ── Code blocks ────────────────────────────────────────────────────
+     Islands on the reading surface: a tone shift and a radius, no outline. */
+  div[class*="language-"] {
+    border-radius: var(--radius-lg);
+    background-color: var(--vp-code-block-bg);
+  }
+
+  div[class*="language-"] > span.lang {
+    font-family: var(--font-family-mono);
+    font-size: var(--font-size-2xs);
+    letter-spacing: 0.04em;
+    text-transform: uppercase;
+  }
+
+  [class*="language-"] pre {
+    font-variation-settings: "wght" var(--font-weight-mono-normal);
+  }
+
+  .vp-code-group .tabs {
+    border-radius: var(--radius-lg) var(--radius-lg) 0 0;
+    box-shadow: none;
+  }
+
+  /* ── Tables ─────────────────────────────────────────────────────────
+     The docs lean on tables for catalogs of settings, formats and keys.
+     VitePress boxes every cell, which turns a reference table into a grid
+     of little boxes. Rules between rows are enough; the header earns the
+     one solid line on the page. */
+  table {
+    display: table;
+    width: 100%;
+    margin: var(--spacing-xl) 0;
+    border-collapse: collapse;
+    font-size: var(--font-size-sm);
+  }
+
+  th,
+  td {
+    padding: 10px var(--spacing-md);
+    border: none;
+    border-bottom: 1px solid var(--color-border-lighter);
+    text-align: left;
+    vertical-align: top;
+  }
+
+  th {
+    border-bottom: 1px solid var(--color-border);
+    background: transparent;
+    color: var(--color-text-tertiary);
+    font-size: var(--font-size-xs);
+    font-weight: var(--font-weight-semibold);
+    font-variation-settings: "wght" var(--font-weight-semibold);
+    letter-spacing: 0.03em;
+    text-transform: uppercase;
+    white-space: nowrap;
+  }
+
+  td {
+    color: var(--color-text-secondary);
+  }
+
+  /* No zebra striping — the row rules already separate them, and the tint
+     fights every inline code chip sitting in the cell. */
+  tr,
+  tr:nth-child(2n) {
+    background-color: transparent;
+    border-top: none;
+    transition: background-color var(--duration-fast) var(--ease-standard);
+  }
+
+  tbody tr:hover,
+  tbody tr:nth-child(2n):hover {
+    background-color: var(--color-surface-hover);
+  }
+
+  tbody tr:last-child td {
+    border-bottom: none;
+  }
+
+  th:first-child,
+  td:first-child {
+    padding-left: 0;
+  }
+
+  th:last-child,
+  td:last-child {
+    padding-right: 0;
+  }
+
+  /* ── Quotes ─────────────────────────────────────────────────────────*/
+  blockquote {
+    border-left: 2px solid var(--accent-border);
+    padding-left: var(--spacing-lg);
+
+    > p {
+      color: var(--color-text-tertiary);
+      font-size: var(--font-size-md);
+    }
+  }
+
+  /* ── Images ─────────────────────────────────────────────────────────*/
+  img {
+    border-radius: var(--radius-lg);
+  }
+
+  /* ── Mermaid ────────────────────────────────────────────────────────
+     Diagrams are a figure, not a code block — sit them on the canvas so
+     they separate from the prose the same way a card does. */
+  .mermaid {
+    margin: var(--spacing-xl) 0;
+    padding: var(--spacing-lg);
+    border-radius: var(--radius-lg);
+    background: var(--color-bg-primary);
+    text-align: center;
+  }
+}
+
+/* ── "Rendered from…" note on generated wrapper pages ────────────────────
+   Every contributor page is a thin shell around a README that lives in the
+   repository (see `writeWrapper` in `.vitepress/config.ts`). The note says
+   where to edit it, so it belongs above the title as quiet metadata — not as
+   a callout competing with the page's own first sentence. */
+.vp-doc .doc-source {
+  margin-bottom: var(--spacing-xl);
+  color: var(--color-text-tertiary);
+  font-size: var(--font-size-xs);
+
+  code {
+    padding: 1px 5px;
+    background: var(--color-surface-alt);
+    color: inherit;
+    font-size: var(--font-size-2xs);
+  }
+
+  a {
+    color: inherit;
+    font-weight: var(--font-weight-normal);
+    font-variation-settings: "wght" var(--font-weight-normal);
+
+    &:hover {
+      color: var(--vp-c-brand-1);
+    }
+  }
+}

--- a/docs/.vitepress/theme/styles/_home.scss
+++ b/docs/.vitepress/theme/styles/_home.scss
@@ -1,0 +1,141 @@
+/// Home page — hero and feature islands.
+/// @group docs-theme
+
+/* ── Buttons ──────────────────────────────────────────────────────────────
+   VitePress ships 20px pills. The app's buttons are `--radius-md` rectangles
+   at a fixed height, so these are too — a pill on the landing page and a
+   rounded rectangle everywhere in the product is a visible seam.
+
+   The radius is set through a doubled class because VitePress's own rule is
+   a *scoped* style (`.VPButton.medium[data-v-…]`), which a plain
+   `.VPButton.medium` loses to on specificity. */
+.VPButton.VPButton {
+  font-weight: var(--font-weight-medium);
+  font-variation-settings: "wght" var(--font-weight-medium);
+  transition:
+    background-color var(--duration-fast) var(--ease-standard),
+    border-color var(--duration-fast) var(--ease-standard),
+    color var(--duration-fast) var(--ease-standard);
+
+  &.medium,
+  &.big {
+    border-radius: var(--radius-md);
+    padding: 0 var(--spacing-xl);
+  }
+
+  &.medium {
+    font-size: var(--font-size-md);
+    line-height: 38px;
+  }
+
+  &.big {
+    font-size: var(--font-size-lg);
+    line-height: 42px;
+  }
+
+  &.alt {
+    box-shadow: var(--shadow-xs);
+  }
+}
+
+/* ── Hero ─────────────────────────────────────────────────────────────── */
+.VPHero {
+  .name {
+    font-size: 54px;
+    font-weight: var(--font-weight-semibold);
+    font-variation-settings: "wght" 700;
+    letter-spacing: -0.028em;
+    line-height: 1.05;
+  }
+
+  .text {
+    max-width: 20ch;
+    color: var(--color-text-primary);
+    font-size: 30px;
+    font-weight: var(--font-weight-medium);
+    font-variation-settings: "wght" var(--font-weight-medium);
+    letter-spacing: -0.018em;
+    line-height: 1.2;
+  }
+
+  .tagline {
+    max-width: 52ch;
+    padding-top: var(--spacing-md);
+    color: var(--color-text-secondary);
+    font-size: var(--font-size-lg);
+    line-height: 1.6;
+  }
+
+  .actions {
+    padding-top: var(--spacing-xl);
+    gap: var(--spacing-sm);
+  }
+
+  /* The mascot stands on its own — no gradient blob behind it. */
+  .image-bg {
+    display: none;
+  }
+
+  .VPImage {
+    filter: none;
+  }
+}
+
+@media (min-width: 960px) {
+  .VPHero .name {
+    font-size: 62px;
+  }
+
+  .VPHero .text {
+    font-size: 34px;
+  }
+}
+
+/* ── Feature islands ──────────────────────────────────────────────────────
+   Rounded solid surfaces separated from the page by tone, not outlined. They
+   lift on hover only enough to say they are clickable. */
+.VPFeatures .VPFeature {
+  border: none;
+  border-radius: var(--radius-lg);
+  background-color: var(--color-bg-primary);
+  transition:
+    background-color var(--duration-normal) var(--ease-standard),
+    box-shadow var(--duration-normal) var(--ease-standard),
+    transform var(--duration-normal) var(--ease-standard);
+
+  .title {
+    font-size: var(--font-size-lg);
+    font-weight: var(--font-weight-semibold);
+    font-variation-settings: "wght" var(--font-weight-semibold);
+    letter-spacing: -0.008em;
+  }
+
+  .details {
+    color: var(--color-text-secondary);
+    font-size: var(--font-size-sm);
+    line-height: 1.6;
+  }
+
+  .link-text {
+    padding-top: var(--spacing-md);
+  }
+
+  .link-text-value {
+    color: var(--vp-c-brand-1);
+    font-size: var(--font-size-sm);
+    font-weight: var(--font-weight-medium);
+    font-variation-settings: "wght" var(--font-weight-medium);
+  }
+}
+
+.VPFeatures a.VPFeature:hover {
+  background-color: var(--color-bg-tertiary);
+  box-shadow: var(--shadow-sm);
+  transform: translateY(-2px);
+}
+
+@media (prefers-reduced-motion: reduce) {
+  .VPFeatures a.VPFeature:hover {
+    transform: none;
+  }
+}

--- a/docs/.vitepress/theme/styles/_layout.scss
+++ b/docs/.vitepress/theme/styles/_layout.scss
@@ -1,0 +1,208 @@
+/// App chrome — nav, sidebar, aside, footer.
+/// @group docs-theme
+///
+/// The rule this file exists to enforce: **structural chrome is separated by
+/// surface tone, not by lines.** The nav and sidebar sit on the canvas
+/// (`--color-bg-primary`), the content column on the reading surface
+/// (`--color-bg-secondary`), and the boundary between them is the tone change
+/// itself. Every hairline VitePress draws around that chrome is removed here.
+
+/* ── Nav bar ──────────────────────────────────────────────────────────── */
+.VPNavBar,
+.VPNavBar.has-sidebar .content-body,
+.VPNavBar:not(.home.top) {
+  border-bottom: none;
+  background-color: var(--vp-nav-bg-color);
+}
+
+.VPNavBar .divider,
+.VPNavBar .divider-line,
+.VPNavBar.has-sidebar .divider {
+  display: none;
+}
+
+.VPNavBar .title {
+  border-bottom: none;
+}
+
+.VPNavBarTitle .title {
+  font-size: var(--font-size-lg);
+  letter-spacing: -0.01em;
+}
+
+.VPNavBarTitle .logo {
+  height: 26px;
+  margin-right: var(--spacing-sm);
+}
+
+/* The search trigger is a control, so it reads as one: the `secondary`
+   button recipe — a surface, a real border, a hairline shadow. */
+.VPNavBarSearch .DocSearch-Button {
+  height: 32px;
+  border: 1px solid var(--color-border);
+  border-radius: var(--radius-md);
+  background: var(--color-surface);
+  box-shadow: var(--shadow-xs);
+  transition:
+    background-color var(--duration-fast) var(--ease-standard),
+    border-color var(--duration-fast) var(--ease-standard);
+
+  &:hover {
+    background: var(--color-surface-hover);
+  }
+
+  /* DocSearch's own `.DocSearch-Button:focus` outranks the global focus rule
+     and would drop the browser's default ring on the most prominent control
+     in the nav. */
+  &:focus-visible {
+    outline: 2px solid var(--color-focus-ring);
+    outline-offset: 1px;
+  }
+}
+
+.VPNavBarSearch .DocSearch-Button-Key {
+  border-radius: var(--radius-sm);
+  background: var(--color-bg-tertiary);
+  box-shadow: none;
+  color: var(--color-text-tertiary);
+  font-family: var(--font-family-mono);
+  font-size: var(--font-size-2xs);
+}
+
+/* ── Local nav (the mobile "On this page" bar) ────────────────────────── */
+.VPLocalNav {
+  border-bottom: 1px solid var(--color-border-light);
+  background-color: var(--vp-local-nav-bg-color);
+}
+
+/* ── Sidebar ──────────────────────────────────────────────────────────── */
+.VPSidebar {
+  padding-top: var(--spacing-lg);
+}
+
+.VPSidebar .group + .group {
+  border-top: none;
+  margin-top: var(--spacing-xl);
+  padding-top: 0;
+}
+
+/* Section titles are a quiet label, not a second heading level. */
+.VPSidebarItem.level-0 > .item > .text {
+  color: var(--color-text-tertiary);
+  font-size: var(--font-size-xs);
+  font-weight: var(--font-weight-semibold);
+  font-variation-settings: "wght" var(--font-weight-semibold);
+  letter-spacing: 0.04em;
+  text-transform: uppercase;
+}
+
+/* Leaf links behave like rows in the app's own lists: a ghost hover, an
+   `--accent-soft` fill when selected. The colour-only active state VitePress
+   ships is easy to lose against a wall of links. */
+.VPSidebarItem.is-link > .item {
+  margin-inline: calc(var(--spacing-sm) * -1);
+  padding-inline: var(--spacing-sm);
+  border-radius: var(--radius-md);
+  transition: background-color var(--duration-fast) var(--ease-standard);
+}
+
+.VPSidebarItem.is-link:hover > .item {
+  background: var(--color-surface-hover);
+}
+
+.VPSidebarItem.is-link.is-active > .item {
+  background: var(--accent-soft);
+}
+
+.VPSidebarItem.is-link.is-active > .item > .indicator {
+  background-color: transparent;
+}
+
+.VPSidebarItem .link .text {
+  transition: color var(--duration-fast) var(--ease-standard);
+}
+
+/* ── Aside / outline ──────────────────────────────────────────────────── */
+.VPDocAsideOutline .content {
+  border-left-color: var(--color-border-light);
+}
+
+.VPDocOutlineItem .outline-link {
+  transition: color var(--duration-fast) var(--ease-standard);
+
+  &.active {
+    color: var(--vp-c-brand-1);
+    font-weight: var(--font-weight-medium);
+    font-variation-settings: "wght" var(--font-weight-medium);
+  }
+}
+
+.VPDocAside .outline-title {
+  color: var(--color-text-tertiary);
+  font-size: var(--font-size-xs);
+  letter-spacing: 0.04em;
+  text-transform: uppercase;
+}
+
+/* ── Doc footer ───────────────────────────────────────────────────────── */
+.VPDoc .VPDocFooter {
+  border-top: none;
+}
+
+.VPDocFooter .prev-next {
+  border-top: 1px solid var(--color-border-light);
+}
+
+/* Prev/next are islands on the reading surface: a tone shift and a radius,
+   no outline. */
+.VPDocFooter .pager-link {
+  border: none;
+  border-radius: var(--radius-lg);
+  background: var(--color-bg-primary);
+  transition:
+    background-color var(--duration-fast) var(--ease-standard),
+    transform var(--duration-fast) var(--ease-standard);
+
+  &:hover {
+    background: var(--color-bg-tertiary);
+
+    .title {
+      color: var(--vp-c-brand-1);
+    }
+  }
+}
+
+.VPDocFooter .pager-link .desc {
+  color: var(--color-text-tertiary);
+  font-size: var(--font-size-xs);
+}
+
+.VPDocFooter .edit-info .edit-link-button,
+.VPDocFooter .edit-info .last-updated {
+  color: var(--color-text-tertiary);
+  font-size: var(--font-size-sm);
+}
+
+/* ── Flyouts and menus ────────────────────────────────────────────────── */
+.VPMenu {
+  border: 1px solid var(--color-border);
+  border-radius: var(--radius-lg);
+  background: var(--color-surface);
+  box-shadow: var(--shadow-md);
+}
+
+.VPMenuLink .link,
+.VPMenuGroup .VPMenuLink .link {
+  border-radius: var(--radius-md);
+  transition: background-color var(--duration-fast) var(--ease-standard);
+
+  &:hover {
+    background: var(--color-surface-hover);
+  }
+}
+
+/* ── Footer ───────────────────────────────────────────────────────────── */
+.VPFooter {
+  border-top: none;
+  background-color: var(--color-bg-primary);
+}

--- a/docs/.vitepress/theme/styles/_notices.scss
+++ b/docs/.vitepress/theme/styles/_notices.scss
@@ -1,0 +1,163 @@
+/// Custom blocks as `nexus-inline-notice`.
+/// @group docs-theme
+///
+/// The app has exactly one way to raise a contextual note: a solid tinted
+/// surface (never blurred), a tone-coloured icon and title, and quieter body
+/// text. `::: tip` / `::: warning` / `::: danger` are the same idea in prose,
+/// so they get the same shape.
+///
+/// Each severity sets one `--notice-tone`; the base rule mixes it into the
+/// icon and title colour. That is the library's own pattern — one line per
+/// tone, not a repeated block.
+
+.vp-doc .custom-block,
+.custom-block {
+  --notice-tone: var(--color-text-tertiary);
+
+  padding: var(--spacing-md) var(--spacing-lg);
+  border-radius: var(--radius-md);
+  font-size: var(--font-size-sm);
+  line-height: var(--line-height-base);
+
+  p,
+  li {
+    color: inherit;
+    font-size: var(--font-size-sm);
+  }
+
+  a {
+    color: var(--vp-c-brand-1);
+    font-weight: var(--font-weight-medium);
+    font-variation-settings: "wght" var(--font-weight-medium);
+    text-decoration: none;
+
+    &:hover {
+      text-decoration: underline;
+    }
+  }
+
+  code {
+    font-size: var(--font-size-xs);
+  }
+}
+
+.custom-block.tip {
+  --notice-tone: var(--color-secondary);
+}
+
+.custom-block.warning {
+  --notice-tone: var(--color-warning);
+}
+
+.custom-block.danger,
+.custom-block.caution {
+  --notice-tone: var(--color-danger);
+}
+
+.custom-block.important {
+  --notice-tone: var(--color-tertiary);
+}
+
+/* ── Title row — icon, bold lead line ─────────────────────────────────── */
+.custom-block .custom-block-title {
+  display: flex;
+  gap: var(--spacing-sm);
+  align-items: center;
+  margin-bottom: var(--spacing-xs);
+  color: var(--color-text-primary);
+  font-size: var(--font-size-xs);
+  font-weight: var(--font-weight-semibold);
+  font-variation-settings: "wght" var(--font-weight-semibold);
+  letter-spacing: 0.01em;
+}
+
+/* Icons are masked SVGs so a single `background-color` tints them from
+   `--notice-tone`, matching how `nexus-icon` inherits `color`. Stroke width
+   is the app's `--icon-stroke-width`. */
+.custom-block.tip .custom-block-title::before,
+.custom-block.warning .custom-block-title::before,
+.custom-block.danger .custom-block-title::before,
+.custom-block.caution .custom-block-title::before,
+.custom-block.important .custom-block-title::before {
+  content: "";
+  flex: none;
+  width: 15px;
+  height: 15px;
+  background-color: var(--notice-tone);
+  mask-repeat: no-repeat;
+  mask-position: center;
+  mask-size: contain;
+}
+
+.custom-block.tip .custom-block-title::before,
+.custom-block.important .custom-block-title::before {
+  mask-image: url("data:image/svg+xml;utf8,<svg xmlns='http://www.w3.org/2000/svg' viewBox='0 0 24 24' fill='none' stroke='black' stroke-width='1.8' stroke-linecap='round' stroke-linejoin='round'><circle cx='12' cy='12' r='10'/><path d='M12 11.5v5'/><path d='M12 7.51l.01-.011'/></svg>");
+}
+
+.custom-block.warning .custom-block-title::before,
+.custom-block.danger .custom-block-title::before,
+.custom-block.caution .custom-block-title::before {
+  mask-image: url("data:image/svg+xml;utf8,<svg xmlns='http://www.w3.org/2000/svg' viewBox='0 0 24 24' fill='none' stroke='black' stroke-width='1.8' stroke-linecap='round' stroke-linejoin='round'><path d='M10.615 3.892L2.39 18.098c-.569.982.14 2.212 1.276 2.212h16.667c1.135 0 1.845-1.23 1.276-2.212L13.385 3.892c-.567-.98-1.982-.98-2.55 0z'/><path d='M12 9v4'/><path d='M12 16h.01'/></svg>");
+}
+
+/* ── Details — progressive disclosure ─────────────────────────────────────
+   The `use/` pages hide advanced material behind these, so the summary is a
+   real affordance: a caret that turns, and a hover that says it is clickable. */
+.vp-doc .custom-block.details,
+.custom-block.details {
+  padding: 0;
+  background: var(--color-bg-primary);
+
+  > summary {
+    display: flex;
+    gap: var(--spacing-sm);
+    align-items: center;
+    margin: 0;
+    padding: var(--spacing-md) var(--spacing-lg);
+    border-radius: var(--radius-md);
+    color: var(--color-text-secondary);
+    font-size: var(--font-size-sm);
+    font-weight: var(--font-weight-medium);
+    font-variation-settings: "wght" var(--font-weight-medium);
+    cursor: pointer;
+    list-style: none;
+    transition: color var(--duration-fast) var(--ease-standard);
+
+    &::-webkit-details-marker {
+      display: none;
+    }
+
+    &::before {
+      content: "";
+      flex: none;
+      width: 14px;
+      height: 14px;
+      background-color: currentColor;
+      mask-image: url("data:image/svg+xml;utf8,<svg xmlns='http://www.w3.org/2000/svg' viewBox='0 0 24 24' fill='none' stroke='black' stroke-width='1.8' stroke-linecap='round' stroke-linejoin='round'><path d='M9 6l6 6-6 6'/></svg>");
+      mask-repeat: no-repeat;
+      mask-position: center;
+      mask-size: contain;
+      transition: transform var(--duration-fast) var(--ease-standard);
+    }
+
+    &:hover {
+      color: var(--color-text-primary);
+    }
+  }
+
+  &[open] > summary {
+    color: var(--color-text-primary);
+
+    &::before {
+      transform: rotate(90deg);
+    }
+  }
+
+  > *:not(summary) {
+    margin-inline: var(--spacing-lg);
+  }
+
+  > *:last-child:not(summary) {
+    margin-bottom: var(--spacing-lg);
+  }
+}

--- a/docs/.vitepress/theme/styles/_tokens.scss
+++ b/docs/.vitepress/theme/styles/_tokens.scss
@@ -1,0 +1,404 @@
+/// Cold Crabby design language → VitePress.
+/// @group docs-theme
+///
+/// **No colour is defined in this file.** The three `@use`d partials are the
+/// real theme from the shared UI library (ColdCrabby/ui), vendored into
+/// `ui/vendor/coldcrabby-ui` and resolved through the Sass `loadPaths` in
+/// `.vitepress/config.ts` — exactly how the Angular app consumes them. Change
+/// the accent in the library and this site follows; the docs cannot drift from
+/// the product they document.
+///
+/// Everything below is a *bridge*: it maps those tokens onto the `--vp-*`
+/// variables VitePress's default theme reads. Add a mapping here rather than a
+/// literal value anywhere else in the theme.
+
+@use "theme/light";
+@use "theme/dark";
+@use "theme/root";
+
+:root {
+  /* ── Typeface ─────────────────────────────────────────────────────────
+     The same pairing the app ships: Plus Jakarta Sans over IBM Plex Mono. */
+  --vp-font-family-base: var(--font-family-ui);
+  --vp-font-family-mono: var(--font-family-mono);
+
+  /* ── Brand = the accent ───────────────────────────────────────────────
+     VitePress splits a brand colour three ways: `1` is text-safe (links,
+     titles), `2` is its hover, `3` is a solid fill. Molten amber is bright
+     enough to fill a button but too light to read as body text on a
+     near-white canvas, so light mode borrows the darker `--accent-active`
+     for `1` and dark mode uses the accent as-is. */
+  --vp-c-brand-1: var(--accent-active);
+  --vp-c-brand-2: var(--accent);
+  --vp-c-brand-3: var(--accent);
+  --vp-c-brand-soft: var(--accent-soft);
+  --vp-c-brand: var(--accent);
+
+  /* ── Surfaces ─────────────────────────────────────────────────────────
+     Regions separate by tone, never by a line. The content column is the
+     bright reading surface; the nav, sidebar and footer sit on the calmer
+     app canvas and recede behind it. */
+  --vp-c-bg: var(--color-bg-secondary);
+  --vp-c-bg-alt: var(--color-bg-primary);
+  --vp-c-bg-soft: var(--color-bg-primary);
+  --vp-c-bg-elv: var(--color-surface);
+
+  --vp-c-text-1: var(--color-text-primary);
+  --vp-c-text-2: var(--color-text-secondary);
+  --vp-c-text-3: var(--color-text-tertiary);
+
+  --vp-c-divider: var(--color-border-light);
+  --vp-c-border: var(--color-border);
+  --vp-c-gutter: transparent;
+
+  --vp-c-default-1: var(--color-text-secondary);
+  --vp-c-default-2: var(--color-text-tertiary);
+  --vp-c-default-3: var(--color-border);
+  --vp-c-default-soft: var(--color-surface-alt);
+
+  --vp-c-neutral: var(--color-text-primary);
+  --vp-c-neutral-inverse: var(--color-bg-secondary);
+
+  --vp-shadow-1: var(--shadow-xs);
+  --vp-shadow-2: var(--shadow-sm);
+  --vp-shadow-3: var(--shadow-md);
+  --vp-shadow-4: var(--shadow-md);
+  --vp-shadow-5: var(--shadow-lg);
+
+  --vp-backdrop-bg-color: var(--scrim);
+
+  /* ── Status families ──────────────────────────────────────────────────
+     Same severities the app uses. `tip` is the teal secondary, which is what
+     `nexus-inline-notice` calls its `info` tone. */
+  --vp-c-tip-1: var(--color-secondary);
+  --vp-c-tip-2: var(--color-secondary-hover);
+  --vp-c-tip-3: var(--color-secondary-active);
+  --vp-c-tip-soft: color-mix(in oklab, var(--color-secondary) 12%, transparent);
+
+  --vp-c-note-1: var(--color-text-secondary);
+  --vp-c-note-2: var(--color-text-tertiary);
+  --vp-c-note-3: var(--color-border);
+  --vp-c-note-soft: var(--color-surface-alt);
+
+  --vp-c-success-1: var(--color-success);
+  --vp-c-success-2: var(--color-success);
+  --vp-c-success-3: var(--color-success);
+  --vp-c-success-soft: color-mix(
+    in oklab,
+    var(--color-success) 12%,
+    transparent
+  );
+
+  --vp-c-important-1: var(--color-tertiary);
+  --vp-c-important-2: var(--color-tertiary-hover);
+  --vp-c-important-3: var(--color-tertiary-active);
+  --vp-c-important-soft: color-mix(
+    in oklab,
+    var(--color-tertiary) 12%,
+    transparent
+  );
+
+  --vp-c-warning-1: var(--color-warning);
+  --vp-c-warning-2: var(--color-warning);
+  --vp-c-warning-3: var(--color-warning);
+  --vp-c-warning-soft: color-mix(
+    in oklab,
+    var(--color-warning) 12%,
+    transparent
+  );
+
+  --vp-c-danger-1: var(--color-danger);
+  --vp-c-danger-2: var(--color-danger);
+  --vp-c-danger-3: var(--color-danger);
+  --vp-c-danger-soft: color-mix(in oklab, var(--color-danger) 12%, transparent);
+
+  --vp-c-caution-1: var(--color-danger);
+  --vp-c-caution-2: var(--color-danger);
+  --vp-c-caution-3: var(--color-danger);
+  --vp-c-caution-soft: color-mix(
+    in oklab,
+    var(--color-danger) 12%,
+    transparent
+  );
+
+  /* Palette aliases VitePress still reaches for in a few components. */
+  --vp-c-indigo-1: var(--accent-active);
+  --vp-c-indigo-2: var(--accent);
+  --vp-c-indigo-3: var(--accent);
+  --vp-c-indigo-soft: var(--accent-soft);
+  --vp-c-green-1: var(--color-success);
+  --vp-c-green-soft: color-mix(in oklab, var(--color-success) 12%, transparent);
+  --vp-c-yellow-1: var(--color-warning);
+  --vp-c-yellow-soft: color-mix(
+    in oklab,
+    var(--color-warning) 12%,
+    transparent
+  );
+  --vp-c-red-1: var(--color-danger);
+  --vp-c-red-soft: color-mix(in oklab, var(--color-danger) 12%, transparent);
+  --vp-c-purple-1: var(--color-tertiary);
+  --vp-c-purple-soft: color-mix(
+    in oklab,
+    var(--color-tertiary) 12%,
+    transparent
+  );
+  --vp-c-sponsor: var(--color-danger);
+
+  /* ── Chrome ───────────────────────────────────────────────────────────
+     The nav is close to the app's own titlebar height so the two feel like
+     one product; nav and sidebar share the canvas so nothing is boxed in. */
+  --vp-nav-height: 56px;
+  --vp-nav-bg-color: var(--color-bg-primary);
+  --vp-nav-screen-bg-color: var(--color-bg-primary);
+  --vp-local-nav-bg-color: var(--color-bg-primary);
+  --vp-sidebar-bg-color: var(--color-bg-primary);
+  --vp-sidebar-width: 264px;
+  --vp-layout-max-width: 1400px;
+
+  --vp-input-bg-color: var(--color-surface);
+  --vp-input-border-color: var(--color-border);
+  --vp-input-switch-bg-color: var(--color-bg-tertiary);
+
+  /* ── Buttons — mirrors `button[nexusButton]` ─────────────────────────
+     Primary is an accent fill with `--accent-contrast` text and no border.
+     Alt is the `secondary` variant: a surface with a real border, because a
+     button is a hit target and earns its outline. */
+  --vp-button-brand-bg: var(--accent);
+  --vp-button-brand-text: var(--accent-contrast);
+  --vp-button-brand-border: transparent;
+  --vp-button-brand-hover-bg: var(--accent-hover);
+  --vp-button-brand-hover-text: var(--accent-contrast);
+  --vp-button-brand-hover-border: transparent;
+  --vp-button-brand-active-bg: var(--accent-active);
+  --vp-button-brand-active-text: var(--accent-contrast);
+  --vp-button-brand-active-border: transparent;
+
+  --vp-button-alt-bg: var(--color-surface);
+  --vp-button-alt-text: var(--color-text-primary);
+  --vp-button-alt-border: var(--color-border);
+  --vp-button-alt-hover-bg: var(--color-surface-hover);
+  --vp-button-alt-hover-text: var(--color-text-primary);
+  --vp-button-alt-hover-border: var(--color-border);
+  --vp-button-alt-active-bg: var(--color-surface-active);
+  --vp-button-alt-active-text: var(--color-text-primary);
+  --vp-button-alt-active-border: var(--color-border);
+
+  /* ── Code ─────────────────────────────────────────────────────────────
+     A block sits one tone away from the page in both modes: a warm grey on
+     the light canvas, a deeper graphite on the dark one. */
+  --vp-code-font-size: 0.875em;
+  --vp-code-line-height: 1.65;
+  --vp-code-block-bg: var(--color-bg-primary);
+  --vp-code-block-color: var(--color-text-secondary);
+  --vp-code-block-divider-color: var(--color-border);
+  --vp-code-bg: var(--color-surface-alt);
+  --vp-code-color: var(--color-text-primary);
+  --vp-code-link-color: var(--vp-c-brand-1);
+  --vp-code-link-hover-color: var(--accent-hover);
+  --vp-code-lang-color: var(--color-text-tertiary);
+  --vp-code-line-number-color: var(--color-text-tertiary);
+  --vp-code-line-highlight-color: var(--accent-softer);
+  --vp-code-line-diff-add-color: color-mix(
+    in oklab,
+    var(--color-success) 16%,
+    transparent
+  );
+  --vp-code-line-diff-add-symbol-color: var(--color-success);
+  --vp-code-line-diff-remove-color: color-mix(
+    in oklab,
+    var(--color-danger) 16%,
+    transparent
+  );
+  --vp-code-line-diff-remove-symbol-color: var(--color-danger);
+  --vp-code-line-warning-color: color-mix(
+    in oklab,
+    var(--color-warning) 16%,
+    transparent
+  );
+  --vp-code-line-error-color: color-mix(
+    in oklab,
+    var(--color-danger) 16%,
+    transparent
+  );
+
+  --vp-code-copy-code-bg: var(--color-surface);
+  --vp-code-copy-code-hover-bg: var(--color-surface-hover);
+  --vp-code-copy-code-border-color: var(--color-border);
+  --vp-code-copy-code-hover-border-color: var(--color-border);
+  --vp-code-copy-code-active-text: var(--color-text-secondary);
+
+  --vp-code-tab-bg: var(--color-bg-primary);
+  --vp-code-tab-divider: var(--color-border);
+  --vp-code-tab-text-color: var(--color-text-tertiary);
+  --vp-code-tab-hover-text-color: var(--color-text-primary);
+  --vp-code-tab-active-text-color: var(--color-text-primary);
+  --vp-code-tab-active-bar-color: var(--accent);
+
+  /* ── Custom blocks — the `nexus-inline-notice` recipe ────────────────
+     One tone per severity, mixed 8% into the surface for the fill and 28%
+     into transparent for the border. Solid, never blurred. */
+  --vp-custom-block-font-size: var(--font-size-md);
+  --vp-custom-block-code-font-size: 0.875em;
+
+  --vp-custom-block-tip-border: color-mix(
+    in oklab,
+    var(--color-secondary) 28%,
+    transparent
+  );
+  --vp-custom-block-tip-text: var(--color-text-secondary);
+  --vp-custom-block-tip-bg: color-mix(
+    in oklab,
+    var(--color-secondary) 8%,
+    var(--color-surface)
+  );
+  --vp-custom-block-tip-code-bg: color-mix(
+    in oklab,
+    var(--color-secondary) 14%,
+    transparent
+  );
+
+  --vp-custom-block-info-border: var(--color-border);
+  --vp-custom-block-info-text: var(--color-text-secondary);
+  --vp-custom-block-info-bg: var(--color-bg-primary);
+  --vp-custom-block-info-code-bg: var(--color-surface-alt);
+
+  --vp-custom-block-note-border: var(--color-border);
+  --vp-custom-block-note-text: var(--color-text-secondary);
+  --vp-custom-block-note-bg: var(--color-bg-primary);
+  --vp-custom-block-note-code-bg: var(--color-surface-alt);
+
+  --vp-custom-block-important-border: color-mix(
+    in oklab,
+    var(--color-tertiary) 28%,
+    transparent
+  );
+  --vp-custom-block-important-text: var(--color-text-secondary);
+  --vp-custom-block-important-bg: color-mix(
+    in oklab,
+    var(--color-tertiary) 8%,
+    var(--color-surface)
+  );
+  --vp-custom-block-important-code-bg: color-mix(
+    in oklab,
+    var(--color-tertiary) 14%,
+    transparent
+  );
+
+  --vp-custom-block-warning-border: color-mix(
+    in oklab,
+    var(--color-warning) 28%,
+    transparent
+  );
+  --vp-custom-block-warning-text: var(--color-text-secondary);
+  --vp-custom-block-warning-bg: color-mix(
+    in oklab,
+    var(--color-warning) 8%,
+    var(--color-surface)
+  );
+  --vp-custom-block-warning-code-bg: color-mix(
+    in oklab,
+    var(--color-warning) 14%,
+    transparent
+  );
+
+  --vp-custom-block-danger-border: color-mix(
+    in oklab,
+    var(--color-danger) 28%,
+    transparent
+  );
+  --vp-custom-block-danger-text: var(--color-text-secondary);
+  --vp-custom-block-danger-bg: color-mix(
+    in oklab,
+    var(--color-danger) 8%,
+    var(--color-surface)
+  );
+  --vp-custom-block-danger-code-bg: color-mix(
+    in oklab,
+    var(--color-danger) 14%,
+    transparent
+  );
+
+  --vp-custom-block-caution-border: color-mix(
+    in oklab,
+    var(--color-danger) 28%,
+    transparent
+  );
+  --vp-custom-block-caution-text: var(--color-text-secondary);
+  --vp-custom-block-caution-bg: color-mix(
+    in oklab,
+    var(--color-danger) 8%,
+    var(--color-surface)
+  );
+  --vp-custom-block-caution-code-bg: color-mix(
+    in oklab,
+    var(--color-danger) 14%,
+    transparent
+  );
+
+  --vp-custom-block-details-border: var(--color-border);
+  --vp-custom-block-details-text: var(--color-text-secondary);
+  --vp-custom-block-details-bg: var(--color-bg-primary);
+  --vp-custom-block-details-code-bg: var(--color-surface-alt);
+
+  /* ── Badges ───────────────────────────────────────────────────────── */
+  --vp-badge-info-border: var(--color-border);
+  --vp-badge-info-text: var(--color-text-secondary);
+  --vp-badge-info-bg: var(--color-surface-alt);
+  --vp-badge-tip-border: color-mix(
+    in oklab,
+    var(--color-secondary) 28%,
+    transparent
+  );
+  --vp-badge-tip-text: var(--color-secondary);
+  --vp-badge-tip-bg: color-mix(
+    in oklab,
+    var(--color-secondary) 10%,
+    transparent
+  );
+  --vp-badge-warning-border: color-mix(
+    in oklab,
+    var(--color-warning) 28%,
+    transparent
+  );
+  --vp-badge-warning-text: var(--color-warning);
+  --vp-badge-warning-bg: color-mix(
+    in oklab,
+    var(--color-warning) 10%,
+    transparent
+  );
+  --vp-badge-danger-border: color-mix(
+    in oklab,
+    var(--color-danger) 28%,
+    transparent
+  );
+  --vp-badge-danger-text: var(--color-danger);
+  --vp-badge-danger-bg: color-mix(
+    in oklab,
+    var(--color-danger) 10%,
+    transparent
+  );
+
+  /* ── Search ───────────────────────────────────────────────────────── */
+  --vp-local-search-bg: var(--color-surface);
+  --vp-local-search-result-bg: var(--color-surface);
+  --vp-local-search-result-border: transparent;
+  --vp-local-search-result-selected-bg: var(--color-surface-hover);
+  --vp-local-search-result-selected-border: var(--accent-border);
+  --vp-local-search-highlight-bg: var(--accent-soft);
+  --vp-local-search-highlight-text: var(--color-text-primary);
+
+  /* The hero name is a flat accent word, not a gradient — gradients are
+     decoration, and the one loud move on this page is the mascot. */
+  --vp-home-hero-name-color: var(--vp-c-brand-1);
+  --vp-home-hero-name-background: transparent;
+  --vp-home-hero-image-background-image: none;
+  --vp-home-hero-image-filter: none;
+}
+
+.dark {
+  /* Amber lightens against graphite, so the accent itself is already the
+     text-safe shade; `--accent-active` would only mute it. */
+  --vp-c-brand-1: var(--accent);
+  --vp-c-brand-2: var(--accent-hover);
+  --vp-c-brand-3: var(--accent);
+}

--- a/docs/.vitepress/theme/styles/index.scss
+++ b/docs/.vitepress/theme/styles/index.scss
@@ -1,0 +1,12 @@
+/// Docs theme entry.
+/// @group docs-theme
+///
+/// Order matters: `tokens` must come first so every rule below it (and every
+/// component style) has the Cold Crabby variables to consume.
+
+@use "tokens";
+@use "base";
+@use "layout";
+@use "content";
+@use "notices";
+@use "home";

--- a/docs/brand.md
+++ b/docs/brand.md
@@ -41,27 +41,47 @@ regenerate.
 
 ## Colour
 
-The default accent is **molten amber**.
+The default accent is **molten amber**. It lightens a little in dark mode so it
+stays legible on graphite — the chip below is whichever you're reading in right
+now, read straight off this page's own theme.
 
-| | Light | Dark |
-| --- | --- | --- |
-| Accent | `#e0730f` | `#f5883a` |
+<Swatches :items="[{ name: 'Molten Amber', value: 'var(--accent)', note: 'Default accent' }]" />
 
 Five alternates ship alongside it, and users can pick any colour they like:
 
-| | |
-| --- | --- |
-| Teal | `#0d8f86` |
-| Indigo | `#5b62e0` |
-| Violet | `#7c5cff` |
-| Rose | `#e0568b` |
-| Forest | `#3f9d5a` |
+<Swatches :items="[
+  { name: 'Teal', value: '#0d8f86' },
+  { name: 'Indigo', value: '#5b62e0' },
+  { name: 'Violet', value: '#7c5cff' },
+  { name: 'Rose', value: '#e0568b' },
+  { name: 'Forest', value: '#3f9d5a' }
+]" />
 
 On macOS and Windows the app can inherit the **system accent** instead. That's
 not a compromise — it's the intent. See below.
 
-Everything else is neutral: near-white surfaces in light mode, deep graphite in
-dark. Models render in neutral grey unless you turn on filament colouring.
+Everything else is neutral: warm graphite, near-white in light mode and deep in
+dark. These are the surfaces the app is built from, and the ones this page is
+drawn on.
+
+<Swatches :items="[
+  { name: 'Canvas', value: 'var(--color-bg-primary)' },
+  { name: 'Surface', value: 'var(--color-surface)' },
+  { name: 'Border', value: 'var(--color-border)' },
+  { name: 'Text', value: 'var(--color-text-primary)' },
+  { name: 'Muted text', value: 'var(--color-text-secondary)' }
+]" />
+
+Three more carry meaning, and only meaning — a green that says something worked,
+an amber that says check this, a red that says this will destroy something:
+
+<Swatches :items="[
+  { name: 'Success', value: 'var(--color-success)' },
+  { name: 'Warning', value: 'var(--color-warning)' },
+  { name: 'Danger', value: 'var(--color-danger)' }
+]" />
+
+Models render in neutral grey unless you turn on filament colouring.
 
 ## The design language
 

--- a/docs/index.md
+++ b/docs/index.md
@@ -18,9 +18,6 @@ hero:
     - theme: alt
       text: For teams
       link: /teams/
-    - theme: alt
-      text: GitHub
-      link: https://github.com/max-scopp/slicer-engine
 
 features:
   - title: Nothing to install

--- a/docs/package.json
+++ b/docs/package.json
@@ -11,6 +11,7 @@
     "devDependencies": {
         "@types/node": "^25.6.0",
         "mermaid": "^11.17.0",
+        "sass": "^1.97.1",
         "vitepress": "^1.6.3",
         "vitepress-plugin-mermaid": "^2.0.17"
     }

--- a/pnpm-lock.yaml
+++ b/pnpm-lock.yaml
@@ -33,6 +33,9 @@ importers:
       mermaid:
         specifier: ^11.17.0
         version: 11.17.2
+      sass:
+        specifier: ^1.97.1
+        version: 1.101.0
       vitepress:
         specifier: ^1.6.3
         version: 1.6.4(@algolia/client-search@5.51.0)(@types/node@25.6.0)(fuse.js@7.5.0)(lightningcss@1.33.0)(postcss@8.5.26)(sass@1.101.0)(search-insights@2.17.3)(typescript@6.0.3)


### PR DESCRIPTION
The docs site looked like stock VitePress sitting next to a product with a
carefully tuned design language. Rather than approximate that language with a
copied palette, the theme now **reads the app's real token files**.

## How it works

[`docs/.vitepress/theme/styles/_tokens.scss`](docs/.vitepress/theme/styles/_tokens.scss)
`@use`s the shared UI library's own `theme/_light`, `_dark` and `_root`
partials — vendored at `ui/vendor/coldcrabby-ui` and resolved through Sass
`loadPaths`, the same idiom `ui/angular.json` already uses — and maps them onto
VitePress's `--vp-*` variables.

**No colour, radius, duration or font literal lives in the docs theme.** Change
the accent in the library and the docs recolour with it; the two cannot drift.
The rule is written down in AGENTS.md so it stays that way.

## What it changes

The rest of `styles/` applies the rules those tokens exist to serve:

- **Chrome separates by surface tone, not hairlines.** The borders VitePress
  draws around the nav, sidebar, footer and pager are removed. Sidebar links
  get the app's ghost hover and `--accent-soft` selected fill instead of a
  colour-only active state.
- **Custom blocks follow the `nexus-inline-notice` recipe** — one tone per
  severity, mixed 8% into the surface and 28% into the border, with matching
  icons. Solid, never blurred. `::: details` gains a real disclosure caret.
- **Focus is a 2px accent outline everywhere**, matching the app's global rule.
- **Reference tables lose their per-cell box and zebra tint.** The header
  carries the one solid rule; rows separate with hairlines. The `use/` pages
  lean on tables heavily and they read as catalogs now rather than grids.
- **Cards are islands** at `--radius-lg` — feature cards, prev/next, code
  blocks, Mermaid figures. Buttons are `--radius-md` rectangles rather than
  pills, so the landing page and the product agree.
- **Plus Jakarta Sans over IBM Plex Mono**, with the variable weight axes the
  app uses (462 / 536 / 614) rather than the nearest 100-step.

## Content touches

- The brand page's hex tables become a `Swatches` component that prints each
  chip's **resolved** colour off the live theme, so it can never quote a colour
  the product no longer uses. Neutrals and status colours are shown too.
- The generated "Source:" pull-quote on contributor pages becomes a quiet
  metadata line above the title, instead of a callout competing with the page's
  own first sentence.
- The hero drops its GitHub button — already the nav's social link. Easy to put
  back if you'd rather keep it.

## For reviewers

- **The docs build now needs the vendored UI checkout.** A tree that never ran
  `ui`'s postinstall fails with "Can't find stylesheet to import" — run
  `pnpm --filter slicer-ui vendor:ui`. CI installs the workspace, so it is
  covered.
- Two rules needed extra specificity, and both say why at the site: VitePress's
  component styles are scoped (`.VPButton.medium[data-v-…]`), and DocSearch
  ships its own `button:focus` ring that would otherwise beat the global focus
  rule on the most prominent control in the nav.
- `sass` is the one new devDependency. No CHANGELOG entry — this is the docs
  site's presentation, not an app change.

Verified in the browser at 1440px, tablet and 420px, in both modes, across the
home page, a `use/` page, a `teams/` page with code and a danger notice, a
Mermaid-heavy module README, and the search modal. `pnpm docs:build` passes.

## Before / after

**Home** — VitePress indigo, pill buttons, outlined cards → the accent, rectangles, islands.

| Before | After |
| --- | --- |
| <img width="700" alt="before-home" src="https://github.com/user-attachments/assets/c141585a-73c5-461e-81aa-6ec2f8ae5acc" /> | <img width="700" alt="after-home" src="https://github.com/user-attachments/assets/9e4528ab-5e48-405c-b4af-51c9e04f2299" /> |

**A `use/` page** — the boxed table and the indigo tip block are the two things this section leans on most.

| Before | After |
| --- | --- |
| <img width="700" alt="before-doc" src="https://github.com/user-attachments/assets/112ab4d7-8c1b-423a-aa56-b6dc750df68a" /> | <img width="700" alt="after-doc" src="https://github.com/user-attachments/assets/df89896a-71c4-409f-957c-c3daa772d439" /> |
