### PR TITLE
ui: stop dialogs collapsing in Safari

### DIFF
--- a/.github/instructions/ui-design-language.instructions.md
+++ b/.github/instructions/ui-design-language.instructions.md
@@ -216,6 +216,14 @@ editors pass the **active printer's** params alongside the profile being edited.
   `:host ::ng-deep` for shell/outlet layout rules that must reach routed hosts.
 - **Avoid percentage-height children on `fr` grid tracks** (indefinite height) —
   use flex with `min-height: 0` instead.
+- **`flex: 1` collapses a scrolling child inside a container the viewport does
+  not size.** The shorthand expands to `flex-basis: 0%`, and WebKit resolves a
+  percentage basis against an indefinite column height (`auto`, `fit-content` —
+  a `<dialog>`) as zero instead of falling back to the content; a neighbouring
+  `min-height: 0` then removes the minimum that would have saved it. Write
+  `flex: 1 1 auto` there — it lays out identically in Chromium and Gecko when it
+  is the only flexible item. Playwright's WebKit does **not** reproduce this;
+  check real Safari (an iOS simulator serves as one).
 - Standalone components, `ChangeDetectionStrategy.OnPush`, signal `input()`,
   `nexus-` selector prefix.
 

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -27,6 +27,15 @@ issue/PR numbers or repo links in the notes. See the tone rules in
 
 ## [Unreleased]
 
+### Fixed
+
+- **Dialogs no longer collapse in Safari** — a dialog with a body ("Running in
+  your browser", "What's New", the operation pipeline) drew as a title with the
+  buttons jammed underneath and its content squashed to one clipped line. It now
+  opens at its full height and scrolls when taller than the screen. Affected
+  iPad, iPhone and the macOS app; the in-browser slicer worst of all, since its
+  welcome notice is a dialog.
+
 ### Added
 
 - **Phone layout** — the whole UI rearranges itself below 640px instead of

--- a/ui/src/app/shared/dialog/dialog-outlet.scss
+++ b/ui/src/app/shared/dialog/dialog-outlet.scss
@@ -89,8 +89,17 @@ nexus-dialog-outlet {
     }
   }
 
+  // `flex-basis` must stay `auto`, not the `0%` that the `flex: 1` shorthand
+  // expands to. A `<dialog>` is sized `height: fit-content` by the UA, so the
+  // column's main size is indefinite — and WebKit resolves a percentage basis
+  // against an indefinite height as zero instead of falling back to the
+  // content. `min-height: 0` then removes the automatic minimum that would
+  // otherwise have saved it, so the body collapses to its padding and the
+  // dialog shrinks to a title with the buttons jammed under it. Measured on
+  // iPadOS Safari: a 444px body laid out at 24px. Chromium and Gecko size the
+  // body identically either way, since it is the only flexible item here.
   .dialog__body {
-    flex: 1;
+    flex: 1 1 auto;
     min-height: 0;
     overflow-y: auto;
     padding: 8px 22px 16px;


### PR DESCRIPTION
On a real iPad running the in-browser (WASM) slicer, a dialog with a body drew
as a title with the buttons jammed underneath and its content squashed to a
single clipped line.

## Cause

A `<dialog>` is sized `height: fit-content` by the UA, so the column's main size
is **indefinite**. The `flex: 1` shorthand on `.dialog__body` expands to
`flex-basis: 0%`, and WebKit resolves a percentage basis against an indefinite
height as **zero** rather than falling back to the content. The `min-height: 0`
sitting beside it — there so the body can shrink and scroll — then removes the
automatic minimum size that would otherwise have saved it, so the body collapses
to its own padding.

Measured on iPadOS Safari: a **444px** body laid out at **24px** (exactly its
`8px + 16px` padding).

This is not iPad-specific — macOS Safari does it too (`bodyH=23` for 416px of
content), so the desktop app's WKWebView is affected as well. It shows up worst
in the browser build because that runtime greets every session with a dialog.

Affected dialogs are the three that carry a content component: **Running in your
browser**, **What's New**, and the **operation pipeline** inspector. Plain
confirm/alert dialogs have no body and were always fine, which is why this hid
for so long. `nexus-modal-shell` is unaffected — its card is a grid item with a
definite height, so there is no percentage to misresolve.

## Fix

Pin the basis to `auto`. The body is the only flexible item in that column, so
Chromium and Gecko lay it out identically either way — this is a WebKit
correction, not a layout change.

## Verification

Measured the **actually compiled** SCSS, before and after, at an iPad viewport:

| Engine | Variant | short content | overflowing content |
| --- | --- | --- | --- |
| **iPadOS 26.5 Safari** | before | body **24px** / 444 ✗ | body **24px** / 2264 ✗ |
| **iPadOS 26.5 Safari** | after | body 444px, dialog 570 ✓ | body 888px, dialog clamped to `max-height` 1010, scrolls, actions visible ✓ |
| **macOS Safari** | before | body **23px** / 416 ✗ | — |
| **macOS Safari** | after | body 416px ✓ | — |
| Chromium | before / after | 186 / 186 — identical | scrolls, actions visible (uses 23px more of the allowed height after) |
| Firefox | before / after | 204 / 204 — identical | 900 / 900 — identical |
| Playwright WebKit | before / after | 192 / 192 — identical | 904 / 904 — identical |

Note the last row: **Playwright's WebKit does not reproduce this**, which is why
it went unnoticed. Real Safari is required — an iOS simulator serves as one. That
caveat is now recorded in the styling gotchas next to the fix.

## Before / after on a real iPad

Same page, same compiled CSS, only `flex-basis` differs. 444px of body content:

| Before — body laid out at 24px | After — body at its full 444px |
| --- | --- |
| ![before](https://github.com/user-attachments/assets/25a7cd2b-0359-4ec7-97ef-b260cfadc0e7) | ![after](https://github.com/user-attachments/assets/de88aa69-9592-44ef-83f2-85d17b0d4207) |
