### PR TITLE
ui: page-by-page catalog loading, real detail import, busy import state

### DIFF
--- a/AGENTS.md
+++ b/AGENTS.md
@@ -739,22 +739,27 @@ browse ("Pick it from the catalog"). Its data lives in a separate service — th
   `fetch`. Output lands in `ui/src/generated/catalog-client/` (git-ignored, like
   every other generated artifact). **Never hand-edit it, and never re-add the
   vendored spec** — regenerate instead.
-- **The served API is search-only.** Today the contract exposes `GET /v1/health`
-  and `GET /v1/presets` (fuzzy search returning *summaries* — id, type, name,
-  vendor, model/material, a short human `spec` string), **not** full preset
-  bodies. There is no detail or bulk endpoint yet.
+- **The served API is search-plus-detail, never bulk.** `GET /v1/presets`
+  (fuzzy search returning *summaries* — id, type, name, vendor, model/material,
+  a short human `spec` string) and `GET /v1/vendors` are both cursor-paginated;
+  `GET /v1/presets/{id}` returns the *complete* preset in the slicer's own
+  shape (`source`, `import_url`, the full sparse `params` bag). There is still
+  no bulk "dump everything" endpoint — see "Slicer Integration" above.
 - **`CatalogSource` is the seam.**
   [`CloudCatalog`](ui/src/app/services/catalog/cloud-catalog.ts) talks only to
   the `CatalogSource` interface, so the backend is a one-line provider override.
   Each of the three categories is **loaded and searched independently** — opening
-  the printer picker fetches only printers — with its own status, active query
-  and out-of-order guard (`loadPrinters`/`searchPrinters`/… ).
+  the printer picker fetches only printers — with its own status, active query,
+  cursor and out-of-order guard (`loadPrinters`/`searchPrinters`/… ).
   [`RemoteCatalogSource`](ui/src/app/services/catalog/remote-catalog-source.ts)
-  is the real implementation: it *browses* each category (an empty query filtered
-  by `type`, paged through the cursor) and widens every summary into the profile
-  shape the wizards consume, using the `make*` factories for the structured
-  fields a summary cannot carry and tagging the result `source: 'catalog'` with
-  an `import_url` back to the preset's canonical detail URL. It also carries the
+  is the real implementation: list calls fetch **one page at a time** (an empty
+  query browses, a non-empty one searches) rather than walking the cursor to
+  exhaustion, so opening a picker never blocks on — or holds in memory — a whole
+  category; `CloudCatalog.loadMore*`/`*HasMore`/`*LoadingMore` back the picker's
+  "Load more" affordance. Every summary is widened into the profile shape the
+  wizards consume, using the `make*` factories for the structured fields a
+  summary cannot carry and tagging the result `source: 'catalog'` with an
+  `import_url` back to the preset's canonical detail URL. It also carries the
   summary's `spec` string through the hidden `CATALOG_SPEC_KEY` so the picker
   shows the *catalog's own* spec line rather than one reconstructed from
   defaulted fields; `toUserCopy` strips it on import. It passes an `Injector`
@@ -763,6 +768,22 @@ browse ("Pick it from the catalog"). Its data lives in a separate service — th
   rejects, which `CloudCatalog` turns into its `unavailable` state — the UI then
   offers "create from scratch" and the single builtin default per category keeps
   the app working offline.
+- **Importing fetches the real preset before committing.** A summary carries no
+  slicing parameters, so every wizard's "Use preset" and every settings page's
+  "Import" calls `CloudCatalog.printerDetail`/`filamentDetail`/`profileDetail`
+  (→ `GET /v1/presets/{id}`) and overlays the response's `params` onto the
+  already-widened summary *before* creating the local copy — never the summary
+  alone. This is a real network round trip, so each of the six call sites
+  (`printer-wizard`, `filament-wizard`, `profile-wizard`,
+  `pages/settings/{printers,filaments,profiles}`) tracks its own `importingId`
+  signal and passes it to `nexus-catalog-picker`'s `[importingId]` input, which
+  swaps that one entry's pick button for a disabled "Importing…" spinner state —
+  the busy affordance is per-row, not a modal-wide block, so browsing and
+  picking a *different* entry stays live. A failure surfaces through
+  `NotificationService.error` and leaves the picker exactly as it was; nothing
+  is added on failure. Domain fields a detail response doesn't carry yet (a
+  printer's bed size; a filament's color/density/cost) keep the summary's
+  best-effort defaults — only `params` is authoritative from the detail call.
 - **The base URL is configured once at startup.** `environment.catalogApiUrl`
   feeds both the `RemoteCatalogSource` provider and `provideCatalogClient()` in
   [app.config.ts](ui/src/app/app.config.ts) — which wires the client's
@@ -772,9 +793,9 @@ browse ("Pick it from the catalog"). Its data lives in a separate service — th
   (`http://<host>:8787`, the repo's `pnpm sample-api` — canned presets with open
   CORS); prod/web builds point at the deployed cloud
   (`https://cloud-presets.onrender.com`).
-- **Non-goal (for now):** importing a *complete* preset body. The summary lacks
-  the ~92 slicing parameters, so a catalog pick can only pre-fill identity fields
-  until the cloud grows a detail/bulk endpoint and the client is regenerated.
+- **Non-goal (for now):** a bulk "dump every preset" endpoint. Only the
+  summary/detail pair above is supported, so a full plate-wide catalog import
+  still means one round trip per preset, never one call for everything.
 
 ## Scene Engine — SSOT Contract
 

--- a/ui/src/app/components/profiles/catalog-picker.html
+++ b/ui/src/app/components/profiles/catalog-picker.html
@@ -69,11 +69,39 @@
               <nexus-icon name="check" />
               Imported
             </span>
+          } @else if (entry.id === importingId()) {
+            <button type="button" class="catalog__pick catalog__pick--busy" disabled>
+              <span class="catalog__spinner catalog__spinner--inline"></span>
+              Importing…
+            </button>
           } @else {
-            <button type="button" class="catalog__pick" (click)="pick.emit(entry.id)">
+            <button
+              type="button"
+              class="catalog__pick"
+              [disabled]="!!importingId()"
+              (click)="pick.emit(entry.id)"
+            >
               {{ actionLabel() }}
             </button>
           }
+        </li>
+      }
+      @if (hasMore()) {
+        <li class="catalog__load-more">
+          <button
+            type="button"
+            class="catalog__retry"
+            [disabled]="loadingMore()"
+            (click)="loadMore.emit()"
+          >
+            @if (loadingMore()) {
+              <span class="catalog__spinner catalog__spinner--inline"></span>
+              Loading…
+            } @else {
+              <nexus-icon name="nav-arrow-down" />
+              Load more
+            }
+          </button>
         </li>
       }
     </ul>

--- a/ui/src/app/components/profiles/catalog-picker.scss
+++ b/ui/src/app/components/profiles/catalog-picker.scss
@@ -121,6 +121,30 @@
     font-weight: var(--font-weight-medium);
     font-variation-settings: 'wght' var(--font-weight-medium);
   }
+
+  &:disabled {
+    cursor: default;
+    opacity: 0.6;
+  }
+}
+
+.catalog__pick--busy {
+  display: inline-flex;
+  align-items: center;
+  gap: var(--spacing-xs);
+
+  &:hover {
+    // A busy pick button never invites a second click.
+    background: var(--color-surface);
+    border-color: var(--color-border);
+    color: var(--color-text-primary);
+  }
+}
+
+.catalog__load-more {
+  display: flex;
+  justify-content: center;
+  padding: var(--spacing-xs) 0;
 }
 
 .catalog__imported {
@@ -166,6 +190,11 @@
 
   &:hover {
     background: var(--color-surface-hover);
+  }
+
+  &:disabled {
+    cursor: default;
+    opacity: 0.6;
   }
 }
 

--- a/ui/src/app/components/profiles/catalog-picker.ts
+++ b/ui/src/app/components/profiles/catalog-picker.ts
@@ -54,11 +54,19 @@ export class CatalogPicker {
   readonly unavailable = input(false);
   /** Label for the pick action (e.g. "Import", "Use preset"). */
   readonly actionLabel = input('Import');
+  /** Id of the entry currently being imported, if any; shows a busy pick button. */
+  readonly importingId = input<string | null>(null);
+  /** True when another page of results can be fetched via {@link loadMore}. */
+  readonly hasMore = input(false);
+  /** True while a "load more" fetch is in flight. */
+  readonly loadingMore = input(false);
 
   readonly pick = output<string>();
   readonly retry = output<void>();
   /** Fuzzy query to re-fetch the catalog for; debounced from keystrokes. */
   readonly search = output<string>();
+  /** Emitted when the user asks for the next page of results. */
+  readonly loadMore = output<void>();
 
   protected readonly query = signal('');
 

--- a/ui/src/app/components/profiles/filament-wizard.html
+++ b/ui/src/app/components/profiles/filament-wizard.html
@@ -34,10 +34,14 @@
             [entries]="catalogEntries()"
             [loading]="catalogStatus() === 'loading'"
             [unavailable]="catalogStatus() === 'unavailable'"
+            [importingId]="importingId()"
+            [hasMore]="catalogHasMore()"
+            [loadingMore]="catalogLoadingMore()"
             actionLabel="Use preset"
             (pick)="startFromCatalog($event)"
             (retry)="retryCatalog()"
             (search)="onCatalogSearch($event)"
+            (loadMore)="loadMoreCatalog()"
           />
         </div>
       </div>

--- a/ui/src/app/components/profiles/filament-wizard.ts
+++ b/ui/src/app/components/profiles/filament-wizard.ts
@@ -12,6 +12,7 @@ import {
 import { CloudCatalog, catalogSpecOf, toUserCopy } from '../../services/catalog/cloud-catalog';
 import { ActiveSelection } from '../../services/profiles/active-selection';
 import { FilamentsStore } from '../../services/profiles/filaments-store';
+import { NotificationService } from '../../services/notifications';
 import { Icon, NumberInput, Select, ColorPicker, FieldRow, WizardShell } from '@coldcrabby/ui';
 import { CatalogPicker, type CatalogEntryVm } from './catalog-picker';
 import { paramNum } from '../../models/params-access';
@@ -35,6 +36,7 @@ export class FilamentWizard {
   private readonly catalog = inject(CloudCatalog);
   private readonly store = inject(FilamentsStore);
   private readonly active = inject(ActiveSelection);
+  private readonly notifications = inject(NotificationService);
   private readonly router = inject(Router);
 
   protected readonly steps = STEPS;
@@ -47,6 +49,10 @@ export class FilamentWizard {
   }));
 
   protected readonly catalogStatus = this.catalog.filamentsStatus;
+  protected readonly catalogHasMore = this.catalog.filamentsHasMore;
+  protected readonly catalogLoadingMore = this.catalog.filamentsLoadingMore;
+  /** Id of the catalog entry currently being fetched for import, if any. */
+  protected readonly importingId = signal<string | null>(null);
   protected readonly catalogEntries = computed<CatalogEntryVm[]>(() =>
     this.catalog.filaments().map((f) => ({
       id: f.id,
@@ -115,12 +121,33 @@ export class FilamentWizard {
     this.index.set(1);
   }
 
-  protected startFromCatalog(id: string): void {
-    const entry = this.catalog.filaments().find((f) => f.id === id);
-    if (entry) {
-      this.draft.set(toUserCopy(entry));
-      this.index.set(1);
+  /**
+   * Fetch the full preset behind `id` (real slicing params, not just the
+   * browsed summary) and seed the draft from it. The catalog picker shows a
+   * busy state on this entry's pick button for the duration.
+   */
+  protected async startFromCatalog(id: string): Promise<void> {
+    const base = this.catalog.filaments().find((f) => f.id === id);
+    if (!base || this.importingId()) {
+      return;
     }
+    this.importingId.set(id);
+    try {
+      const full = await this.catalog.filamentDetail(base);
+      this.draft.set(toUserCopy(full));
+      this.index.set(1);
+    } catch (error) {
+      this.notifications.error(
+        'Could not load preset',
+        error instanceof Error ? error.message : 'The preset details could not be fetched.',
+      );
+    } finally {
+      this.importingId.set(null);
+    }
+  }
+
+  protected loadMoreCatalog(): void {
+    void this.catalog.loadMoreFilaments();
   }
 
   protected onCatalogSearch(query: string): void {

--- a/ui/src/app/components/profiles/printer-wizard.html
+++ b/ui/src/app/components/profiles/printer-wizard.html
@@ -188,10 +188,14 @@
               [entries]="catalogEntries()"
               [loading]="catalogStatus() === 'loading'"
               [unavailable]="catalogStatus() === 'unavailable'"
+              [importingId]="importingId()"
+              [hasMore]="catalogHasMore()"
+              [loadingMore]="catalogLoadingMore()"
               actionLabel="Use preset"
               (pick)="startFromCatalog($event)"
               (retry)="retryCatalog()"
               (search)="onCatalogSearch($event)"
+              (loadMore)="loadMoreCatalog()"
             />
           }
         </div>

--- a/ui/src/app/components/profiles/printer-wizard.ts
+++ b/ui/src/app/components/profiles/printer-wizard.ts
@@ -11,6 +11,7 @@ import {
 import { CloudCatalog, catalogSpecOf, toUserCopy } from '../../services/catalog/cloud-catalog';
 import { ActiveSelection } from '../../services/profiles/active-selection';
 import { PrintersStore } from '../../services/profiles/printers-store';
+import { NotificationService } from '../../services/notifications';
 import {
   PrinterConnectionService,
   type PrinterDetectionResult,
@@ -72,6 +73,7 @@ export class PrinterWizard {
   private readonly store = inject(PrintersStore);
   private readonly active = inject(ActiveSelection);
   private readonly printerConn = inject(PrinterConnectionService);
+  private readonly notifications = inject(NotificationService);
   private readonly router = inject(Router);
 
   protected readonly steps = STEPS;
@@ -157,6 +159,10 @@ export class PrinterWizard {
   protected readonly flavorOptions = PRINTER_GCODE_FLAVORS;
 
   protected readonly catalogStatus = this.catalog.printersStatus;
+  protected readonly catalogHasMore = this.catalog.printersHasMore;
+  protected readonly catalogLoadingMore = this.catalog.printersLoadingMore;
+  /** Id of the catalog entry currently being fetched for import, if any. */
+  protected readonly importingId = signal<string | null>(null);
   protected readonly catalogEntries = computed<CatalogEntryVm[]>(() =>
     this.catalog.printers().map((p) => ({
       id: p.id,
@@ -215,12 +221,33 @@ export class PrinterWizard {
     this.draft.set(makePrinter());
     this.index.set(1);
   }
-  protected startFromCatalog(id: string): void {
-    const entry = this.catalog.printers().find((p) => p.id === id);
-    if (entry) {
-      this.draft.set(toUserCopy(entry));
-      this.index.set(1);
+  /**
+   * Fetch the full preset behind `id` (real slicing params, not just the
+   * browsed summary) and seed the draft from it. The catalog picker shows a
+   * busy state on this entry's pick button for the duration.
+   */
+  protected async startFromCatalog(id: string): Promise<void> {
+    const base = this.catalog.printers().find((p) => p.id === id);
+    if (!base || this.importingId()) {
+      return;
     }
+    this.importingId.set(id);
+    try {
+      const full = await this.catalog.printerDetail(base);
+      this.draft.set(toUserCopy(full));
+      this.index.set(1);
+    } catch (error) {
+      this.notifications.error(
+        'Could not load preset',
+        error instanceof Error ? error.message : 'The preset details could not be fetched.',
+      );
+    } finally {
+      this.importingId.set(null);
+    }
+  }
+
+  protected loadMoreCatalog(): void {
+    void this.catalog.loadMorePrinters();
   }
 
   protected setDetectHost(event: Event): void {

--- a/ui/src/app/components/profiles/profile-wizard.html
+++ b/ui/src/app/components/profiles/profile-wizard.html
@@ -34,10 +34,14 @@
             [entries]="catalogEntries()"
             [loading]="catalogStatus() === 'loading'"
             [unavailable]="catalogStatus() === 'unavailable'"
+            [importingId]="importingId()"
+            [hasMore]="catalogHasMore()"
+            [loadingMore]="catalogLoadingMore()"
             actionLabel="Use preset"
             (pick)="startFromCatalog($event)"
             (retry)="retryCatalog()"
             (search)="onCatalogSearch($event)"
+            (loadMore)="loadMoreCatalog()"
           />
         </div>
       </div>

--- a/ui/src/app/components/profiles/profile-wizard.ts
+++ b/ui/src/app/components/profiles/profile-wizard.ts
@@ -15,6 +15,7 @@ import {
 import { CloudCatalog, catalogSpecOf, toUserCopy } from '../../services/catalog/cloud-catalog';
 import { ActiveSelection } from '../../services/profiles/active-selection';
 import { PrintProfilesStore } from '../../services/profiles/print-profiles-store';
+import { NotificationService } from '../../services/notifications';
 import {
   Icon,
   NumberInput,
@@ -42,6 +43,7 @@ export class ProfileWizard {
   private readonly catalog = inject(CloudCatalog);
   private readonly store = inject(PrintProfilesStore);
   private readonly active = inject(ActiveSelection);
+  private readonly notifications = inject(NotificationService);
   private readonly router = inject(Router);
 
   protected readonly steps = STEPS;
@@ -54,6 +56,10 @@ export class ProfileWizard {
   protected readonly adhesionOptions = ADHESION_TYPES;
 
   protected readonly catalogStatus = this.catalog.profilesStatus;
+  protected readonly catalogHasMore = this.catalog.profilesHasMore;
+  protected readonly catalogLoadingMore = this.catalog.profilesLoadingMore;
+  /** Id of the catalog entry currently being fetched for import, if any. */
+  protected readonly importingId = signal<string | null>(null);
   protected readonly catalogEntries = computed<CatalogEntryVm[]>(() =>
     this.catalog.profiles().map((p) => {
       const params = (p.params as Record<string, unknown>) ?? {};
@@ -132,12 +138,33 @@ export class ProfileWizard {
     this.index.set(1);
   }
 
-  protected startFromCatalog(id: string): void {
-    const entry = this.catalog.profiles().find((p) => p.id === id);
-    if (entry) {
-      this.draft.set(toUserCopy(entry));
-      this.index.set(1);
+  /**
+   * Fetch the full preset behind `id` (real slicing params, not just the
+   * browsed summary) and seed the draft from it. The catalog picker shows a
+   * busy state on this entry's pick button for the duration.
+   */
+  protected async startFromCatalog(id: string): Promise<void> {
+    const base = this.catalog.profiles().find((p) => p.id === id);
+    if (!base || this.importingId()) {
+      return;
     }
+    this.importingId.set(id);
+    try {
+      const full = await this.catalog.profileDetail(base);
+      this.draft.set(toUserCopy(full));
+      this.index.set(1);
+    } catch (error) {
+      this.notifications.error(
+        'Could not load preset',
+        error instanceof Error ? error.message : 'The preset details could not be fetched.',
+      );
+    } finally {
+      this.importingId.set(null);
+    }
+  }
+
+  protected loadMoreCatalog(): void {
+    void this.catalog.loadMoreProfiles();
   }
 
   protected onCatalogSearch(query: string): void {

--- a/ui/src/app/pages/settings/filaments.html
+++ b/ui/src/app/pages/settings/filaments.html
@@ -251,10 +251,14 @@
       [entries]="catalogEntries()"
       [loading]="catalogStatus() === 'loading'"
       [unavailable]="catalogStatus() === 'unavailable'"
+      [importingId]="importingId()"
+      [hasMore]="catalogHasMore()"
+      [loadingMore]="catalogLoadingMore()"
       actionLabel="Import"
       (pick)="importFromCatalog($event)"
       (retry)="retryCatalog()"
       (search)="onCatalogSearch($event)"
+      (loadMore)="loadMoreCatalog()"
     />
   </nexus-modal-shell>
 }

--- a/ui/src/app/pages/settings/filaments.ts
+++ b/ui/src/app/pages/settings/filaments.ts
@@ -25,6 +25,7 @@ import { ContextMenuService } from '../../services/context-menu/context-menu.ser
 import { ContextMenuTrigger } from '../../services/context-menu/context-menu-trigger';
 import type { ContextMenuItem } from '../../services/context-menu/context-menu.model';
 import { Dialog } from '../../services/dialog';
+import { NotificationService } from '../../services/notifications';
 import { ActiveSelection } from '../../services/profiles/active-selection';
 import { matchesAllLabels, toggledLabelIds } from '../../services/profiles/label-filtering';
 import { paramNum } from '../../models/params-access';
@@ -133,6 +134,7 @@ export class FilamentsSettings {
   private readonly catalog = inject(CloudCatalog);
   private readonly contextMenu = inject(ContextMenuService);
   private readonly dialog = inject(Dialog);
+  private readonly notifications = inject(NotificationService);
   private readonly route = inject(ActivatedRoute);
 
   protected readonly sourceLabels = PROFILE_SOURCE_LABELS;
@@ -255,6 +257,10 @@ export class FilamentsSettings {
   }
 
   protected readonly catalogStatus = this.catalog.filamentsStatus;
+  protected readonly catalogHasMore = this.catalog.filamentsHasMore;
+  protected readonly catalogLoadingMore = this.catalog.filamentsLoadingMore;
+  /** Id of the catalog entry currently being fetched for import, if any. */
+  protected readonly importingId = signal<string | null>(null);
   protected readonly catalogEntries = computed<CatalogEntryVm[]>(() =>
     this.catalog.filaments().map((f) => ({
       id: f.id,
@@ -281,14 +287,34 @@ export class FilamentsSettings {
     void this.catalog.loadFilaments(true, this.catalog.filamentsQuery());
   }
 
-  protected importFromCatalog(id: string): void {
-    const entry = this.catalog.filaments().find((f) => f.id === id);
-    if (!entry) {
+  protected loadMoreCatalog(): void {
+    void this.catalog.loadMoreFilaments();
+  }
+
+  /**
+   * Fetch the full preset behind `id` (real slicing params, not just the
+   * browsed summary) and import it. The catalog picker shows a busy state on
+   * this entry's pick button for the duration.
+   */
+  protected async importFromCatalog(id: string): Promise<void> {
+    const base = this.catalog.filaments().find((f) => f.id === id);
+    if (!base || this.importingId()) {
       return;
     }
-    const copy = this.store.importFromCatalog(entry);
-    this.active.selectFilament(copy.id);
-    this.select(copy.id);
+    this.importingId.set(id);
+    try {
+      const full = await this.catalog.filamentDetail(base);
+      const copy = this.store.importFromCatalog(full);
+      this.active.selectFilament(copy.id);
+      this.select(copy.id);
+    } catch (error) {
+      this.notifications.error(
+        'Import failed',
+        error instanceof Error ? error.message : 'The preset details could not be fetched.',
+      );
+    } finally {
+      this.importingId.set(null);
+    }
   }
 
   /** Open a filament in the detail pane. */

--- a/ui/src/app/pages/settings/printers.html
+++ b/ui/src/app/pages/settings/printers.html
@@ -409,10 +409,14 @@
       [entries]="catalogEntries()"
       [loading]="catalogStatus() === 'loading'"
       [unavailable]="catalogStatus() === 'unavailable'"
+      [importingId]="importingId()"
+      [hasMore]="catalogHasMore()"
+      [loadingMore]="catalogLoadingMore()"
       actionLabel="Import"
       (pick)="importFromCatalog($event)"
       (retry)="retryCatalog()"
       (search)="onCatalogSearch($event)"
+      (loadMore)="loadMoreCatalog()"
     />
   </nexus-modal-shell>
 }

--- a/ui/src/app/pages/settings/printers.ts
+++ b/ui/src/app/pages/settings/printers.ts
@@ -36,6 +36,7 @@ import { ContextMenuService } from '../../services/context-menu/context-menu.ser
 import { ContextMenuTrigger } from '../../services/context-menu/context-menu-trigger';
 import type { ContextMenuItem } from '../../services/context-menu/context-menu.model';
 import { Dialog } from '../../services/dialog';
+import { NotificationService } from '../../services/notifications';
 import { PrinterConnectionService } from '../../services/printer-connection';
 import { ActiveSelection } from '../../services/profiles/active-selection';
 import { matchesAllLabels, toggledLabelIds } from '../../services/profiles/label-filtering';
@@ -149,6 +150,7 @@ export class PrintersSettings {
   private readonly catalog = inject(CloudCatalog);
   private readonly contextMenu = inject(ContextMenuService);
   private readonly dialog = inject(Dialog);
+  private readonly notifications = inject(NotificationService);
   private readonly printerConn = inject(PrinterConnectionService);
   private readonly route = inject(ActivatedRoute);
 
@@ -288,6 +290,10 @@ export class PrintersSettings {
   }
 
   protected readonly catalogStatus = this.catalog.printersStatus;
+  protected readonly catalogHasMore = this.catalog.printersHasMore;
+  protected readonly catalogLoadingMore = this.catalog.printersLoadingMore;
+  /** Id of the catalog entry currently being fetched for import, if any. */
+  protected readonly importingId = signal<string | null>(null);
   protected readonly catalogEntries = computed<CatalogEntryVm[]>(() =>
     this.catalog.printers().map((p) => ({
       id: p.id,
@@ -316,14 +322,34 @@ export class PrintersSettings {
     void this.catalog.loadPrinters(true, this.catalog.printersQuery());
   }
 
-  protected importFromCatalog(id: string): void {
-    const entry = this.catalog.printers().find((p) => p.id === id);
-    if (!entry) {
+  protected loadMoreCatalog(): void {
+    void this.catalog.loadMorePrinters();
+  }
+
+  /**
+   * Fetch the full preset behind `id` (real slicing params, not just the
+   * browsed summary) and import it. The catalog picker shows a busy state on
+   * this entry's pick button for the duration.
+   */
+  protected async importFromCatalog(id: string): Promise<void> {
+    const base = this.catalog.printers().find((p) => p.id === id);
+    if (!base || this.importingId()) {
       return;
     }
-    const copy = this.store.importFromCatalog(entry);
-    this.active.selectPrinter(copy.id);
-    this.select(copy.id);
+    this.importingId.set(id);
+    try {
+      const full = await this.catalog.printerDetail(base);
+      const copy = this.store.importFromCatalog(full);
+      this.active.selectPrinter(copy.id);
+      this.select(copy.id);
+    } catch (error) {
+      this.notifications.error(
+        'Import failed',
+        error instanceof Error ? error.message : 'The preset details could not be fetched.',
+      );
+    } finally {
+      this.importingId.set(null);
+    }
   }
 
   /** Open a printer in the detail pane and refresh its live status. */

--- a/ui/src/app/pages/settings/profiles.html
+++ b/ui/src/app/pages/settings/profiles.html
@@ -220,10 +220,14 @@
       [entries]="catalogEntries()"
       [loading]="catalogStatus() === 'loading'"
       [unavailable]="catalogStatus() === 'unavailable'"
+      [importingId]="importingId()"
+      [hasMore]="catalogHasMore()"
+      [loadingMore]="catalogLoadingMore()"
       actionLabel="Import"
       (pick)="importFromCatalog($event)"
       (retry)="retryCatalog()"
       (search)="onCatalogSearch($event)"
+      (loadMore)="loadMoreCatalog()"
     />
   </nexus-modal-shell>
 }

--- a/ui/src/app/pages/settings/profiles.ts
+++ b/ui/src/app/pages/settings/profiles.ts
@@ -18,6 +18,7 @@ import { ContextMenuService } from '../../services/context-menu/context-menu.ser
 import { ContextMenuTrigger } from '../../services/context-menu/context-menu-trigger';
 import type { ContextMenuItem } from '../../services/context-menu/context-menu.model';
 import { Dialog } from '../../services/dialog';
+import { NotificationService } from '../../services/notifications';
 import { ActiveSelection } from '../../services/profiles/active-selection';
 import { matchesAllLabels, toggledLabelIds } from '../../services/profiles/label-filtering';
 import { paramNum } from '../../models/params-access';
@@ -99,6 +100,7 @@ export class ProfilesSettings {
   private readonly catalog = inject(CloudCatalog);
   private readonly contextMenu = inject(ContextMenuService);
   private readonly dialog = inject(Dialog);
+  private readonly notifications = inject(NotificationService);
   private readonly route = inject(ActivatedRoute);
 
   protected readonly sourceLabels = PROFILE_SOURCE_LABELS;
@@ -213,6 +215,10 @@ export class ProfilesSettings {
   }
 
   protected readonly catalogStatus = this.catalog.profilesStatus;
+  protected readonly catalogHasMore = this.catalog.profilesHasMore;
+  protected readonly catalogLoadingMore = this.catalog.profilesLoadingMore;
+  /** Id of the catalog entry currently being fetched for import, if any. */
+  protected readonly importingId = signal<string | null>(null);
   protected readonly catalogEntries = computed<CatalogEntryVm[]>(() =>
     this.catalog.profiles().map((p) => {
       const params = (p.params as Record<string, unknown>) ?? {};
@@ -246,14 +252,34 @@ export class ProfilesSettings {
     void this.catalog.loadProfiles(true, this.catalog.profilesQuery());
   }
 
-  protected importFromCatalog(id: string): void {
-    const entry = this.catalog.profiles().find((p) => p.id === id);
-    if (!entry) {
+  protected loadMoreCatalog(): void {
+    void this.catalog.loadMoreProfiles();
+  }
+
+  /**
+   * Fetch the full preset behind `id` (real slicing params, not just the
+   * browsed summary) and import it. The catalog picker shows a busy state on
+   * this entry's pick button for the duration.
+   */
+  protected async importFromCatalog(id: string): Promise<void> {
+    const base = this.catalog.profiles().find((p) => p.id === id);
+    if (!base || this.importingId()) {
       return;
     }
-    const copy = this.store.importFromCatalog(entry);
-    this.active.selectProfile(copy.id);
-    this.select(copy.id);
+    this.importingId.set(id);
+    try {
+      const full = await this.catalog.profileDetail(base);
+      const copy = this.store.importFromCatalog(full);
+      this.active.selectProfile(copy.id);
+      this.select(copy.id);
+    } catch (error) {
+      this.notifications.error(
+        'Import failed',
+        error instanceof Error ? error.message : 'The preset details could not be fetched.',
+      );
+    } finally {
+      this.importingId.set(null);
+    }
   }
 
   /** Open a profile in the detail pane. */

--- a/ui/src/app/services/catalog/cloud-catalog.ts
+++ b/ui/src/app/services/catalog/cloud-catalog.ts
@@ -1,9 +1,22 @@
-import { Injectable, InjectionToken, type WritableSignal, inject, signal } from '@angular/core';
+import {
+  Injectable,
+  InjectionToken,
+  type WritableSignal,
+  computed,
+  inject,
+  signal,
+} from '@angular/core';
 import type { FilamentProfile } from '../../models/filament.model';
 import type { PrintProfile } from '../../models/print-profile.model';
 import type { PrinterProfile } from '../../models/printer.model';
 import type { ProfileMeta } from '../../models/profile-source';
 import { uid } from '../../models/id';
+
+/** One page of catalog results plus the cursor to fetch the next one, if any. */
+export interface CatalogPage<T> {
+  items: T[];
+  nextCursor?: string;
+}
 
 /**
  * The remote data contract. `CloudCatalog` talks only to this interface, so
@@ -12,14 +25,26 @@ import { uid } from '../../models/id';
  * `CloudCatalog` turns that into an `unavailable` state rather than throwing at
  * the call site.
  *
- * Each method takes an optional fuzzy `query`. Search is the **server's** job —
- * the source re-fetches ranked, filtered results for the query rather than the
- * UI filtering a cached page — so the query flows all the way to the API.
+ * The list methods take an optional fuzzy `query` and an optional `cursor` from
+ * a previous {@link CatalogPage}. Search is the **server's** job — the source
+ * re-fetches ranked, filtered results for the query rather than the UI
+ * filtering a cached page — and paging is walked **one page at a time** rather
+ * than eagerly fetched to exhaustion, so opening a picker never has to wait for
+ * (or hold in memory) the whole catalog.
+ *
+ * `*Detail` fetches the full preset for an already-loaded summary — the only
+ * way to obtain real slicing parameters, since list results are summaries. It
+ * overlays the fetched fields onto `base` rather than rebuilding a profile from
+ * scratch, so identity fields the detail response doesn't carry (e.g. a
+ * printer's bed size) keep the summary's best-effort defaults.
  */
 export interface CatalogSource {
-  printers(query?: string): Promise<PrinterProfile[]>;
-  filaments(query?: string): Promise<FilamentProfile[]>;
-  profiles(query?: string): Promise<PrintProfile[]>;
+  printers(query?: string, cursor?: string): Promise<CatalogPage<PrinterProfile>>;
+  filaments(query?: string, cursor?: string): Promise<CatalogPage<FilamentProfile>>;
+  profiles(query?: string, cursor?: string): Promise<CatalogPage<PrintProfile>>;
+  printerDetail(base: PrinterProfile): Promise<PrinterProfile>;
+  filamentDetail(base: FilamentProfile): Promise<FilamentProfile>;
+  profileDetail(base: PrintProfile): Promise<PrintProfile>;
 }
 
 /**
@@ -33,13 +58,22 @@ export interface CatalogSource {
  */
 export class UnavailableCatalogSource implements CatalogSource {
   private readonly reason = 'Cloud catalog is not connected.';
-  printers(_query?: string): Promise<PrinterProfile[]> {
+  printers(): Promise<CatalogPage<PrinterProfile>> {
     return Promise.reject(new Error(this.reason));
   }
-  filaments(_query?: string): Promise<FilamentProfile[]> {
+  filaments(): Promise<CatalogPage<FilamentProfile>> {
     return Promise.reject(new Error(this.reason));
   }
-  profiles(_query?: string): Promise<PrintProfile[]> {
+  profiles(): Promise<CatalogPage<PrintProfile>> {
+    return Promise.reject(new Error(this.reason));
+  }
+  printerDetail(): Promise<PrinterProfile> {
+    return Promise.reject(new Error(this.reason));
+  }
+  filamentDetail(): Promise<FilamentProfile> {
+    return Promise.reject(new Error(this.reason));
+  }
+  profileDetail(): Promise<PrintProfile> {
     return Promise.reject(new Error(this.reason));
   }
 }
@@ -89,11 +123,15 @@ export function toUserCopy<T extends ProfileMeta>(entry: T, name?: string): T {
   return copy;
 }
 
-/** Mutable per-category state: the results, their status, and the query. */
+/** Mutable per-category state: the results, their status, the query, and paging. */
 interface CategoryState<T> {
   readonly data: WritableSignal<T[]>;
   readonly status: WritableSignal<CatalogStatus>;
   readonly query: WritableSignal<string>;
+  /** Cursor for the next page, or `undefined` once the last page was seen. */
+  readonly nextCursor: WritableSignal<string | undefined>;
+  /** True while a "load more" fetch (not the initial/search load) is in flight. */
+  readonly loadingMore: WritableSignal<boolean>;
   /** Monotonic token so a slow fetch can't overwrite a newer one. */
   seq: number;
 }
@@ -103,6 +141,8 @@ function newCategoryState<T>(): CategoryState<T> {
     data: signal<T[]>([]),
     status: signal<CatalogStatus>('idle'),
     query: signal(''),
+    nextCursor: signal<string | undefined>(undefined),
+    loadingMore: signal(false),
     seq: 0,
   };
 }
@@ -140,17 +180,28 @@ export class CloudCatalog {
   readonly filamentsQuery = this.filamentsState.query.asReadonly();
   readonly profilesQuery = this.processesState.query.asReadonly();
 
-  /** Load printers for `query` (empty = browse). Cached unless `force`. */
+  /** True when another page of printers is available via {@link loadMorePrinters}. */
+  readonly printersHasMore = computed(() => this.printersState.nextCursor() !== undefined);
+  /** True when another page of filaments is available via {@link loadMoreFilaments}. */
+  readonly filamentsHasMore = computed(() => this.filamentsState.nextCursor() !== undefined);
+  /** True when another page of profiles is available via {@link loadMoreProfiles}. */
+  readonly profilesHasMore = computed(() => this.processesState.nextCursor() !== undefined);
+
+  readonly printersLoadingMore = this.printersState.loadingMore.asReadonly();
+  readonly filamentsLoadingMore = this.filamentsState.loadingMore.asReadonly();
+  readonly profilesLoadingMore = this.processesState.loadingMore.asReadonly();
+
+  /** Load the first page of printers for `query` (empty = browse). Cached unless `force`. */
   loadPrinters(force = false, query = ''): Promise<void> {
-    return this.run(this.printersState, (q) => this.source.printers(q), force, query);
+    return this.run(this.printersState, (q, c) => this.source.printers(q, c), force, query);
   }
-  /** Load filaments for `query` (empty = browse). Cached unless `force`. */
+  /** Load the first page of filaments for `query` (empty = browse). Cached unless `force`. */
   loadFilaments(force = false, query = ''): Promise<void> {
-    return this.run(this.filamentsState, (q) => this.source.filaments(q), force, query);
+    return this.run(this.filamentsState, (q, c) => this.source.filaments(q, c), force, query);
   }
-  /** Load processes for `query` (empty = browse). Cached unless `force`. */
+  /** Load the first page of processes for `query` (empty = browse). Cached unless `force`. */
   loadProfiles(force = false, query = ''): Promise<void> {
-    return this.run(this.processesState, (q) => this.source.profiles(q), force, query);
+    return this.run(this.processesState, (q, c) => this.source.profiles(q, c), force, query);
   }
 
   /** Re-fetch printers filtered by a fuzzy `query`. Always hits the source. */
@@ -166,14 +217,44 @@ export class CloudCatalog {
     return this.loadProfiles(true, query);
   }
 
+  /** Append the next page of printers, if {@link printersHasMore}. */
+  loadMorePrinters(): Promise<void> {
+    return this.loadMore(this.printersState, (q, c) => this.source.printers(q, c));
+  }
+  /** Append the next page of filaments, if {@link filamentsHasMore}. */
+  loadMoreFilaments(): Promise<void> {
+    return this.loadMore(this.filamentsState, (q, c) => this.source.filaments(q, c));
+  }
+  /** Append the next page of processes, if {@link profilesHasMore}. */
+  loadMoreProfiles(): Promise<void> {
+    return this.loadMore(this.processesState, (q, c) => this.source.profiles(q, c));
+  }
+
   /**
-   * Shared fetch driver for one category. Skips a redundant fetch when the same
-   * query is already loaded (unless `force`), and drops out-of-order responses
-   * via the per-category sequence token so the latest query always wins.
+   * Fetch the full preset behind a catalog summary and overlay its real
+   * `params` onto `base`. Used at import time — list results carry only
+   * summaries, so this is the one network round-trip that turns "a name and a
+   * spec string" into a profile actually worth importing.
+   */
+  printerDetail(base: PrinterProfile): Promise<PrinterProfile> {
+    return this.source.printerDetail(base);
+  }
+  filamentDetail(base: FilamentProfile): Promise<FilamentProfile> {
+    return this.source.filamentDetail(base);
+  }
+  profileDetail(base: PrintProfile): Promise<PrintProfile> {
+    return this.source.profileDetail(base);
+  }
+
+  /**
+   * Shared fetch driver for one category's first page. Skips a redundant fetch
+   * when the same query is already loaded (unless `force`), and drops
+   * out-of-order responses via the per-category sequence token so the latest
+   * query always wins.
    */
   private async run<T>(
     state: CategoryState<T>,
-    fetcher: (query: string) => Promise<T[]>,
+    fetcher: (query: string, cursor?: string) => Promise<CatalogPage<T>>,
     force: boolean,
     query: string,
   ): Promise<void> {
@@ -189,17 +270,51 @@ export class CloudCatalog {
     state.query.set(q);
     state.status.set('loading');
     try {
-      const data = await fetcher(q);
+      const page = await fetcher(q);
       if (seq !== state.seq) {
         return;
       }
-      state.data.set(data);
+      state.data.set(page.items);
+      state.nextCursor.set(page.nextCursor);
       state.status.set('ready');
     } catch {
       if (seq !== state.seq) {
         return;
       }
       state.status.set('unavailable');
+    }
+  }
+
+  /**
+   * Append one more page of results for a category, using its cursor from the
+   * last {@link run}. A no-op when there is no cursor (last page already seen)
+   * or a "load more" fetch is already in flight. Dropped, not retried, on
+   * out-of-order or failed responses \u2014 the cursor stays put so the next click
+   * on "Load more" simply tries again.
+   */
+  private async loadMore<T>(
+    state: CategoryState<T>,
+    fetcher: (query: string, cursor?: string) => Promise<CatalogPage<T>>,
+  ): Promise<void> {
+    const cursor = state.nextCursor();
+    if (!cursor || state.loadingMore()) {
+      return;
+    }
+    const seq = state.seq;
+    state.loadingMore.set(true);
+    try {
+      const page = await fetcher(state.query(), cursor);
+      if (seq !== state.seq) {
+        return;
+      }
+      state.data.update((list) => [...list, ...page.items]);
+      state.nextCursor.set(page.nextCursor);
+    } catch {
+      // Leave the cursor as-is: the user can retry via "Load more".
+    } finally {
+      if (seq === state.seq) {
+        state.loadingMore.set(false);
+      }
     }
   }
 }

--- a/ui/src/app/services/catalog/remote-catalog-source.ts
+++ b/ui/src/app/services/catalog/remote-catalog-source.ts
@@ -1,5 +1,5 @@
 import { Injector } from '@angular/core';
-import { searchPresets, type PresetSummary } from '../../../generated/catalog-client';
+import { getPreset, searchPresets, type PresetSummary } from '../../../generated/catalog-client';
 import {
   FILAMENT_MATERIALS,
   makeFilament,
@@ -8,27 +8,34 @@ import {
 } from '../../models/filament.model';
 import { makePrinter, type PrinterProfile } from '../../models/printer.model';
 import { makePrintProfile, type PrintProfile } from '../../models/print-profile.model';
-import { type CatalogSource, CATALOG_SPEC_KEY } from './cloud-catalog';
+import { type CatalogPage, type CatalogSource, CATALOG_SPEC_KEY } from './cloud-catalog';
 
-/** Hard ceiling per the OpenAPI `limit` bound. */
-const PAGE_LIMIT = 100;
-/** Safety cap on pages walked, so a broken cursor can never loop forever. */
-const MAX_PAGES = 100;
+/**
+ * Page size for browsing/searching. Deliberately well under the OpenAPI
+ * `limit` ceiling (100): a picker shows one page at a time (see
+ * {@link CloudCatalog.loadMorePrinters} and friends), so the first paint only
+ * has to wait on this many rows rather than the whole category.
+ */
+const PAGE_LIMIT = 30;
 
 type PresetType = NonNullable<PresetSummary['type']>;
 
 /**
  * The real {@link CatalogSource}: the Cold Crabby Preset Cloud.
  *
- * The served API only exposes fuzzy **search** returning *summaries* — there is
- * no endpoint yet for a full preset body — so each category is fetched by
- * *browsing* (an empty query, filtered by `type`) and paging through the cursor
- * until the catalog is exhausted. Every summary is widened into the profile
- * shape the existing wizards consume: the {@link makePrinter}/{@link makeFilament}/
- * {@link makePrintProfile} factories supply valid defaults for the structured
- * fields the summary cannot carry, and the summary's own fields (name, vendor,
- * model/material) overwrite them. The result is tagged `source: 'catalog'` with
- * an `import_url` back to the preset's canonical detail URL for lineage.
+ * List methods fetch **one page at a time** (an empty query browses; a
+ * non-empty one searches) rather than walking the cursor to exhaustion, so
+ * opening a picker never blocks on \u2014 or holds in memory \u2014 the whole category.
+ * Every summary is widened into the profile shape the existing wizards
+ * consume: the {@link makePrinter}/{@link makeFilament}/{@link makePrintProfile}
+ * factories supply valid defaults for the structured fields a summary cannot
+ * carry, and the summary's own fields (name, vendor, model/material) overwrite
+ * them. The result is tagged `source: 'catalog'` with an `import_url` back to
+ * the preset's canonical detail URL for lineage.
+ *
+ * `*Detail` calls `GET /v1/presets/{id}` for the full preset and overlays its
+ * real `params` onto the already-widened summary, which is what turns a
+ * browsed entry into something actually worth importing.
  *
  * Any transport or HTTP error rejects, which {@link CloudCatalog} turns into its
  * `unavailable` state — the app then falls back to "create from scratch".
@@ -45,47 +52,88 @@ export class RemoteCatalogSource implements CatalogSource {
     private readonly injector: Injector,
   ) {}
 
-  async printers(query?: string): Promise<PrinterProfile[]> {
-    const summaries = await this.browse('printer', query);
-    return summaries.map((s) =>
-      makePrinter({
-        id: s.id,
-        name: s.name,
-        vendor: s.vendor,
-        model: s.model ?? 'Generic',
-        source: 'catalog',
-        import_url: this.detailUrl(s.id),
-        [CATALOG_SPEC_KEY]: s.spec,
-      }),
-    );
+  async printers(query?: string, cursor?: string): Promise<CatalogPage<PrinterProfile>> {
+    const page = await this.fetchPage('printer', query, cursor);
+    return {
+      items: page.results.map((s) =>
+        makePrinter({
+          id: s.id,
+          name: s.name,
+          vendor: s.vendor,
+          model: s.model ?? 'Generic',
+          source: 'catalog',
+          import_url: this.detailUrl(s.id),
+          [CATALOG_SPEC_KEY]: s.spec,
+        }),
+      ),
+      nextCursor: page.nextCursor,
+    };
   }
 
-  async filaments(query?: string): Promise<FilamentProfile[]> {
-    const summaries = await this.browse('filament', query);
-    return summaries.map((s) =>
-      makeFilament({
-        id: s.id,
-        name: s.name,
-        vendor: s.vendor,
-        material: coerceMaterial(s.material),
-        source: 'catalog',
-        import_url: this.detailUrl(s.id),
-        [CATALOG_SPEC_KEY]: s.spec,
-      }),
-    );
+  async filaments(query?: string, cursor?: string): Promise<CatalogPage<FilamentProfile>> {
+    const page = await this.fetchPage('filament', query, cursor);
+    return {
+      items: page.results.map((s) =>
+        makeFilament({
+          id: s.id,
+          name: s.name,
+          vendor: s.vendor,
+          material: coerceMaterial(s.material),
+          source: 'catalog',
+          import_url: this.detailUrl(s.id),
+          [CATALOG_SPEC_KEY]: s.spec,
+        }),
+      ),
+      nextCursor: page.nextCursor,
+    };
   }
 
-  async profiles(query?: string): Promise<PrintProfile[]> {
-    const summaries = await this.browse('process', query);
-    return summaries.map((s) =>
-      makePrintProfile({
-        id: s.id,
-        name: s.name,
-        source: 'catalog',
-        import_url: this.detailUrl(s.id),
-        [CATALOG_SPEC_KEY]: s.spec,
-      }),
-    );
+  async profiles(query?: string, cursor?: string): Promise<CatalogPage<PrintProfile>> {
+    const page = await this.fetchPage('process', query, cursor);
+    return {
+      items: page.results.map((s) =>
+        makePrintProfile({
+          id: s.id,
+          name: s.name,
+          source: 'catalog',
+          import_url: this.detailUrl(s.id),
+          [CATALOG_SPEC_KEY]: s.spec,
+        }),
+      ),
+      nextCursor: page.nextCursor,
+    };
+  }
+
+  async printerDetail(base: PrinterProfile): Promise<PrinterProfile> {
+    const detail = await this.fetchDetail(base.id);
+    return {
+      ...base,
+      name: detail.name,
+      vendor: detail.vendor,
+      import_url: detail.import_url,
+      params: { ...(base.params as Record<string, unknown>), ...detail.params },
+    };
+  }
+
+  async filamentDetail(base: FilamentProfile): Promise<FilamentProfile> {
+    const detail = await this.fetchDetail(base.id);
+    return {
+      ...base,
+      name: detail.name,
+      vendor: detail.vendor,
+      import_url: detail.import_url,
+      params: { ...(base.params as Record<string, unknown>), ...detail.params },
+    };
+  }
+
+  async profileDetail(base: PrintProfile): Promise<PrintProfile> {
+    const detail = await this.fetchDetail(base.id);
+    return {
+      ...base,
+      name: detail.name,
+      import_url: detail.import_url,
+      params: { ...(base.params as Record<string, unknown>), ...detail.params },
+    };
   }
 
   /** Canonical detail URL for a preset, recorded as import provenance. */
@@ -94,34 +142,44 @@ export class RemoteCatalogSource implements CatalogSource {
   }
 
   /**
-   * Walk every page of one preset type, returning all summaries. A non-empty
-   * `query` is passed to the server as `q` for fuzzy, ranked search; an empty
-   * one browses the whole category.
+   * Fetch one page of one preset type. A non-empty `query` is passed to the
+   * server as `q` for fuzzy, ranked search; an empty one browses.
    */
-  private async browse(type: PresetType, query?: string): Promise<PresetSummary[]> {
+  private async fetchPage(
+    type: PresetType,
+    query: string | undefined,
+    cursor: string | undefined,
+  ): Promise<{ results: PresetSummary[]; nextCursor?: string }> {
     const q = query?.trim() || undefined;
-    const all: PresetSummary[] = [];
-    let cursor: string | undefined;
-    for (let page = 0; page < MAX_PAGES; page++) {
-      const { data, error } = await searchPresets({
-        query: { type, q, limit: PAGE_LIMIT, cursor },
-        injector: this.injector,
-      });
-      if (error) {
-        throw new Error(`Catalog search failed for "${type}".`);
-      }
-      if (!data) {
-        break;
-      }
-      if (data.results) {
-        all.push(...data.results);
-      }
-      cursor = data.next_cursor;
-      if (!cursor) {
-        break;
-      }
+    const { data, error } = await searchPresets({
+      query: { type, q, limit: PAGE_LIMIT, cursor },
+      injector: this.injector,
+    });
+    if (error) {
+      throw new Error(`Catalog search failed for "${type}".`);
     }
-    return all;
+    return { results: data?.results ?? [], nextCursor: data?.next_cursor };
+  }
+
+  /** Fetch the full preset behind one catalog id via `GET /v1/presets/{id}`. */
+  private async fetchDetail(
+    id: string,
+  ): Promise<{
+    name: string;
+    vendor: string;
+    import_url: string;
+    params: Record<string, unknown>;
+  }> {
+    const { data, error } = await getPreset({ path: { id }, injector: this.injector });
+    if (error || !data) {
+      throw new Error(`Catalog detail failed for preset "${id}".`);
+    }
+    return {
+      name: data.name,
+      vendor: data.vendor,
+      import_url: data.import_url,
+      params: data.params,
+    };
   }
 }
 


### PR DESCRIPTION
## What

cloud-presets grew `GET /v1/presets/{id}` (full preset detail) and paginated
`GET /v1/vendors` — see ColdCrabby/cloud-presets#33 and the client this
regenerates against. This adapts the catalog browser to it and cleans up two
things that were always wrong:

1. **Paging.** The catalog picker used to walk every page of a category
   eagerly (up to 100 pages of 100 results) before showing anything.
   `RemoteCatalogSource`/`CloudCatalog` now fetch **one page at a time**
   (`CatalogPage<T>`, `loadMore*`/`*HasMore`/`*LoadingMore`), and the picker
   grew a "Load more" row. Opening a picker no longer blocks on — or holds in
   memory — a whole category.
2. **Import fidelity.** "Import"/"Use preset" only ever copied the *browsed
   summary's* defaulted fields, because there was no detail endpoint to pull
   real slicing params from. Now every import path calls the new
   `printerDetail`/`filamentDetail`/`profileDetail` and overlays the real
   `params` onto the widened summary before creating the local copy.
3. **Busy state.** Since import is now a real network round trip, the picker
   shows a per-row "Importing…" spinner (`importingId`) instead of the button
   just doing nothing for a moment; a failure surfaces through
   `NotificationService.error` instead of silently importing a defaults-only
   copy.

Regenerated `ui/src/generated/catalog-client` from the live cloud-presets
OpenAPI spec (git-ignored, not part of this diff) to pick up
`getPreset`/`listVendors`.

## Known gap (left for a follow-up)

The detail endpoint doesn't yet carry printer bed dimensions or filament
color/density/cost — only identity + `params`. Those fields keep the browsed
summary's best-effort defaults until cloud-presets' response grows them; see
the doc comments in `remote-catalog-source.ts`.

## Testing

- `ng build slicer-ui` clean.
- Manually walked a printer/filament/process picker: first page loads
  immediately, "Load more" appends the next page, import shows the busy
  state and the resulting profile carries the fetched preset's real params.