### PR TITLE
ui: stop pinch-to-zoom spinning the model on touch

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -29,6 +29,21 @@ issue/PR numbers or repo links in the notes. See the tone rules in
 
 ### Fixed
 
+- **Pinching to zoom no longer spins the model on a touchscreen** — rotation is
+  measured as an angle, so its noise floor grows as your fingers close; a
+  measured pinch-in sprayed ~16° of unwanted roll. Twist now has to be a
+  sustained, deliberate turn, and once you have clearly started pinching the
+  view is locked against rolling for the rest of the gesture.
+- **Slow pinches now zoom** — a gentle pinch moves well under a pixel per event
+  on a 120 Hz iPad, and every one of those was discarded rather than banked, so
+  the camera simply refused to move. Small movements now accumulate.
+- **A palm can no longer hijack a two-finger gesture** — a hand settling while
+  two fingers were already pinching was let through, and took over the gesture
+  the moment a real finger lifted.
+- **Losing a finger no longer freezes the camera** — a touch released over the
+  toolbar, or the app being backgrounded mid-pinch, could strand the viewport
+  with navigation disabled until the page was reloaded.
+
 - **Dialogs no longer collapse in Safari** — a dialog with a body ("Running in
   your browser", "What's New", the operation pipeline) drew as a title with the
   buttons jammed underneath and its content squashed to one clipped line. It now

--- a/docs/use/interface.md
+++ b/docs/use/interface.md
@@ -35,6 +35,11 @@ On a trackpad or tablet, a two-finger swipe orbits by default. If you'd rather
 it panned, change it in **Settings → General → Controls**. Palm rejection is on
 by default for pen input.
 
+On a touchscreen, two fingers pinch to zoom and slide to pan — both at once, as
+you'd expect. Twisting rotates the view, but only if you clearly mean it: once
+you've started pinching, the view won't tip just because your wrist turned. Rest
+your hand on the glass while drawing with a pencil and it's ignored.
+
 ## The tool cluster
 
 Floating under the model, this is where you manipulate what's on the plate.

--- a/ui/src/app/components/viewer/README.md
+++ b/ui/src/app/components/viewer/README.md
@@ -394,11 +394,22 @@ Two properties carry the design:
   zooms — which is why an ordinary pinch used to spray roll every frame (~16° of
   unwanted spin on a single measured pinch-in). Roll now engages only after a
   sustained twist (`ROLL_ENGAGE_ANGLE_RAD`) at a separation where the angle means
-  something (`ROLL_MIN_SEPARATION_PX`), and only while tangential fingertip
-  travel dominates radial travel (`ROLL_DOMINANCE_RATIO`). Once radial travel
-  passes `ROLL_LOCKOUT_PINCH_PX` the gesture is a pinch **for good** — a latch,
-  not a threshold a jittery frame can beat, and it survives a re-anchor so
-  swapping fingers is not a backdoor.
+  something (`ROLL_MIN_SEPARATION_PX`), and only while tangential displacement
+  dominates radial (`ROLL_DOMINANCE_RATIO`). Once radial displacement passes
+  `ROLL_LOCKOUT_PINCH_PX` the gesture is a pinch **for good** — a latch, not a
+  threshold a jittery frame can beat, and it survives a re-anchor so swapping
+  fingers is not a backdoor.
+- **Travel is net displacement from the gesture's origin, never summed per-event
+  path length.** This distinction decides whether roll can fire _at all_ on real
+  hardware, and getting it wrong is subtle because it still looks correct in a
+  clean test. A fingertip's reported separation jitters every event, so summing
+  `|Δdist|` integrates the _absolute value_ of that noise and only ever grows: at
+  120 Hz even 0.3 px of jitter crosses a 24 px pinch threshold in **0.58 s**,
+  latching roll off mid-twist before the user has rotated far enough to engage
+  it. Measured from the origin, the same pure twist reads 0.4 px radial against
+  43.6 px tangential. The fixtures in `two-finger-gesture.spec.ts` therefore
+  **model contact jitter deliberately** — a constant-separation twist describes
+  no hardware that exists, and hides exactly this class of bug.
 - **Dead zones accumulate, they do not discard.** Each channel keeps its own
   anchor and moves it only when it actually applies motion, so sub-threshold
   movement is stored rather than thrown away. The previous code re-based every

--- a/ui/src/app/components/viewer/README.md
+++ b/ui/src/app/components/viewer/README.md
@@ -226,20 +226,20 @@ path. Cross that distance and the snap "pops": the camera starts orbiting from
 the snapped orientation and the projection animates back. Interacting with the
 cube again always keeps ortho.
 
-A pan or zoom releases the *freeze* — otherwise the very next frame would pin
+A pan or zoom releases the _freeze_ — otherwise the very next frame would pin
 the camera straight back and the gesture would appear to do nothing — but
-never the *projection*: `autoOrtho` stays engaged, so the view keeps its flat,
+never the _projection_: `autoOrtho` stays engaged, so the view keeps its flat,
 dimension-true look while the user pans/zooms around it freely.
 
-| Action                                                   | Auto-ortho          |
-| --------------------------------------------------------- | ------------------- |
-| Cube face/edge/corner snap                                 | engage (→ ortho)    |
-| Rotate **inside** the breakout distance                    | keep — view frozen  |
-| **Rotate past breakout** (1-finger / left-drag / swipe)    | **revert** (pops)   |
-| Cube drag-orbit / roll / re-snap                            | keep                 |
-| Pan (2-finger / right-drag / ⌥-swipe)                      | keep — sticky        |
-| Zoom (pinch / wheel / autoscroll)                           | keep — sticky        |
-| Toolbar view toggle / home reset                           | cancel (manual)      |
+| Action                                                  | Auto-ortho         |
+| ------------------------------------------------------- | ------------------ |
+| Cube face/edge/corner snap                              | engage (→ ortho)   |
+| Rotate **inside** the breakout distance                 | keep — view frozen |
+| **Rotate past breakout** (1-finger / left-drag / swipe) | **revert** (pops)  |
+| Cube drag-orbit / roll / re-snap                        | keep               |
+| Pan (2-finger / right-drag / ⌥-swipe)                   | keep — sticky      |
+| Zoom (pinch / wheel / autoscroll)                       | keep — sticky      |
+| Toolbar view toggle / home reset                        | cancel (manual)    |
 
 This lives across two files. Both the projection override (`autoOrtho`) and the
 detent (`snapHoldPose`) are in [`SceneCamera`](scene/camera.ts). Engaging
@@ -310,9 +310,9 @@ flowchart TD
     E[pointer event on host<br/>capture phase] --> P{pointerType?}
     P -->|pen| T[track pen: penActive + penEverUsed<br/>pass through]
     P -->|mouse| A[pass through]
-    P -->|touch| G{another touch<br/>already down?}
-    G -->|yes| I[inherit group verdict<br/>admit wins over palm]
-    G -->|no · fresh group| C{palm?}
+    P -->|touch| G{how many touches<br/>already down?}
+    G -->|exactly one| I[inherit group verdict<br/>admit wins over palm]
+    G -->|none, or two+| C{palm?}
     C -->|pen active/in grace, or<br/>palm-sized within PEN_SIZE_ARM_MS| S[stopImmediatePropagation<br/>swallow]
     C -->|otherwise| A
     I -->|palm| S
@@ -335,17 +335,93 @@ touches are down; a lone touch falls to OrbitControls' single-finger rotate. If
 the arbiter ever swallowed exactly one finger of a two-finger gesture, the
 survivor would spin the camera — the "spazzing" a stylus user hits when a
 palm-sized fingertip, or a flickering pen hover/grace state, splits the pair.
-So only the first contact of a fresh group is classified from scratch; any touch
-that lands while another is already down **inherits** the group verdict (admit
-wins over palm). A resting hand is still rejected because its contacts open the
-group as palm (the pencil is the active tool, and a lone palm never lifts, so
-the group stays palm across long pauses between strokes). To keep a dropped
-`pointerup` (an iPad that never delivers the palm's lift) from stranding a
-`palm` verdict that every later finger would inherit — locking out all touch —
-stale verdicts and a stuck pen-down latch are reclaimed by timeout
+So a touch landing while **exactly one** other is down **inherits** the group
+verdict (admit wins over palm). A resting hand is still rejected because its
+contacts open the group as palm (the pencil is the active tool, and a lone palm
+never lifts, so the group stays palm across long pauses between strokes).
+
+**The inheritance stops at the pair.** Once two touches are down, a further
+contact cannot split them, so it is classified on its own merits again. This is
+what keeps a palm from _joining_ a live pinch: the two-finger controller
+re-anchors onto whichever contacts remain when a finger lifts, so an admitted
+palm becomes half the gesture the moment a real finger leaves — and the camera
+lurches with the wandering contact patch.
+
+**Synthetic resets are ignored.** The two-finger controller dispatches a
+`pointercancel` per live finger to clear OrbitControls' drag state. Those travel
+the host's capture phase like real events, and taking them at face value emptied
+the live set while both fingers were still down — destroying group coherence at
+the exact moment it mattered. They carry a marker
+([`synthetic-pointer.ts`](scene/synthetic-pointer.ts)) and are skipped by
+everything that models physical contacts.
+
+To keep a dropped `pointerup` (an iPad that never delivers the palm's lift) from
+stranding a `palm` verdict that every later finger would inherit — locking out
+all touch — stale verdicts and a stuck pen-down latch are reclaimed by timeout
 (`TOUCH_VERDICT_STALE_MS`, `PEN_CONTACT_STALE_MS`); a contact really still down
 keeps itself fresh. The user can turn the whole behaviour off from **Settings →
 General → Controls → Palm rejection** (persisted; default on).
+
+### Two-finger gestures: deciding what the user meant
+
+Pinch-dolly, centroid pan and twist-roll are computed from the same two
+contacts, and fingers never move on a clean line — so every pinch carries some
+rotation and every twist carries some separation change. Feeding all three raw
+signals to the camera made a zoom spin the model.
+
+[`TwoFingerGestureTracker`](scene/two-finger-gesture.ts) (pure and unit-tested,
+driven by the DOM bookkeeping in [`controls.ts`](scene/controls.ts)) arbitrates:
+
+```mermaid
+flowchart TD
+    S[sample: dist, angle, centroid] --> ACC[accumulate radial<br/>and tangential travel]
+    ACC --> L{radial travel ><br/>ROLL_LOCKOUT_PINCH_PX?}
+    L -->|yes| LOCK[roll latched off<br/>for this gesture]
+    L -->|no| E{sustained twist,<br/>wide enough,<br/>tangential dominant?}
+    E -->|yes| ENG[roll engaged]
+    E -->|not yet| PEND[track angle,<br/>emit no roll]
+    LOCK --> OUT[dolly + pan only]
+    ENG --> OUT2[dolly + pan + roll]
+    PEND --> OUT
+```
+
+Two properties carry the design:
+
+- **Roll must earn its way in, and can be shut out.** Rotation is measured as an
+  _angle_, so its noise floor scales with `1 / separation`: 2 px of tremor reads
+  as 0.6° at 200 px apart but 4.6° at 25 px. Since pinching in drives separation
+  down, a fixed angular threshold gets _easier_ to trip exactly as the user
+  zooms — which is why an ordinary pinch used to spray roll every frame (~16° of
+  unwanted spin on a single measured pinch-in). Roll now engages only after a
+  sustained twist (`ROLL_ENGAGE_ANGLE_RAD`) at a separation where the angle means
+  something (`ROLL_MIN_SEPARATION_PX`), and only while tangential fingertip
+  travel dominates radial travel (`ROLL_DOMINANCE_RATIO`). Once radial travel
+  passes `ROLL_LOCKOUT_PINCH_PX` the gesture is a pinch **for good** — a latch,
+  not a threshold a jittery frame can beat, and it survives a re-anchor so
+  swapping fingers is not a backdoor.
+- **Dead zones accumulate, they do not discard.** Each channel keeps its own
+  anchor and moves it only when it actually applies motion, so sub-threshold
+  movement is stored rather than thrown away. The previous code re-based every
+  anchor each event, silently deleting anything below the threshold; on a 120 Hz
+  iPad a deliberate slow pinch never reached the 1.5 px per event it needed and
+  the camera simply refused to zoom.
+
+Per-event clamps (`ROLL_MAX_STEP_RAD`, `DOLLY_MAX_STEP_FACTOR`,
+`PAN_MAX_STEP_PX`) absorb discontinuities no hand can produce — a contact patch
+morphing, coalesced events after a stall, or the pair re-anchoring. The pair
+driving the camera is pinned explicitly to the two longest-standing contacts, so
+a third finger never silently displaces one, and a change of pair re-anchors
+without emitting motion.
+
+**Recovering a stranded gesture.** While two fingers are down the controller
+disables OrbitControls, so a lift it never sees leaves the camera dead until a
+reload. Three nets cover that: window-level `pointerup`/`pointercancel` (a
+finger released over the toolbar is delivered to the toolbar, not the canvas),
+`blur`/`visibilitychange` (backgrounding an iPad mid-pinch delivers no lift at
+all), and a staleness sweep on the next `pointerdown` (`TOUCH_STALE_MS`) for
+events the OS drops outright. The sweep deliberately does **not** run on move: a
+stationary finger emits nothing, so a user pausing mid-pinch would have their
+live gesture torn down underneath them.
 
 ### Hand-aware inspector tooltip placement
 

--- a/ui/src/app/components/viewer/README.md
+++ b/ui/src/app/components/viewer/README.md
@@ -374,10 +374,10 @@ driven by the DOM bookkeeping in [`controls.ts`](scene/controls.ts)) arbitrates:
 
 ```mermaid
 flowchart TD
-    S[sample: dist, angle, centroid] --> ACC[accumulate radial<br/>and tangential travel]
-    ACC --> L{radial travel ><br/>ROLL_LOCKOUT_PINCH_PX?}
+    S[sample: dist, angle, centroid] --> ACC[net twist + net separation<br/>ratio, from gesture origin]
+    ACC --> L{separation changed ><br/>ROLL_LOCKOUT_PINCH_RATIO?}
     L -->|yes| LOCK[roll latched off<br/>for this gesture]
-    L -->|no| E{sustained twist,<br/>wide enough,<br/>tangential dominant?}
+    L -->|no| E{sustained twist,<br/>wide enough,<br/>rotation > scaling?}
     E -->|yes| ENG[roll engaged]
     E -->|not yet| PEND[track angle,<br/>emit no roll]
     LOCK --> OUT[dolly + pan only]
@@ -385,7 +385,7 @@ flowchart TD
     PEND --> OUT
 ```
 
-Two properties carry the design:
+Three properties carry the design:
 
 - **Roll must earn its way in, and can be shut out.** Rotation is measured as an
   _angle_, so its noise floor scales with `1 / separation`: 2 px of tremor reads
@@ -394,11 +394,23 @@ Two properties carry the design:
   zooms — which is why an ordinary pinch used to spray roll every frame (~16° of
   unwanted spin on a single measured pinch-in). Roll now engages only after a
   sustained twist (`ROLL_ENGAGE_ANGLE_RAD`) at a separation where the angle means
-  something (`ROLL_MIN_SEPARATION_PX`), and only while tangential displacement
-  dominates radial (`ROLL_DOMINANCE_RATIO`). Once radial displacement passes
-  `ROLL_LOCKOUT_PINCH_PX` the gesture is a pinch **for good** — a latch, not a
+  something (`ROLL_MIN_SEPARATION_PX`), and only while rotation dominates scaling
+  (`ROLL_DOMINANCE_RATIO`). Once separation has changed by
+  `ROLL_LOCKOUT_PINCH_RATIO` the gesture is a pinch **for good** — a latch, not a
   threshold a jittery frame can beat, and it survives a re-anchor so swapping
   fingers is not a backdoor.
+- **Rotation and pinch are compared per unit radius, so the test is
+  scale-invariant.** This is what lets a twist be recognised with the fingers
+  close together, and getting it wrong made roll unusable in the hand even after
+  it "worked". Rotating by `θ` moves each fingertip `θ·r`; scaling by `s` moves
+  each fingertip `(s−1)·r`. Dividing out the common `r` leaves **radians against
+  a separation _ratio_**, independent of how far apart the fingers are — the same
+  split UIKit draws between its pinch (scale) and rotation (angle) recognisers.
+  Comparing an _arc length_ against an absolute pixel change instead is biased by
+  the radius: it demanded 6° of twist at a 300 px span but **30°** at 60 px, so a
+  normal pinch-sized grip could never roll. The lockout is a ratio for the same
+  reason — a narrow grip and a wide one should have to pinch equally _hard_, not
+  equally _far_.
 - **Travel is net displacement from the gesture's origin, never summed per-event
   path length.** This distinction decides whether roll can fire _at all_ on real
   hardware, and getting it wrong is subtle because it still looks correct in a

--- a/ui/src/app/components/viewer/scene/controls.ts
+++ b/ui/src/app/components/viewer/scene/controls.ts
@@ -30,7 +30,7 @@ const TWO_FINGER_DOLLY_DEAD_ZONE_PX = 1.5;
  */
 const TWO_FINGER_ROLL_DEAD_ZONE_RAD = 0.01;
 /**
- * Net twist (rad ≈ 8°) that must build up from the start of a two-finger
+ * Net twist (rad ≈ 6°) that must build up from the start of a two-finger
  * gesture before roll engages at all.
  *
  * The old code had no such gate: it rolled whenever a single frame's angle
@@ -40,34 +40,45 @@ const TWO_FINGER_ROLL_DEAD_ZONE_RAD = 0.01;
  * drives the separation down. So an ordinary zoom sprayed roll every frame:
  * the "zooming makes it rotate" spin. Requiring a real, sustained twist first
  * puts the gate on the user's intent instead of on their tremor.
+ *
+ * Kept modest because the *dominance* test below is what actually separates a
+ * twist from a pinch; this only has to outrun tremor.
  */
-const ROLL_ENGAGE_ANGLE_RAD = 0.14;
+const ROLL_ENGAGE_ANGLE_RAD = 0.105;
 /**
  * Minimum finger separation (px) for roll to be considered. Angular resolution
  * collapses as the fingers meet, so below this a twist reading is noise by
- * construction — no threshold on the angle itself can rescue it.
+ * construction — no threshold on the angle itself can rescue it. Low enough to
+ * admit a normal pinch-sized grip, which is the span most rolls are made with.
  */
-const ROLL_MIN_SEPARATION_PX = 60;
+const ROLL_MIN_SEPARATION_PX = 45;
 /**
- * How much more net tangential than net radial displacement a gesture needs
- * before it counts as a twist. Compares like with like — both in pixels of
- * fingertip movement measured from the gesture's origin — so it holds at any
- * separation.
- */
-const ROLL_DOMINANCE_RATIO = 1.6;
-/**
- * Net radial displacement (px) that permanently disqualifies roll for the rest
- * of the gesture. Once the user has clearly pinched, later rotational drift —
- * the wrist unavoidably turning as the fingers close — must never be honoured.
- * This latch is what makes "a zoom never becomes a spin" a guarantee rather
- * than a threshold that a jittery frame can beat.
+ * How far rotation must outweigh scaling for a gesture to count as a twist,
+ * comparing radians of turn against the fractional change in separation.
  *
- * Measured as displacement from the gesture's origin, **not** as summed
- * per-event travel: the latter integrates contact jitter, which at 120 Hz
- * crosses this figure from noise alone in well under a second and locks roll
- * out of every gesture. See the module doc in `two-finger-gesture.ts`.
+ * Both are per-unit-radius fingertip displacement (`θ·r` against `(s−1)·r`), so
+ * the test is **scale-invariant** — it asks the same of a narrow grip as a wide
+ * one. Comparing an *arc length* against an absolute pixel change instead, as
+ * this originally did, is biased by the radius: it demanded 6° of twist with
+ * the fingers 300 px apart but **30°** at 60 px, so a normal grip could not
+ * roll at all.
  */
-const ROLL_LOCKOUT_PINCH_PX = 24;
+const ROLL_DOMINANCE_RATIO = 1.0;
+/**
+ * Fractional change in separation (0.2 = 20%) that permanently disqualifies
+ * roll for the rest of the gesture. Once the user has clearly pinched, later
+ * rotational drift — the wrist unavoidably turning as the fingers close — must
+ * never be honoured. This latch is what makes "a zoom never becomes a spin" a
+ * guarantee rather than a threshold that a jittery frame can beat.
+ *
+ * A *ratio*, not a pixel count, so a small grip and a wide one have to pinch
+ * equally hard rather than equally far. Measured from the gesture's origin,
+ * **not** summed per-event travel: the latter integrates contact jitter, which
+ * at 120 Hz crosses any such figure from noise alone in well under a second and
+ * locks roll out of every gesture. See the module doc in
+ * `two-finger-gesture.ts`.
+ */
+const ROLL_LOCKOUT_PINCH_RATIO = 0.2;
 /**
  * Largest roll applied from a single event (rad ≈ 17°). A jump beyond this is
  * not a wrist — it is a contact patch morphing, a palm being adopted into the
@@ -967,7 +978,7 @@ export class SceneControls {
         engageAngleRad: ROLL_ENGAGE_ANGLE_RAD,
         minSeparationPx: ROLL_MIN_SEPARATION_PX,
         dominanceRatio: ROLL_DOMINANCE_RATIO,
-        lockoutPinchPx: ROLL_LOCKOUT_PINCH_PX,
+        lockoutPinchRatio: ROLL_LOCKOUT_PINCH_RATIO,
         deadZoneRad: TWO_FINGER_ROLL_DEAD_ZONE_RAD,
         maxStepRad: ROLL_MAX_STEP_RAD,
       },

--- a/ui/src/app/components/viewer/scene/controls.ts
+++ b/ui/src/app/components/viewer/scene/controls.ts
@@ -11,10 +11,94 @@ import {
   type WebGLRenderer,
 } from 'three';
 import type { OrbitControls } from 'three/examples/jsm/controls/OrbitControls.js';
+import { isSyntheticPointerEvent, markSyntheticPointerEvent } from './synthetic-pointer';
+import { type TwoFingerSample, TwoFingerGestureTracker } from './two-finger-gesture';
 
 const TOUCH_DISABLED = -1 as unknown as TOUCH;
+/**
+ * Separation change (px, accumulated since the last applied dolly) before a
+ * pinch starts zooming. Accumulated rather than measured per frame: at 120 Hz a
+ * deliberate slow pinch moves well under a pixel per event, so a per-frame test
+ * discarded the whole gesture and the camera never zoomed at all.
+ */
 const TWO_FINGER_DOLLY_DEAD_ZONE_PX = 1.5;
+/**
+ * Twist (rad, accumulated since the last applied roll) before an *engaged* roll
+ * moves the camera. Only consulted after {@link ROLL_ENGAGE_ANGLE_RAD} has
+ * already qualified the gesture as a twist — this is fine-grain smoothing, not
+ * the gate.
+ */
 const TWO_FINGER_ROLL_DEAD_ZONE_RAD = 0.01;
+/**
+ * Total twist (rad ≈ 9°) that must accumulate from the start of a two-finger
+ * gesture before roll engages at all.
+ *
+ * The old code had no such gate: it rolled whenever a single frame's angle
+ * delta cleared {@link TWO_FINGER_ROLL_DEAD_ZONE_RAD}. Because that delta is
+ * `perpendicular_jitter / separation`, the test gets *easier* the closer the
+ * fingers are — 2 px of noise at 40 px apart is already 2.9°, and pinching in
+ * drives the separation down. So an ordinary zoom sprayed roll every frame:
+ * the "zooming makes it rotate" spin. Requiring a real, sustained twist first
+ * puts the gate on the user's intent instead of on their tremor.
+ */
+const ROLL_ENGAGE_ANGLE_RAD = 0.16;
+/**
+ * Minimum finger separation (px) for roll to be considered. Angular resolution
+ * collapses as the fingers meet, so below this a twist reading is noise by
+ * construction — no threshold on the angle itself can rescue it.
+ */
+const ROLL_MIN_SEPARATION_PX = 70;
+/**
+ * How much more tangential travel than radial travel a gesture needs before it
+ * counts as a twist. Compares like with like — both in pixels of fingertip
+ * movement — so it holds at any separation. A pinch that also drifts a little
+ * in rotation stays a pinch.
+ */
+const ROLL_DOMINANCE_RATIO = 1.6;
+/**
+ * Radial travel (px) that permanently disqualifies roll for the rest of the
+ * gesture. Once the user has clearly pinched, later rotational drift — the
+ * wrist unavoidably turning as the fingers close — must never be honoured.
+ * This latch is what makes "a zoom never becomes a spin" a guarantee rather
+ * than a threshold that a jittery frame can beat.
+ */
+const ROLL_LOCKOUT_PINCH_PX = 24;
+/**
+ * Largest roll applied from a single event (rad ≈ 17°). A jump beyond this is
+ * not a wrist — it is a contact patch morphing, a palm being adopted into the
+ * pair, or coalesced events after a stall. Clamping keeps such an artefact from
+ * whipping the camera around.
+ */
+const ROLL_MAX_STEP_RAD = 0.3;
+/**
+ * Largest per-event dolly ratio. Guards the same class of discontinuity as
+ * {@link ROLL_MAX_STEP_RAD}: a pair re-anchoring onto a different pair of
+ * contacts can halve or double the separation in one event.
+ */
+const DOLLY_MAX_STEP_FACTOR = 1.6;
+/**
+ * Largest centroid pan applied from a single event (px). A real fingertip
+ * cannot cross this much between events; a re-anchor or a palm can.
+ */
+const PAN_MAX_STEP_PX = 160;
+/**
+ * How long a tracked touch survives without any event before the two-finger
+ * controller reclaims it.
+ *
+ * Without this a dropped `pointerup` — a finger lifted over the toolbar, a
+ * pointer stolen by the OS, the app backgrounded mid-pinch — strands a phantom
+ * contact. The gesture never sees `touches.size === 0`, so it never ends, and
+ * `controls.enabled` stays `false`: the camera is dead until the page reloads.
+ *
+ * Pruning deliberately runs **only when a new contact lands**, never on move. A
+ * stationary finger emits no events, so a user who pauses mid-pinch to think
+ * would otherwise have their live gesture torn down underneath them. Waiting
+ * for the next `pointerdown` costs nothing — the user is touching the screen
+ * again, which is exactly when a stuck gesture needs clearing — and the window
+ * and visibility listeners already cover every case where the lift is merely
+ * delivered somewhere else.
+ */
+const TOUCH_STALE_MS = 3000;
 /**
  * Right-drag travel (px) before it counts as a genuine pan for releasing the
  * viewport-cube snap's frozen detent (not the ortho projection — pan is
@@ -173,6 +257,13 @@ export class SceneControls {
   private rotateBreakoutPointerDownHandler: ((event: PointerEvent) => void) | null = null;
   private rotateBreakoutPointerMoveHandler: ((event: PointerEvent) => void) | null = null;
   private rotateBreakoutPointerUpHandler: ((event: PointerEvent) => void) | null = null;
+
+  /**
+   * Removes the window/document-level safety nets the two-finger controller
+   * installs for lifts the canvas never sees. Those outlive the canvas, so they
+   * must be torn down explicitly.
+   */
+  private twoFingerTeardown: (() => void) | null = null;
 
   /**
    * @param cancelDragCallback  Called when a two-finger gesture begins so
@@ -397,6 +488,8 @@ export class SceneControls {
     this.uninstallRendererPointerListeners();
     this.uninstallWebKitGestureZoom();
     this.uninstallRotateBreakoutDetection();
+    this.twoFingerTeardown?.();
+    this.twoFingerTeardown = null;
     this.renderer.domElement.removeEventListener('wheel', this.wheelHandler, { capture: true });
   }
 
@@ -824,14 +917,16 @@ export class SceneControls {
     const el = this.renderer.domElement;
     const activeTouches = new Set<number>();
     const onDown = (event: PointerEvent): void => {
-      if (event.pointerType !== 'touch') {
+      if (event.pointerType !== 'touch' || isSyntheticPointerEvent(event)) {
         return;
       }
       activeTouches.add(event.pointerId);
       this.controls.zoomToCursor = true;
     };
     const onEnd = (event: PointerEvent): void => {
-      if (event.pointerType !== 'touch') {
+      // A synthetic cancel does not mean the finger left — dropping the contact
+      // here would clear `zoomToCursor` in the middle of a live pinch.
+      if (event.pointerType !== 'touch' || isSyntheticPointerEvent(event)) {
         return;
       }
       activeTouches.delete(event.pointerId);
@@ -852,31 +947,97 @@ export class SceneControls {
    * {@link PointerArbiter} installed on the canvas host swallows them in the
    * capture phase, upstream of these listeners. So a resting hand can't be
    * mistaken for the second finger of a pinch. See `scene/pointer-arbiter.ts`.
+   *
+   * Which of pinch, pan and roll a gesture actually performs is decided by
+   * {@link TwoFingerGestureTracker}, not by raw per-frame thresholds — that is
+   * what stops a zoom from spinning the view. This method owns only the DOM
+   * bookkeeping: which contacts are live, which two of them drive the camera,
+   * and how the gesture recovers when the OS never tells us a finger left.
    */
   private installCustomTwoFingerControls(): void {
     const el = this.renderer.domElement;
-    const touches = new Map<number, { x: number; y: number }>();
+    const touches = new Map<number, { x: number; y: number; lastSeenMs: number }>();
+    const tracker = new TwoFingerGestureTracker(
+      {
+        engageAngleRad: ROLL_ENGAGE_ANGLE_RAD,
+        minSeparationPx: ROLL_MIN_SEPARATION_PX,
+        dominanceRatio: ROLL_DOMINANCE_RATIO,
+        lockoutPinchPx: ROLL_LOCKOUT_PINCH_PX,
+        deadZoneRad: TWO_FINGER_ROLL_DEAD_ZONE_RAD,
+        maxStepRad: ROLL_MAX_STEP_RAD,
+      },
+      {
+        deadZonePx: TWO_FINGER_DOLLY_DEAD_ZONE_PX,
+        maxStepFactor: DOLLY_MAX_STEP_FACTOR,
+        maxPanStepPx: PAN_MAX_STEP_PX,
+      },
+    );
     const state = {
       active: false,
-      lastDist: 0,
-      lastAngle: 0,
-      lastCx: 0,
-      lastCy: 0,
       savedControlsEnabled: true,
       suppressOwnCancel: false,
+      /**
+       * The two pointer ids currently driving the camera. Pinned explicitly
+       * rather than read off the front of the map each frame, so a third
+       * contact cannot quietly become half of the gesture and so a re-anchor
+       * happens exactly once, when the pair really changes.
+       */
+      pair: [] as number[],
     };
 
-    const recomputeAnchors = (): void => {
-      const pts = [...touches.values()];
-      if (pts.length < 2) {
+    const now = (): number => (typeof performance !== 'undefined' ? performance.now() : Date.now());
+
+    /**
+     * Drop contacts whose `pointerup` the OS never delivered — a finger lifted
+     * over the toolbar, a pointer stolen mid-gesture, the app backgrounded.
+     * Without this the gesture never ends and `controls.enabled` stays `false`,
+     * leaving the camera dead until a reload.
+     */
+    const pruneStaleTouches = (): void => {
+      const cutoff = now() - TOUCH_STALE_MS;
+      for (const [id, contact] of touches) {
+        if (contact.lastSeenMs < cutoff) {
+          touches.delete(id);
+        }
+      }
+    };
+
+    const sampleOf = (ids: number[]): TwoFingerSample | null => {
+      const a = touches.get(ids[0]);
+      const b = touches.get(ids[1]);
+      if (!a || !b) {
+        return null;
+      }
+      return {
+        dist: Math.hypot(b.x - a.x, b.y - a.y),
+        angle: Math.atan2(b.y - a.y, b.x - a.x),
+        cx: (a.x + b.x) / 2,
+        cy: (a.y + b.y) / 2,
+      };
+    };
+
+    /** The two longest-standing live contacts — insertion order is arrival order. */
+    const currentPair = (): number[] => [...touches.keys()].slice(0, 2);
+
+    const samePair = (next: number[]): boolean =>
+      next.length === state.pair.length && next.every((id, i) => id === state.pair[i]);
+
+    /**
+     * Re-point the gesture at `next` without emitting motion. The jump between
+     * two different pairs of contacts is a bookkeeping artefact, never
+     * something the user's hand did.
+     */
+    const adoptPair = (next: number[], mode: 'begin' | 'reanchor'): void => {
+      state.pair = next;
+      const sample = sampleOf(next);
+      if (!sample) {
         return;
       }
-      const a = pts[0];
-      const b = pts[1];
-      state.lastDist = Math.hypot(b.x - a.x, b.y - a.y);
-      state.lastAngle = Math.atan2(b.y - a.y, b.x - a.x);
-      state.lastCx = (a.x + b.x) / 2;
-      state.lastCy = (a.y + b.y) / 2;
+      if (mode === 'begin') {
+        tracker.begin(sample);
+      } else {
+        tracker.reanchor(sample);
+      }
     };
 
     const beginTwoFinger = (): void => {
@@ -888,13 +1049,18 @@ export class SceneControls {
       this.orbitVelTarget.set(0, 0, 0);
       this.cancelDragCallback();
       // Fire synthetic pointercancel events so OrbitControls clears its
-      // internal pointer state before we re-disable it.
+      // internal pointer state before we re-disable it. They are marked so the
+      // palm-rejection arbiter and the touch tuning — which model *physical*
+      // contacts — ignore them; treating them as real lifts would forget both
+      // live fingers and let a palm be admitted into the gesture.
       this.controls.enabled = true;
       state.suppressOwnCancel = true;
       for (const id of touches.keys()) {
         try {
           el.dispatchEvent(
-            new PointerEvent('pointercancel', { pointerId: id, pointerType: 'touch' }),
+            markSyntheticPointerEvent(
+              new PointerEvent('pointercancel', { pointerId: id, pointerType: 'touch' }),
+            ),
           );
         } catch {
           // Older browsers may reject the constructor; harmless.
@@ -902,7 +1068,7 @@ export class SceneControls {
       }
       state.suppressOwnCancel = false;
       this.controls.enabled = false;
-      recomputeAnchors();
+      adoptPair(currentPair(), 'begin');
     };
 
     const endTwoFinger = (): void => {
@@ -910,104 +1076,148 @@ export class SceneControls {
         return;
       }
       state.active = false;
+      state.pair = [];
       this.controls.enabled = state.savedControlsEnabled;
     };
 
     const onDown = (event: PointerEvent): void => {
-      if (event.pointerType !== 'touch') {
+      if (event.pointerType !== 'touch' || isSyntheticPointerEvent(event)) {
         return;
       }
-      touches.set(event.pointerId, { x: event.clientX, y: event.clientY });
+      pruneStaleTouches();
+      // If pruning emptied the set, the previous gesture was stranded by a lift
+      // the OS never delivered. End it here so this contact starts clean rather
+      // than being absorbed into a gesture that no longer has any fingers.
+      if (state.active && touches.size === 0) {
+        endTwoFinger();
+      }
+      touches.set(event.pointerId, { x: event.clientX, y: event.clientY, lastSeenMs: now() });
       if (touches.size === 2 && !state.active) {
         beginTwoFinger();
-        event.preventDefault();
-        event.stopPropagation();
-        event.stopImmediatePropagation();
       } else if (state.active) {
-        recomputeAnchors();
-        event.preventDefault();
-        event.stopPropagation();
-        event.stopImmediatePropagation();
+        // A third contact does not displace the pair that is already driving.
+        if (!samePair(currentPair())) {
+          adoptPair(currentPair(), 'reanchor');
+        }
+      } else {
+        return;
       }
+      event.preventDefault();
+      event.stopPropagation();
+      event.stopImmediatePropagation();
     };
 
     const onMove = (event: PointerEvent): void => {
-      if (event.pointerType !== 'touch') {
+      if (event.pointerType !== 'touch' || isSyntheticPointerEvent(event)) {
         return;
       }
-      const t = touches.get(event.pointerId);
-      if (!t) {
+      const contact = touches.get(event.pointerId);
+      if (!contact) {
         return;
       }
-      t.x = event.clientX;
-      t.y = event.clientY;
-      if (state.active) {
-        event.preventDefault();
-        event.stopPropagation();
-        event.stopImmediatePropagation();
-      }
-      if (!state.active || touches.size < 2) {
-        return;
-      }
-      const pts = [...touches.values()];
-      const a = pts[0];
-      const b = pts[1];
-      const dist = Math.hypot(b.x - a.x, b.y - a.y);
-      const angle = Math.atan2(b.y - a.y, b.x - a.x);
-      const cx = (a.x + b.x) / 2;
-      const cy = (a.y + b.y) / 2;
-
-      if (state.lastDist > 0 && Math.abs(dist - state.lastDist) > TWO_FINGER_DOLLY_DEAD_ZONE_PX) {
-        const factor = state.lastDist / Math.max(dist, 1e-3);
-        this.applyTouchDolly(factor, cx, cy);
-      }
-
-      let dAngle = angle - state.lastAngle;
-      if (dAngle > Math.PI) dAngle -= 2 * Math.PI;
-      else if (dAngle < -Math.PI) dAngle += 2 * Math.PI;
-      if (Math.abs(dAngle) > TWO_FINGER_ROLL_DEAD_ZONE_RAD) {
-        this.applyTouchRoll(-dAngle);
-      }
-
-      const dx = cx - state.lastCx;
-      const dy = cy - state.lastCy;
-      if (dx !== 0 || dy !== 0) {
-        this.applyTouchPan(dx, dy);
-      }
-
-      state.lastDist = dist;
-      state.lastAngle = angle;
-      state.lastCx = cx;
-      state.lastCy = cy;
-    };
-
-    const onUp = (event: PointerEvent): void => {
-      if (event.pointerType !== 'touch') {
-        return;
-      }
-      if (state.suppressOwnCancel) {
-        return;
-      }
-      if (!touches.delete(event.pointerId)) {
-        return;
-      }
+      contact.x = event.clientX;
+      contact.y = event.clientY;
+      contact.lastSeenMs = now();
       if (!state.active) {
         return;
       }
       event.preventDefault();
       event.stopPropagation();
       event.stopImmediatePropagation();
+      if (state.pair.length < 2 || !state.pair.includes(event.pointerId)) {
+        return;
+      }
+      const sample = sampleOf(state.pair);
+      if (!sample) {
+        return;
+      }
+      const motion = tracker.update(sample);
+      if (motion.dollyFactor !== null) {
+        this.applyTouchDolly(motion.dollyFactor, sample.cx, sample.cy);
+      }
+      if (motion.rollRad !== 0) {
+        this.applyTouchRoll(-motion.rollRad);
+      }
+      if (motion.panDx !== 0 || motion.panDy !== 0) {
+        this.applyTouchPan(motion.panDx, motion.panDy);
+      }
+    };
+
+    /**
+     * Retire one contact. Shared by the canvas listeners and the window-level
+     * safety net, so a lift that never reaches the canvas still ends the
+     * gesture cleanly.
+     */
+    const releaseTouch = (pointerId: number): boolean => {
+      if (!touches.delete(pointerId)) {
+        return false;
+      }
+      if (!state.active) {
+        return false;
+      }
       if (touches.size === 0) {
         endTwoFinger();
-      } else {
-        recomputeAnchors();
+      } else if (!samePair(currentPair())) {
+        adoptPair(currentPair(), 'reanchor');
       }
+      return true;
+    };
+
+    const onUp = (event: PointerEvent): void => {
+      if (event.pointerType !== 'touch' || isSyntheticPointerEvent(event)) {
+        return;
+      }
+      if (state.suppressOwnCancel) {
+        return;
+      }
+      if (!releaseTouch(event.pointerId)) {
+        return;
+      }
+      event.preventDefault();
+      event.stopPropagation();
+      event.stopImmediatePropagation();
+    };
+
+    /**
+     * Safety net for lifts the canvas never sees. `pointerup` is delivered to
+     * whatever element the finger is over, so releasing above the toolbar or a
+     * settings panel bypasses the canvas listeners entirely and would otherwise
+     * strand the contact.
+     */
+    const onWindowUp = (event: PointerEvent): void => {
+      if (event.pointerType !== 'touch' || isSyntheticPointerEvent(event)) {
+        return;
+      }
+      if (state.suppressOwnCancel || event.target === el) {
+        return;
+      }
+      releaseTouch(event.pointerId);
+    };
+
+    /**
+     * Abandon the gesture wholesale when the page loses the input stream —
+     * backgrounding an iPad mid-pinch delivers no `pointerup` at all.
+     */
+    const onInterrupt = (): void => {
+      touches.clear();
+      endTwoFinger();
     };
 
     el.addEventListener('pointerdown', onDown, { capture: true });
     el.addEventListener('pointermove', onMove, { capture: true });
     el.addEventListener('pointerup', onUp, { capture: true });
     el.addEventListener('pointercancel', onUp, { capture: true });
+    window.addEventListener('pointerup', onWindowUp, { capture: true });
+    window.addEventListener('pointercancel', onWindowUp, { capture: true });
+    window.addEventListener('blur', onInterrupt);
+    document.addEventListener('visibilitychange', onInterrupt);
+
+    this.twoFingerTeardown = (): void => {
+      window.removeEventListener('pointerup', onWindowUp, { capture: true });
+      window.removeEventListener('pointercancel', onWindowUp, { capture: true });
+      window.removeEventListener('blur', onInterrupt);
+      document.removeEventListener('visibilitychange', onInterrupt);
+    };
   }
 
   // -------------------------------------------------------------------------

--- a/ui/src/app/components/viewer/scene/controls.ts
+++ b/ui/src/app/components/viewer/scene/controls.ts
@@ -30,7 +30,7 @@ const TWO_FINGER_DOLLY_DEAD_ZONE_PX = 1.5;
  */
 const TWO_FINGER_ROLL_DEAD_ZONE_RAD = 0.01;
 /**
- * Total twist (rad ≈ 9°) that must accumulate from the start of a two-finger
+ * Net twist (rad ≈ 8°) that must build up from the start of a two-finger
  * gesture before roll engages at all.
  *
  * The old code had no such gate: it rolled whenever a single frame's angle
@@ -41,26 +41,31 @@ const TWO_FINGER_ROLL_DEAD_ZONE_RAD = 0.01;
  * the "zooming makes it rotate" spin. Requiring a real, sustained twist first
  * puts the gate on the user's intent instead of on their tremor.
  */
-const ROLL_ENGAGE_ANGLE_RAD = 0.16;
+const ROLL_ENGAGE_ANGLE_RAD = 0.14;
 /**
  * Minimum finger separation (px) for roll to be considered. Angular resolution
  * collapses as the fingers meet, so below this a twist reading is noise by
  * construction — no threshold on the angle itself can rescue it.
  */
-const ROLL_MIN_SEPARATION_PX = 70;
+const ROLL_MIN_SEPARATION_PX = 60;
 /**
- * How much more tangential travel than radial travel a gesture needs before it
- * counts as a twist. Compares like with like — both in pixels of fingertip
- * movement — so it holds at any separation. A pinch that also drifts a little
- * in rotation stays a pinch.
+ * How much more net tangential than net radial displacement a gesture needs
+ * before it counts as a twist. Compares like with like — both in pixels of
+ * fingertip movement measured from the gesture's origin — so it holds at any
+ * separation.
  */
 const ROLL_DOMINANCE_RATIO = 1.6;
 /**
- * Radial travel (px) that permanently disqualifies roll for the rest of the
- * gesture. Once the user has clearly pinched, later rotational drift — the
- * wrist unavoidably turning as the fingers close — must never be honoured.
+ * Net radial displacement (px) that permanently disqualifies roll for the rest
+ * of the gesture. Once the user has clearly pinched, later rotational drift —
+ * the wrist unavoidably turning as the fingers close — must never be honoured.
  * This latch is what makes "a zoom never becomes a spin" a guarantee rather
  * than a threshold that a jittery frame can beat.
+ *
+ * Measured as displacement from the gesture's origin, **not** as summed
+ * per-event travel: the latter integrates contact jitter, which at 120 Hz
+ * crosses this figure from noise alone in well under a second and locks roll
+ * out of every gesture. See the module doc in `two-finger-gesture.ts`.
  */
 const ROLL_LOCKOUT_PINCH_PX = 24;
 /**

--- a/ui/src/app/components/viewer/scene/controls.ts
+++ b/ui/src/app/components/viewer/scene/controls.ts
@@ -1069,9 +1069,21 @@ export class SceneControls {
       // palm-rejection arbiter and the touch tuning — which model *physical*
       // contacts — ignore them; treating them as real lifts would forget both
       // live fingers and let a palm be admitted into the gesture.
+      //
+      // Only pointers the element actually holds capture for are cancelled,
+      // which is exactly the set OrbitControls has registered: it captures on
+      // the `pointerdown` it handles, and the second finger's `pointerdown` is
+      // stopped by this very handler, so it never reaches OrbitControls at all.
+      // Cancelling that unknown pointer made `releasePointerCapture` throw on
+      // every single two-finger gesture — and because that call sits *before*
+      // OrbitControls removes its document-level move/up listeners, the throw
+      // could leave those attached.
       this.controls.enabled = true;
       state.suppressOwnCancel = true;
       for (const id of touches.keys()) {
+        if (!el.hasPointerCapture?.(id)) {
+          continue;
+        }
         try {
           el.dispatchEvent(
             markSyntheticPointerEvent(

--- a/ui/src/app/components/viewer/scene/pointer-arbiter.spec.ts
+++ b/ui/src/app/components/viewer/scene/pointer-arbiter.spec.ts
@@ -8,6 +8,7 @@ import {
   PointerArbiter,
   TOUCH_VERDICT_STALE_MS,
 } from './pointer-arbiter';
+import { markSyntheticPointerEvent } from './synthetic-pointer';
 
 describe('isPalmTouch', () => {
   const base = {
@@ -74,6 +75,15 @@ describe('PointerArbiter', () => {
     canvas.dispatchEvent(pointerEvent(type, props));
     canvas.removeEventListener(type, spy);
     return reached;
+  }
+
+  /**
+   * Dispatch an event the viewport made up for itself — the reset the
+   * two-finger controller sends to clear OrbitControls' drag state while the
+   * fingers are still down.
+   */
+  function dispatchSynthetic(type: string, props: Partial<PointerEvent>): void {
+    canvas.dispatchEvent(markSyntheticPointerEvent(pointerEvent(type, props)));
   }
 
   beforeEach(() => {
@@ -192,6 +202,75 @@ describe('PointerArbiter', () => {
     expect(
       dispatch('pointerdown', { pointerType: 'touch', pointerId: 2, width: 20, height: 20 }),
     ).toBe(true);
+  });
+
+  it('rejects a palm that lands while two fingers are already pinching', () => {
+    // Arm the size heuristic, then park the pencil in the user's hand.
+    dispatch('pointerdown', { pointerType: 'pen', pointerId: 9 });
+    dispatch('pointerout', { pointerType: 'pen', pointerId: 9 });
+    clock.t += PEN_GRACE_MS + 100;
+    // A genuine two-finger pinch is under way.
+    expect(
+      dispatch('pointerdown', { pointerType: 'touch', pointerId: 1, width: 20, height: 20 }),
+    ).toBe(true);
+    expect(
+      dispatch('pointerdown', { pointerType: 'touch', pointerId: 2, width: 20, height: 20 }),
+    ).toBe(true);
+    // The heel of the hand now settles. Inheriting "admit" here would let it
+    // become half of the gesture the moment a real finger lifts, and the camera
+    // would lurch with the wandering contact patch.
+    expect(
+      dispatch('pointerdown', {
+        pointerType: 'touch',
+        pointerId: 3,
+        width: PALM_CONTACT_MIN_PX + 20,
+        height: PALM_CONTACT_MIN_PX + 20,
+      }),
+    ).toBe(false);
+  });
+
+  it('still admits a genuine third finger while two are down', () => {
+    // No pen this session, so nothing arms the size heuristic.
+    expect(
+      dispatch('pointerdown', { pointerType: 'touch', pointerId: 1, width: 20, height: 20 }),
+    ).toBe(true);
+    expect(
+      dispatch('pointerdown', { pointerType: 'touch', pointerId: 2, width: 20, height: 20 }),
+    ).toBe(true);
+    expect(
+      dispatch('pointerdown', { pointerType: 'touch', pointerId: 3, width: 20, height: 20 }),
+    ).toBe(true);
+  });
+
+  it('ignores a synthetic reset instead of forgetting a live finger', () => {
+    dispatch('pointerdown', { pointerType: 'pen', pointerId: 9 });
+    dispatch('pointerout', { pointerType: 'pen', pointerId: 9 });
+    clock.t += PEN_GRACE_MS + 100;
+    dispatch('pointerdown', { pointerType: 'touch', pointerId: 1, width: 20, height: 20 });
+    dispatch('pointerdown', { pointerType: 'touch', pointerId: 2, width: 20, height: 20 });
+
+    // The two-finger controller resets OrbitControls by dispatching a cancel per
+    // live finger. Both fingers are still on the glass.
+    dispatchSynthetic('pointercancel', { pointerType: 'touch', pointerId: 1 });
+    dispatchSynthetic('pointercancel', { pointerType: 'touch', pointerId: 2 });
+
+    // The group must be intact, so a palm arriving next is still a third contact
+    // and is still rejected. Taking the synthetic cancels at face value would
+    // empty the live set and admit this as a fresh first contact.
+    expect(
+      dispatch('pointerdown', {
+        pointerType: 'touch',
+        pointerId: 3,
+        width: PALM_CONTACT_MIN_PX + 20,
+        height: PALM_CONTACT_MIN_PX + 20,
+      }),
+    ).toBe(false);
+  });
+
+  it('does not let a synthetic pen cancel clear the pen-active latch', () => {
+    dispatch('pointerdown', { pointerType: 'pen', pointerId: 9 });
+    dispatchSynthetic('pointercancel', { pointerType: 'pen', pointerId: 9 });
+    expect(arbiter.isPenActive()).toBe(true);
   });
 
   it('rejects both contacts of a resting hand while a pen is down', () => {

--- a/ui/src/app/components/viewer/scene/pointer-arbiter.ts
+++ b/ui/src/app/components/viewer/scene/pointer-arbiter.ts
@@ -41,10 +41,26 @@
  * if the arbiter ever swallowed exactly one finger of a two-finger gesture, the
  * surviving finger would spin the camera — the "spazzing" a stylus user sees
  * when a palm-sized fingertip, or a flickering pen hover/grace state, splits the
- * pair. To prevent that, only the *first* contact of a fresh group (nothing else
- * down) is classified from scratch; every touch that lands while another is
- * already down inherits that group's verdict (admit wins over palm). A
- * navigation gesture is thus admitted or rejected as a whole, never split.
+ * pair. To prevent that, a touch that lands while **exactly one** other touch is
+ * down inherits that group's verdict (admit wins over palm), so a pair is
+ * admitted or rejected as a whole and never split.
+ *
+ * **The inheritance stops at the pair.** Once two touches are already down, a
+ * further contact cannot possibly split them — the pair is complete and driving
+ * the camera — so a third or later touch is classified from scratch instead of
+ * inheriting `'admit'`. This is what keeps a palm from *joining* a live pinch:
+ * the two-finger controller re-anchors onto whichever contacts remain when a
+ * finger lifts, so an admitted palm becomes half of the gesture the moment a
+ * real finger leaves, and the camera lurches with the wandering contact patch.
+ * Inheriting only across the 1 → 2 step gets the no-tear guarantee without that
+ * hole.
+ *
+ * **Synthetic events are ignored.** The two-finger controller dispatches a
+ * `pointercancel` per live finger to reset OrbitControls' internal drag state.
+ * Those events travel the host's capture phase like real ones, and taking them
+ * at face value would empty the live set while both fingers are still down —
+ * destroying the group coherence above at the exact moment it matters most.
+ * They carry a marker ({@link isSyntheticPointerEvent}) and are skipped.
  *
  * **Self-healing live set.** Because a mid-group contact inherits the group
  * verdict, a leaked `'palm'` entry (an iPad that drops a `pointerup`/
@@ -55,6 +71,8 @@
  * {@link PEN_CONTACT_STALE_MS}. A pointer really still down keeps refreshing its
  * timestamp, so only phantom contacts are reclaimed.
  */
+
+import { isSyntheticPointerEvent } from './synthetic-pointer';
 
 /**
  * How long after a pen lifts off the glass touch input stays suppressed.
@@ -144,6 +162,14 @@ export function isPalmTouch(state: PalmRejectionState): boolean {
   }
   return false;
 }
+
+/**
+ * Number of live touches after which a new contact stops inheriting the group
+ * verdict and is classified on its own merits. Inheritance exists purely to
+ * keep a *pair* from being split (see the module doc); once a pair is down,
+ * rejecting a newcomer cannot split anything, so palms are filtered again.
+ */
+const GROUP_INHERITANCE_MAX_LIVE_TOUCHES = 1;
 
 /** Whether a live touch pointer is being passed through or swallowed. */
 type TouchVerdict = 'admit' | 'palm';
@@ -304,7 +330,13 @@ export class PointerArbiter {
       return 'admit';
     }
     this.pruneStaleTouches();
-    if (this.touchVerdicts.size > 0) {
+    // Inherit only while a pair is still forming. Beyond that, a newcomer is a
+    // third contact that cannot split anything — classify it properly so a palm
+    // never joins (and later becomes half of) a live gesture.
+    if (
+      this.touchVerdicts.size > 0 &&
+      this.touchVerdicts.size <= GROUP_INHERITANCE_MAX_LIVE_TOUCHES
+    ) {
       for (const record of this.touchVerdicts.values()) {
         if (record.verdict === 'admit') {
           return 'admit';
@@ -316,6 +348,9 @@ export class PointerArbiter {
   }
 
   private readonly onPointerDown = (event: PointerEvent): void => {
+    if (isSyntheticPointerEvent(event)) {
+      return;
+    }
     if (event.pointerType === 'pen') {
       this.notePenActivity();
       return;
@@ -331,6 +366,9 @@ export class PointerArbiter {
   };
 
   private readonly onPointerMove = (event: PointerEvent): void => {
+    if (isSyntheticPointerEvent(event)) {
+      return;
+    }
     if (event.pointerType === 'pen') {
       this.notePenActivity();
       return;
@@ -353,6 +391,12 @@ export class PointerArbiter {
   };
 
   private readonly onPointerUp = (event: PointerEvent): void => {
+    // A synthetic reset means "OrbitControls, forget this drag", never "the
+    // finger left the glass". Honouring it would drop a live contact from the
+    // group and let the next one — often the palm — be admitted alongside it.
+    if (isSyntheticPointerEvent(event)) {
+      return;
+    }
     if (event.pointerType === 'pen') {
       this.penContact = false;
       this.lastPenActivityMs = this.now();
@@ -374,6 +418,9 @@ export class PointerArbiter {
   };
 
   private readonly onPointerOut = (event: PointerEvent): void => {
+    if (isSyntheticPointerEvent(event)) {
+      return;
+    }
     // Pen left hover range (or the surface). Drop the "in contact" flag so the
     // grace window starts counting down; touch resumes once it elapses.
     if (event.pointerType === 'pen') {

--- a/ui/src/app/components/viewer/scene/synthetic-pointer.ts
+++ b/ui/src/app/components/viewer/scene/synthetic-pointer.ts
@@ -1,0 +1,36 @@
+/**
+ * Marker for pointer events the viewport synthesises for itself.
+ *
+ * When the two-finger controller takes over a gesture it dispatches a
+ * `pointercancel` for each live finger so OrbitControls forgets its
+ * half-started drag. That event is a lie told to one listener: the fingers are
+ * still very much on the glass. Every *other* listener must ignore it, or it
+ * corrupts state that tracks physical contacts — the palm-rejection arbiter
+ * would forget which touches are down (losing the group verdict that keeps a
+ * palm from joining a live pinch), and the touch tuning would drop
+ * `zoomToCursor` mid-pinch.
+ *
+ * A symbol keyed off the event object is the cheapest reliable channel: it
+ * survives dispatch (the same object instance is delivered), needs no wrapper
+ * type, and cannot collide with anything the DOM defines.
+ */
+const SYNTHETIC_POINTER_EVENT = Symbol.for('slicer.viewer.syntheticPointerEvent');
+
+/**
+ * Tag an event the viewport is about to dispatch at itself, so state that
+ * models *physical* contacts can skip it. See {@link isSyntheticPointerEvent}.
+ */
+export function markSyntheticPointerEvent<T extends Event>(event: T): T {
+  (event as unknown as Record<symbol, boolean>)[SYNTHETIC_POINTER_EVENT] = true;
+  return event;
+}
+
+/**
+ * True for an event the viewport dispatched at itself rather than one the OS
+ * reported. Such an event describes intent, never a real finger lifting.
+ */
+export function isSyntheticPointerEvent(event: Event): boolean {
+  return (
+    (event as unknown as Record<symbol, boolean | undefined>)[SYNTHETIC_POINTER_EVENT] === true
+  );
+}

--- a/ui/src/app/components/viewer/scene/two-finger-gesture.spec.ts
+++ b/ui/src/app/components/viewer/scene/two-finger-gesture.spec.ts
@@ -1,0 +1,250 @@
+import { describe, expect, it } from 'vitest';
+import {
+  type DollyPanGate,
+  type RollGate,
+  type TwoFingerSample,
+  TwoFingerGestureTracker,
+  wrapAngle,
+} from './two-finger-gesture';
+
+/** Mirrors the production tuning in `controls.ts`. */
+const ROLL_GATE: RollGate = {
+  engageAngleRad: 0.16,
+  minSeparationPx: 70,
+  dominanceRatio: 1.6,
+  lockoutPinchPx: 24,
+  deadZoneRad: 0.01,
+  maxStepRad: 0.3,
+};
+
+const DOLLY_PAN_GATE: DollyPanGate = {
+  deadZonePx: 1.5,
+  maxStepFactor: 1.6,
+  maxPanStepPx: 160,
+};
+
+function tracker(): TwoFingerGestureTracker {
+  return new TwoFingerGestureTracker(ROLL_GATE, DOLLY_PAN_GATE);
+}
+
+/** Two contacts at `dist` apart, rotated by `angle`, centred at `cx`/`cy`. */
+function sample(dist: number, angle = 0, cx = 500, cy = 500): TwoFingerSample {
+  return { dist, angle, cx, cy };
+}
+
+/**
+ * A pinch as a real hand performs it: the separation changes smoothly while
+ * the wrist adds a little rotation and the fingertips jitter.
+ */
+function* pinchFrames(
+  from: number,
+  to: number,
+  frames: number,
+  opts: { twistRad?: number; jitterPx?: number } = {},
+): Generator<TwoFingerSample> {
+  const { twistRad = 0, jitterPx = 0 } = opts;
+  for (let i = 1; i <= frames; i++) {
+    const t = i / frames;
+    const dist = from + (to - from) * t;
+    // Deterministic pseudo-jitter, so the test cannot flake.
+    const jitter = jitterPx === 0 ? 0 : Math.sin(i * 2.399) * (jitterPx / dist);
+    yield sample(dist, twistRad * t + jitter);
+  }
+}
+
+describe('wrapAngle', () => {
+  it('takes the short way round the circle', () => {
+    expect(wrapAngle(0.2)).toBeCloseTo(0.2);
+    expect(wrapAngle(Math.PI * 1.9)).toBeCloseTo(-Math.PI * 0.1);
+    expect(wrapAngle(-Math.PI * 1.9)).toBeCloseTo(Math.PI * 0.1);
+  });
+});
+
+describe('TwoFingerGestureTracker — a zoom never becomes a spin', () => {
+  it('does not roll during a pinch that carries ordinary wrist rotation', () => {
+    const t = tracker();
+    t.begin(sample(240));
+    let totalRoll = 0;
+    // 12° of incidental twist across a firm pinch — more than a steady hand adds.
+    for (const frame of pinchFrames(240, 90, 60, { twistRad: 0.21, jitterPx: 2 })) {
+      totalRoll += Math.abs(t.update(frame).rollRad);
+    }
+    expect(totalRoll).toBe(0);
+    expect(t.isRollLocked()).toBe(true);
+  });
+
+  it('does not roll as the fingers close, where angular noise explodes', () => {
+    const t = tracker();
+    t.begin(sample(200));
+    let totalRoll = 0;
+    // Pinching to 20px apart: 2px of jitter there reads as 5.7 deg/frame, which
+    // is what used to whip the camera round.
+    for (const frame of pinchFrames(200, 20, 80, { jitterPx: 2.5 })) {
+      totalRoll += Math.abs(t.update(frame).rollRad);
+    }
+    expect(totalRoll).toBe(0);
+  });
+
+  it('latches roll off for the rest of the gesture once a pinch is established', () => {
+    const t = tracker();
+    t.begin(sample(200));
+    for (const frame of pinchFrames(200, 150, 20)) {
+      t.update(frame);
+    }
+    expect(t.isRollLocked()).toBe(true);
+
+    // A deliberate, large twist afterwards must still be refused: the user is
+    // mid-zoom, and their wrist turning is not a request to roll the camera.
+    let totalRoll = 0;
+    for (let i = 1; i <= 40; i++) {
+      totalRoll += Math.abs(t.update(sample(150, (i / 40) * 1.2)).rollRad);
+    }
+    expect(totalRoll).toBe(0);
+  });
+});
+
+describe('TwoFingerGestureTracker — a deliberate twist still rolls', () => {
+  it('engages roll for a sustained twist at a workable separation', () => {
+    const t = tracker();
+    t.begin(sample(240));
+    let totalRoll = 0;
+    for (let i = 1; i <= 40; i++) {
+      totalRoll += t.update(sample(240, (i / 40) * 0.9)).rollRad;
+    }
+    expect(t.isRollEngaged()).toBe(true);
+    // The twist beyond the engage threshold reaches the camera; the qualifying
+    // part deliberately does not, so engaging never jolts the view.
+    expect(totalRoll).toBeGreaterThan(0.5);
+    expect(totalRoll).toBeLessThan(0.9);
+  });
+
+  it('never dumps the qualifying twist as a single jump when roll engages', () => {
+    const t = tracker();
+    t.begin(sample(240));
+    let maxStep = 0;
+    for (let i = 1; i <= 40; i++) {
+      maxStep = Math.max(maxStep, Math.abs(t.update(sample(240, (i / 40) * 0.9)).rollRad));
+    }
+    expect(maxStep).toBeLessThanOrEqual(ROLL_GATE.maxStepRad);
+    expect(maxStep).toBeLessThan(0.1);
+  });
+
+  it('refuses roll when the fingers are too close for the angle to mean anything', () => {
+    const t = tracker();
+    t.begin(sample(40));
+    let totalRoll = 0;
+    for (let i = 1; i <= 40; i++) {
+      totalRoll += Math.abs(t.update(sample(40, (i / 40) * 1.0)).rollRad);
+    }
+    expect(t.isRollEngaged()).toBe(false);
+    expect(totalRoll).toBe(0);
+  });
+});
+
+describe('TwoFingerGestureTracker — slow pinches still zoom', () => {
+  it('accumulates sub-threshold separation instead of discarding it', () => {
+    const t = tracker();
+    t.begin(sample(200));
+    // 0.5px per event — a deliberate slow pinch on a 120Hz iPad. The old
+    // per-frame dead zone threw every one of these away and never zoomed.
+    let applied = 0;
+    let product = 1;
+    for (let i = 1; i <= 60; i++) {
+      const motion = t.update(sample(200 + i * 0.5));
+      if (motion.dollyFactor !== null) {
+        applied++;
+        product *= motion.dollyFactor;
+      }
+    }
+    expect(applied).toBeGreaterThan(0);
+    // 200 -> 230 is a 1.15x separation, so the camera should dolly by ~1/1.15.
+    expect(product).toBeCloseTo(200 / 230, 2);
+  });
+
+  it('loses no zoom to rounding across many tiny steps', () => {
+    const t = tracker();
+    t.begin(sample(100));
+    let product = 1;
+    for (let i = 1; i <= 400; i++) {
+      const motion = t.update(sample(100 + i * 0.25));
+      if (motion.dollyFactor !== null) {
+        product *= motion.dollyFactor;
+      }
+    }
+    expect(product).toBeCloseTo(100 / 200, 2);
+  });
+});
+
+describe('TwoFingerGestureTracker — discontinuities are absorbed', () => {
+  it('clamps an implausible one-event jump in every channel', () => {
+    const t = tracker();
+    t.begin(sample(200, 0, 500, 500));
+    const motion = t.update(sample(20, 2.5, 900, 100));
+    expect(motion.dollyFactor).toBeLessThanOrEqual(DOLLY_PAN_GATE.maxStepFactor);
+    expect(motion.dollyFactor).toBeGreaterThanOrEqual(1 / DOLLY_PAN_GATE.maxStepFactor);
+    expect(Math.abs(motion.rollRad)).toBeLessThanOrEqual(ROLL_GATE.maxStepRad);
+    expect(Math.abs(motion.panDx)).toBeLessThanOrEqual(DOLLY_PAN_GATE.maxPanStepPx);
+    expect(Math.abs(motion.panDy)).toBeLessThanOrEqual(DOLLY_PAN_GATE.maxPanStepPx);
+  });
+
+  it('emits nothing for the frame a new pair is adopted', () => {
+    const t = tracker();
+    t.begin(sample(200, 0, 500, 500));
+    t.update(sample(190, 0.02, 505, 500));
+    // A finger lifts and a third contact takes its place: wildly different
+    // geometry that owes nothing to the user's hand moving.
+    t.reanchor(sample(60, 1.4, 200, 800));
+    const motion = t.update(sample(60, 1.4, 200, 800));
+    expect(motion.dollyFactor).toBeNull();
+    expect(motion.rollRad).toBe(0);
+    expect(motion.panDx).toBe(0);
+    expect(motion.panDy).toBe(0);
+  });
+
+  it('keeps the pinch verdict across a re-anchor', () => {
+    const t = tracker();
+    t.begin(sample(200));
+    for (const frame of pinchFrames(200, 150, 20)) {
+      t.update(frame);
+    }
+    expect(t.isRollLocked()).toBe(true);
+    t.reanchor(sample(240));
+    // Swapping fingers must not be a backdoor to the roll the lockout denied.
+    let totalRoll = 0;
+    for (let i = 1; i <= 40; i++) {
+      totalRoll += Math.abs(t.update(sample(240, (i / 40) * 1.2)).rollRad);
+    }
+    expect(t.isRollLocked()).toBe(true);
+    expect(totalRoll).toBe(0);
+  });
+
+  it('ignores a degenerate sample rather than dividing by zero', () => {
+    const t = tracker();
+    t.begin(sample(200));
+    expect(t.update(sample(0))).toEqual({
+      dollyFactor: null,
+      rollRad: 0,
+      panDx: 0,
+      panDy: 0,
+    });
+    expect(t.update(sample(Number.NaN)).dollyFactor).toBeNull();
+  });
+});
+
+describe('TwoFingerGestureTracker — panning', () => {
+  it('tracks the centroid one-to-one', () => {
+    const t = tracker();
+    t.begin(sample(200, 0, 500, 500));
+    const motion = t.update(sample(200, 0, 530, 470));
+    expect(motion.panDx).toBeCloseTo(30);
+    expect(motion.panDy).toBeCloseTo(-30);
+  });
+
+  it('reports no pan for a stationary centroid', () => {
+    const t = tracker();
+    t.begin(sample(200, 0, 500, 500));
+    const motion = t.update(sample(180, 0, 500, 500));
+    expect(motion.panDx).toBe(0);
+    expect(motion.panDy).toBe(0);
+  });
+});

--- a/ui/src/app/components/viewer/scene/two-finger-gesture.spec.ts
+++ b/ui/src/app/components/viewer/scene/two-finger-gesture.spec.ts
@@ -9,10 +9,10 @@ import {
 
 /** Mirrors the production tuning in `controls.ts`. */
 const ROLL_GATE: RollGate = {
-  engageAngleRad: 0.14,
-  minSeparationPx: 60,
-  dominanceRatio: 1.6,
-  lockoutPinchPx: 24,
+  engageAngleRad: 0.105,
+  minSeparationPx: 45,
+  dominanceRatio: 1.0,
+  lockoutPinchRatio: 0.2,
   deadZoneRad: 0.01,
   maxStepRad: 0.3,
 };
@@ -160,6 +160,43 @@ describe('TwoFingerGestureTracker — a deliberate twist still rolls', () => {
     t.begin(sample(200));
     for (const frame of twistFrames(25, 120, { jitterPx: 1.5 })) {
       t.update(frame);
+    }
+    expect(t.isRollEngaged()).toBe(true);
+  });
+
+  it('engages roll with the fingers close together', () => {
+    // The span most rolls are actually made with. The old gate compared an arc
+    // length against an absolute pixel change, which is biased by the radius:
+    // it wanted ~30 deg of twist here versus ~6 deg at 300px, so a normal grip
+    // could not roll at all.
+    const t = tracker();
+    t.begin(sample(80));
+    for (const frame of twistFrames(20, 90, { dist: 80, jitterPx: 0.3 })) {
+      t.update(frame);
+    }
+    expect(t.isRollEngaged()).toBe(true);
+  });
+
+  it('asks the same of a narrow grip as a wide one', () => {
+    // Scale invariance: an identical twist, with separation drifting by the
+    // same *fraction*, must be judged identically at any span.
+    for (const dist of [60, 100, 160, 240, 320]) {
+      const t = tracker();
+      t.begin(sample(dist));
+      for (let i = 1; i <= 90; i++) {
+        const drift = dist * 0.06 * (i / 90);
+        t.update(sample(dist + drift, ((15 * Math.PI) / 180) * (i / 90)));
+      }
+      expect(t.isRollEngaged(), `separation ${dist}px should roll`).toBe(true);
+    }
+  });
+
+  it('tolerates the separation drifting while the wrist turns', () => {
+    const t = tracker();
+    t.begin(sample(100));
+    // A real twist is not a perfect pivot — the fingers wander a little.
+    for (let i = 1; i <= 90; i++) {
+      t.update(sample(100 + 10 * (i / 90), ((18 * Math.PI) / 180) * (i / 90)));
     }
     expect(t.isRollEngaged()).toBe(true);
   });

--- a/ui/src/app/components/viewer/scene/two-finger-gesture.spec.ts
+++ b/ui/src/app/components/viewer/scene/two-finger-gesture.spec.ts
@@ -9,8 +9,8 @@ import {
 
 /** Mirrors the production tuning in `controls.ts`. */
 const ROLL_GATE: RollGate = {
-  engageAngleRad: 0.16,
-  minSeparationPx: 70,
+  engageAngleRad: 0.14,
+  minSeparationPx: 60,
   dominanceRatio: 1.6,
   lockoutPinchPx: 24,
   deadZoneRad: 0.01,
@@ -49,6 +49,28 @@ function* pinchFrames(
     // Deterministic pseudo-jitter, so the test cannot flake.
     const jitter = jitterPx === 0 ? 0 : Math.sin(i * 2.399) * (jitterPx / dist);
     yield sample(dist, twistRad * t + jitter);
+  }
+}
+
+/**
+ * A twist as a real hand performs it: the fingers sweep round while their
+ * reported separation jitters every event.
+ *
+ * The jitter is the whole point. Fixtures that hold `dist` perfectly constant
+ * describe no hardware that exists, and they hid a bug that made roll
+ * impossible to trigger on a real iPad — the gate summed per-event separation
+ * travel, so noise alone accumulated past the pinch lockout in under a second.
+ */
+function* twistFrames(
+  degrees: number,
+  frames: number,
+  opts: { dist?: number; jitterPx?: number } = {},
+): Generator<TwoFingerSample> {
+  const { dist = 200, jitterPx = 0.3 } = opts;
+  for (let i = 1; i <= frames; i++) {
+    // Deterministic pseudo-jitter, so the test cannot flake.
+    const noise = Math.sin(i * 2.399) * jitterPx + Math.sin(i * 5.7) * (jitterPx * 0.67);
+    yield sample(dist + noise, ((degrees * Math.PI) / 180) * (i / frames));
   }
 }
 
@@ -104,26 +126,50 @@ describe('TwoFingerGestureTracker — a zoom never becomes a spin', () => {
 });
 
 describe('TwoFingerGestureTracker — a deliberate twist still rolls', () => {
-  it('engages roll for a sustained twist at a workable separation', () => {
+  it('engages roll for a sustained twist on real, jittery hardware', () => {
     const t = tracker();
-    t.begin(sample(240));
+    t.begin(sample(200));
     let totalRoll = 0;
-    for (let i = 1; i <= 40; i++) {
-      totalRoll += t.update(sample(240, (i / 40) * 0.9)).rollRad;
+    // 120 events ~= 1s at 120Hz, the rate a real iPad reports.
+    for (const frame of twistFrames(25, 120)) {
+      totalRoll += t.update(frame).rollRad;
     }
     expect(t.isRollEngaged()).toBe(true);
+    expect(t.isRollLocked()).toBe(false);
     // The twist beyond the engage threshold reaches the camera; the qualifying
     // part deliberately does not, so engaging never jolts the view.
-    expect(totalRoll).toBeGreaterThan(0.5);
-    expect(totalRoll).toBeLessThan(0.9);
+    const total = (25 * Math.PI) / 180;
+    expect(totalRoll).toBeGreaterThan(total - ROLL_GATE.engageAngleRad - 0.02);
+    expect(totalRoll).toBeLessThan(total);
+  });
+
+  it('is not locked out by separation jitter during a long twist', () => {
+    const t = tracker();
+    t.begin(sample(200));
+    // Three seconds of slow twisting. Summing per-event travel would have
+    // crossed the 24px pinch lockout from noise alone within the first second.
+    for (const frame of twistFrames(30, 360)) {
+      t.update(frame);
+    }
+    expect(t.isRollLocked()).toBe(false);
+    expect(t.isRollEngaged()).toBe(true);
+  });
+
+  it('engages roll even with heavy contact noise', () => {
+    const t = tracker();
+    t.begin(sample(200));
+    for (const frame of twistFrames(25, 120, { jitterPx: 1.5 })) {
+      t.update(frame);
+    }
+    expect(t.isRollEngaged()).toBe(true);
   });
 
   it('never dumps the qualifying twist as a single jump when roll engages', () => {
     const t = tracker();
-    t.begin(sample(240));
+    t.begin(sample(200));
     let maxStep = 0;
-    for (let i = 1; i <= 40; i++) {
-      maxStep = Math.max(maxStep, Math.abs(t.update(sample(240, (i / 40) * 0.9)).rollRad));
+    for (const frame of twistFrames(25, 120)) {
+      maxStep = Math.max(maxStep, Math.abs(t.update(frame).rollRad));
     }
     expect(maxStep).toBeLessThanOrEqual(ROLL_GATE.maxStepRad);
     expect(maxStep).toBeLessThan(0.1);
@@ -133,8 +179,8 @@ describe('TwoFingerGestureTracker — a deliberate twist still rolls', () => {
     const t = tracker();
     t.begin(sample(40));
     let totalRoll = 0;
-    for (let i = 1; i <= 40; i++) {
-      totalRoll += Math.abs(t.update(sample(40, (i / 40) * 1.0)).rollRad);
+    for (const frame of twistFrames(40, 60, { dist: 40, jitterPx: 0.2 })) {
+      totalRoll += Math.abs(t.update(frame).rollRad);
     }
     expect(t.isRollEngaged()).toBe(false);
     expect(totalRoll).toBe(0);

--- a/ui/src/app/components/viewer/scene/two-finger-gesture.ts
+++ b/ui/src/app/components/viewer/scene/two-finger-gesture.ts
@@ -22,6 +22,18 @@
  * {@link RollGate.lockoutPinchPx} the gesture is a pinch **for good** and roll
  * is latched off — a guarantee, not a threshold a jittery frame can beat.
  *
+ * **Travel is measured as net displacement, never as accumulated path length.**
+ * This is the difference between a gate that works on real hardware and one
+ * that cannot fire at all. A fingertip's reported separation jitters every
+ * event, so summing `|Δdist|` integrates the *absolute value* of that noise: it
+ * only ever grows, and at 120 Hz even 0.3 px of jitter accumulates past a 24 px
+ * pinch threshold in **0.58 s** — locking roll out mid-twist, from noise alone,
+ * before the user has rotated far enough to engage. Measuring from the
+ * gesture's origin instead lets the noise cancel: the same pure twist reads
+ * 0.4 px of radial movement against 43.6 px of tangential. Both channels are
+ * compared in pixels of real fingertip movement, so the ratio holds at any
+ * separation.
+ *
  * **Dead zones accumulate, they do not discard.** Each channel keeps its own
  * anchor and only moves it when it actually applies motion, so sub-threshold
  * movement is *stored* rather than thrown away. The previous code re-based
@@ -58,13 +70,13 @@ export interface TwoFingerMotion {
 
 /** Tuning for the roll gate. See the module doc for the reasoning. */
 export interface RollGate {
-  /** Net twist from gesture start needed before roll engages. */
+  /** Net twist from the gesture origin needed before roll engages. */
   engageAngleRad: number;
   /** Separation below which a twist reading is noise by construction. */
   minSeparationPx: number;
-  /** Required ratio of tangential to radial fingertip travel. */
+  /** Required ratio of net tangential to net radial fingertip displacement. */
   dominanceRatio: number;
-  /** Radial travel that latches roll off for the rest of the gesture. */
+  /** Net radial displacement that latches roll off for the rest of the gesture. */
   lockoutPinchPx: number;
   /** Fine-grain dead zone applied once roll is engaged. */
   deadZoneRad: number;
@@ -112,14 +124,12 @@ export class TwoFingerGestureTracker {
   private panAnchorCx = 0;
   private panAnchorCy = 0;
 
-  /** Previous raw sample, used to accumulate travel for the roll gate. */
-  private prevDist = 0;
+  /** Previous raw angle, used to accumulate net twist across the gesture. */
   private prevAngle = 0;
 
-  /** Path length of the separation change — how much the user has pinched. */
-  private radialTravelPx = 0;
-  /** Path length each fingertip has swept tangentially — how much they twisted. */
-  private tangentialTravelPx = 0;
+  /** Separation when the gesture (or the current pair) began. */
+  private originDist = 0;
+
   /** Net signed twist since the gesture began. */
   private netAngleRad = 0;
 
@@ -134,9 +144,7 @@ export class TwoFingerGestureTracker {
   /** Start a fresh gesture anchored at `sample`. Clears all arbitration state. */
   begin(sample: TwoFingerSample): void {
     this.setAnchors(sample);
-    this.radialTravelPx = 0;
-    this.tangentialTravelPx = 0;
-    this.netAngleRad = 0;
+    this.resetArbitrationOrigin(sample);
     this.rollEngaged = false;
     this.rollLocked = false;
   }
@@ -146,12 +154,15 @@ export class TwoFingerGestureTracker {
    * changes identity (a finger lifts, another is adopted). The discontinuity is
    * absorbed instead of being applied as a huge one-frame jump.
    *
-   * Arbitration state deliberately survives: a gesture that has already been
-   * judged a pinch stays a pinch across a re-anchor, so swapping fingers is
-   * never a backdoor to the roll the lockout just denied.
+   * The arbitration *origin* is re-based too: distances between two different
+   * pairs of contacts are not comparable, and carrying the old one over would
+   * read the swap as a huge pinch and latch roll off. The *verdicts* however
+   * deliberately survive — a gesture already judged a pinch stays a pinch, so
+   * swapping fingers is never a backdoor to the roll the lockout just denied.
    */
   reanchor(sample: TwoFingerSample): void {
     this.setAnchors(sample);
+    this.resetArbitrationOrigin(sample);
   }
 
   /** True once the gesture has been judged a twist. Exposed for tests. */
@@ -169,33 +180,43 @@ export class TwoFingerGestureTracker {
     this.rollAnchorAngle = sample.angle;
     this.panAnchorCx = sample.cx;
     this.panAnchorCy = sample.cy;
-    this.prevDist = sample.dist;
     this.prevAngle = sample.angle;
   }
 
-  /** Accumulate evidence and decide whether the gesture is a twist. */
-  private arbitrate(sample: TwoFingerSample): void {
-    const dDist = sample.dist - this.prevDist;
-    const dAngle = wrapAngle(sample.angle - this.prevAngle);
-    this.prevDist = sample.dist;
+  /** Re-base the reference the net-displacement measurements are taken from. */
+  private resetArbitrationOrigin(sample: TwoFingerSample): void {
+    this.originDist = sample.dist;
     this.prevAngle = sample.angle;
+    this.netAngleRad = 0;
+  }
 
-    this.radialTravelPx += Math.abs(dDist);
-    // Arc length each fingertip sweeps, so twist and pinch are compared in the
-    // same unit — pixels of actual finger movement — at any separation.
-    this.tangentialTravelPx += Math.abs(dAngle) * (sample.dist / 2);
-    this.netAngleRad += dAngle;
+  /**
+   * Accumulate net twist and decide whether the gesture is a twist.
+   *
+   * Both measurements are **net displacement from the origin**, never summed
+   * per-event travel — see the module doc for why that distinction decides
+   * whether roll can fire at all on real hardware.
+   */
+  private arbitrate(sample: TwoFingerSample): void {
+    this.netAngleRad += wrapAngle(sample.angle - this.prevAngle);
+    this.prevAngle = sample.angle;
 
     if (this.rollEngaged || this.rollLocked) {
       return;
     }
-    if (this.radialTravelPx > this.rollGate.lockoutPinchPx) {
+
+    // How far the fingers have genuinely separated, and how far they have
+    // genuinely swept round. Jitter cancels in both instead of piling up.
+    const netRadialPx = Math.abs(sample.dist - this.originDist);
+    const netTangentialPx = Math.abs(this.netAngleRad) * (sample.dist / 2);
+
+    if (netRadialPx > this.rollGate.lockoutPinchPx) {
       this.rollLocked = true;
       return;
     }
     const twistedEnough = Math.abs(this.netAngleRad) >= this.rollGate.engageAngleRad;
     const wideEnough = sample.dist >= this.rollGate.minSeparationPx;
-    const dominant = this.tangentialTravelPx > this.radialTravelPx * this.rollGate.dominanceRatio;
+    const dominant = netTangentialPx > netRadialPx * this.rollGate.dominanceRatio;
     if (twistedEnough && wideEnough && dominant) {
       this.rollEngaged = true;
     }

--- a/ui/src/app/components/viewer/scene/two-finger-gesture.ts
+++ b/ui/src/app/components/viewer/scene/two-finger-gesture.ts
@@ -17,22 +17,30 @@
  * drives separation down, a fixed angular threshold gets easier to trip exactly
  * as the user zooms — the old behaviour, and the reported bug. So roll engages
  * only after a sustained twist ({@link RollGate.engageAngleRad}) at a
- * separation where the angle means something, and only while tangential travel
- * clearly dominates radial travel. Once radial travel passes
- * {@link RollGate.lockoutPinchPx} the gesture is a pinch **for good** and roll
- * is latched off — a guarantee, not a threshold a jittery frame can beat.
+ * separation where the angle means something, and only while rotation clearly
+ * dominates scaling. Once the fingers have changed separation by
+ * {@link RollGate.lockoutPinchRatio} the gesture is a pinch **for good** and
+ * roll is latched off — a guarantee, not a threshold a jittery frame can beat.
  *
- * **Travel is measured as net displacement, never as accumulated path length.**
- * This is the difference between a gate that works on real hardware and one
- * that cannot fire at all. A fingertip's reported separation jitters every
- * event, so summing `|Δdist|` integrates the *absolute value* of that noise: it
- * only ever grows, and at 120 Hz even 0.3 px of jitter accumulates past a 24 px
- * pinch threshold in **0.58 s** — locking roll out mid-twist, from noise alone,
- * before the user has rotated far enough to engage. Measuring from the
- * gesture's origin instead lets the noise cancel: the same pure twist reads
- * 0.4 px of radial movement against 43.6 px of tangential. Both channels are
- * compared in pixels of real fingertip movement, so the ratio holds at any
- * separation.
+ * **Rotation and pinch are compared per unit radius, so the test is
+ * scale-invariant.** This is what lets a twist be recognised with the fingers
+ * close together. Rotating by `θ` moves each fingertip `θ·r`; scaling by `s`
+ * moves each fingertip `(s−1)·r`. Dividing out the common `r` leaves a
+ * comparison of **radians against a separation *ratio***, with no dependence on
+ * how far apart the fingers happen to be — the same split UIKit draws between
+ * its pinch (scale) and rotation (angle) recognisers. Comparing an *arc length*
+ * against an absolute pixel change instead, as this originally did, is biased
+ * by `r`: it demanded 6° of twist at 300 px but **30°** at 60 px, so a
+ * pinch-sized grip could never roll.
+ *
+ * **Travel is net displacement from the gesture's origin, never summed
+ * per-event path length.** This is the difference between a gate that works on
+ * real hardware and one that cannot fire at all. A fingertip's reported
+ * separation jitters every event, so summing `|Δdist|` integrates the *absolute
+ * value* of that noise: it only ever grows, and at 120 Hz even 0.3 px of jitter
+ * accumulates past a pinch threshold in **0.58 s** — locking roll out
+ * mid-twist, from noise alone, before the user has rotated far enough to
+ * engage. Measuring from the gesture's origin instead lets the noise cancel.
  *
  * **Dead zones accumulate, they do not discard.** Each channel keeps its own
  * anchor and only moves it when it actually applies motion, so sub-threshold
@@ -74,10 +82,17 @@ export interface RollGate {
   engageAngleRad: number;
   /** Separation below which a twist reading is noise by construction. */
   minSeparationPx: number;
-  /** Required ratio of net tangential to net radial fingertip displacement. */
+  /**
+   * How far rotation must outweigh scaling, comparing radians against the
+   * separation *ratio* — both being per-unit-radius fingertip displacement.
+   */
   dominanceRatio: number;
-  /** Net radial displacement that latches roll off for the rest of the gesture. */
-  lockoutPinchPx: number;
+  /**
+   * Fractional change in separation (0.2 = 20%) that latches roll off for the
+   * rest of the gesture. A ratio rather than a pixel count so a small grip and
+   * a wide one have to pinch equally *hard*, not equally *far*.
+   */
+  lockoutPinchRatio: number;
   /** Fine-grain dead zone applied once roll is engaged. */
   deadZoneRad: number;
   /** Largest roll applied from one update. */
@@ -193,8 +208,9 @@ export class TwoFingerGestureTracker {
   /**
    * Accumulate net twist and decide whether the gesture is a twist.
    *
-   * Both measurements are **net displacement from the origin**, never summed
-   * per-event travel — see the module doc for why that distinction decides
+   * Both measurements are **net displacement from the origin**, and both are
+   * expressed **per unit radius** so the comparison does not depend on how far
+   * apart the fingers are — see the module doc for why each of those decides
    * whether roll can fire at all on real hardware.
    */
   private arbitrate(sample: TwoFingerSample): void {
@@ -205,19 +221,20 @@ export class TwoFingerGestureTracker {
       return;
     }
 
-    // How far the fingers have genuinely separated, and how far they have
-    // genuinely swept round. Jitter cancels in both instead of piling up.
-    const netRadialPx = Math.abs(sample.dist - this.originDist);
-    const netTangentialPx = Math.abs(this.netAngleRad) * (sample.dist / 2);
+    // Rotating by θ moves each fingertip θ·r; scaling by s moves each fingertip
+    // (s−1)·r. With the common r divided out these are directly comparable.
+    const twistRad = Math.abs(this.netAngleRad);
+    const pinchRatio = Math.abs(sample.dist / Math.max(this.originDist, 1e-3) - 1);
 
-    if (netRadialPx > this.rollGate.lockoutPinchPx) {
+    if (pinchRatio > this.rollGate.lockoutPinchRatio) {
       this.rollLocked = true;
       return;
     }
-    const twistedEnough = Math.abs(this.netAngleRad) >= this.rollGate.engageAngleRad;
-    const wideEnough = sample.dist >= this.rollGate.minSeparationPx;
-    const dominant = netTangentialPx > netRadialPx * this.rollGate.dominanceRatio;
-    if (twistedEnough && wideEnough && dominant) {
+    if (
+      twistRad >= this.rollGate.engageAngleRad &&
+      sample.dist >= this.rollGate.minSeparationPx &&
+      twistRad > pinchRatio * this.rollGate.dominanceRatio
+    ) {
       this.rollEngaged = true;
     }
   }

--- a/ui/src/app/components/viewer/scene/two-finger-gesture.ts
+++ b/ui/src/app/components/viewer/scene/two-finger-gesture.ts
@@ -1,0 +1,245 @@
+/**
+ * Arbitration for two-finger viewport gestures: pinch-dolly, centroid pan and
+ * twist-roll.
+ *
+ * The hard part of a multi-touch camera is not computing the three channels —
+ * that is trigonometry — it is deciding *which one the user meant*. Fingers
+ * never move on a clean radial line, so a pinch always carries some rotation
+ * and a twist always carries some separation change. Feeding all three raw
+ * signals straight to the camera makes a zoom spin the model, which is exactly
+ * the failure this module exists to remove.
+ *
+ * Two properties do the work:
+ *
+ * **Roll must earn its way in, and can be shut out.** Rotation is measured as
+ * an *angle*, so its noise floor scales with `1 / separation`: 2 px of tremor
+ * reads as 0.6° at 200 px apart but 4.6° at 25 px apart. Since pinching in
+ * drives separation down, a fixed angular threshold gets easier to trip exactly
+ * as the user zooms — the old behaviour, and the reported bug. So roll engages
+ * only after a sustained twist ({@link RollGate.engageAngleRad}) at a
+ * separation where the angle means something, and only while tangential travel
+ * clearly dominates radial travel. Once radial travel passes
+ * {@link RollGate.lockoutPinchPx} the gesture is a pinch **for good** and roll
+ * is latched off — a guarantee, not a threshold a jittery frame can beat.
+ *
+ * **Dead zones accumulate, they do not discard.** Each channel keeps its own
+ * anchor and only moves it when it actually applies motion, so sub-threshold
+ * movement is *stored* rather than thrown away. The previous code re-based
+ * every anchor each event, which silently deleted any motion below the
+ * threshold; on a 120 Hz iPad a deliberate slow pinch never accumulated the
+ * 1.5 px per event it needed and the camera simply refused to zoom.
+ *
+ * The tracker is pure and clock-free: feed it samples, get motion back. That
+ * keeps the arbitration testable without a DOM, a canvas, or a camera.
+ */
+
+/** Geometry of the two contacts driving the gesture, in CSS pixels. */
+export interface TwoFingerSample {
+  /** Distance between the two contacts. */
+  dist: number;
+  /** Angle of the line joining them, radians, from `Math.atan2`. */
+  angle: number;
+  /** Centroid x. */
+  cx: number;
+  /** Centroid y. */
+  cy: number;
+}
+
+/** Camera motion to apply for one update. Zero/`null` fields mean "no motion". */
+export interface TwoFingerMotion {
+  /** Dolly ratio (`< 1` zooms in), or `null` when below the dead zone. */
+  dollyFactor: number | null;
+  /** Roll about the view axis, radians. `0` when roll is not engaged. */
+  rollRad: number;
+  /** Centroid pan, pixels. */
+  panDx: number;
+  panDy: number;
+}
+
+/** Tuning for the roll gate. See the module doc for the reasoning. */
+export interface RollGate {
+  /** Net twist from gesture start needed before roll engages. */
+  engageAngleRad: number;
+  /** Separation below which a twist reading is noise by construction. */
+  minSeparationPx: number;
+  /** Required ratio of tangential to radial fingertip travel. */
+  dominanceRatio: number;
+  /** Radial travel that latches roll off for the rest of the gesture. */
+  lockoutPinchPx: number;
+  /** Fine-grain dead zone applied once roll is engaged. */
+  deadZoneRad: number;
+  /** Largest roll applied from one update. */
+  maxStepRad: number;
+}
+
+/** Tuning for the dolly and pan channels. */
+export interface DollyPanGate {
+  /** Accumulated separation change before a dolly is applied. */
+  deadZonePx: number;
+  /** Largest dolly ratio applied from one update. */
+  maxStepFactor: number;
+  /** Largest centroid pan applied from one update. */
+  maxPanStepPx: number;
+}
+
+const NO_MOTION: TwoFingerMotion = { dollyFactor: null, rollRad: 0, panDx: 0, panDy: 0 };
+
+/** Shortest signed difference between two angles, in `(-π, π]`. */
+export function wrapAngle(delta: number): number {
+  let d = delta;
+  while (d > Math.PI) {
+    d -= 2 * Math.PI;
+  }
+  while (d < -Math.PI) {
+    d += 2 * Math.PI;
+  }
+  return d;
+}
+
+function clamp(value: number, min: number, max: number): number {
+  return Math.min(max, Math.max(min, value));
+}
+
+/**
+ * Turns a stream of two-finger samples into camera motion, arbitrating between
+ * pinch, pan and twist. One instance per gesture; call {@link begin} when the
+ * second finger lands and {@link reanchor} whenever the pair changes identity.
+ */
+export class TwoFingerGestureTracker {
+  /** Per-channel anchors — moved only when that channel emits motion. */
+  private dollyAnchorDist = 0;
+  private rollAnchorAngle = 0;
+  private panAnchorCx = 0;
+  private panAnchorCy = 0;
+
+  /** Previous raw sample, used to accumulate travel for the roll gate. */
+  private prevDist = 0;
+  private prevAngle = 0;
+
+  /** Path length of the separation change — how much the user has pinched. */
+  private radialTravelPx = 0;
+  /** Path length each fingertip has swept tangentially — how much they twisted. */
+  private tangentialTravelPx = 0;
+  /** Net signed twist since the gesture began. */
+  private netAngleRad = 0;
+
+  private rollEngaged = false;
+  private rollLocked = false;
+
+  constructor(
+    private readonly rollGate: RollGate,
+    private readonly dollyPanGate: DollyPanGate,
+  ) {}
+
+  /** Start a fresh gesture anchored at `sample`. Clears all arbitration state. */
+  begin(sample: TwoFingerSample): void {
+    this.setAnchors(sample);
+    this.radialTravelPx = 0;
+    this.tangentialTravelPx = 0;
+    this.netAngleRad = 0;
+    this.rollEngaged = false;
+    this.rollLocked = false;
+  }
+
+  /**
+   * Move every anchor to `sample` without emitting motion, for when the pair
+   * changes identity (a finger lifts, another is adopted). The discontinuity is
+   * absorbed instead of being applied as a huge one-frame jump.
+   *
+   * Arbitration state deliberately survives: a gesture that has already been
+   * judged a pinch stays a pinch across a re-anchor, so swapping fingers is
+   * never a backdoor to the roll the lockout just denied.
+   */
+  reanchor(sample: TwoFingerSample): void {
+    this.setAnchors(sample);
+  }
+
+  /** True once the gesture has been judged a twist. Exposed for tests. */
+  isRollEngaged(): boolean {
+    return this.rollEngaged;
+  }
+
+  /** True once the gesture has been latched as a pinch. Exposed for tests. */
+  isRollLocked(): boolean {
+    return this.rollLocked;
+  }
+
+  private setAnchors(sample: TwoFingerSample): void {
+    this.dollyAnchorDist = sample.dist;
+    this.rollAnchorAngle = sample.angle;
+    this.panAnchorCx = sample.cx;
+    this.panAnchorCy = sample.cy;
+    this.prevDist = sample.dist;
+    this.prevAngle = sample.angle;
+  }
+
+  /** Accumulate evidence and decide whether the gesture is a twist. */
+  private arbitrate(sample: TwoFingerSample): void {
+    const dDist = sample.dist - this.prevDist;
+    const dAngle = wrapAngle(sample.angle - this.prevAngle);
+    this.prevDist = sample.dist;
+    this.prevAngle = sample.angle;
+
+    this.radialTravelPx += Math.abs(dDist);
+    // Arc length each fingertip sweeps, so twist and pinch are compared in the
+    // same unit — pixels of actual finger movement — at any separation.
+    this.tangentialTravelPx += Math.abs(dAngle) * (sample.dist / 2);
+    this.netAngleRad += dAngle;
+
+    if (this.rollEngaged || this.rollLocked) {
+      return;
+    }
+    if (this.radialTravelPx > this.rollGate.lockoutPinchPx) {
+      this.rollLocked = true;
+      return;
+    }
+    const twistedEnough = Math.abs(this.netAngleRad) >= this.rollGate.engageAngleRad;
+    const wideEnough = sample.dist >= this.rollGate.minSeparationPx;
+    const dominant = this.tangentialTravelPx > this.radialTravelPx * this.rollGate.dominanceRatio;
+    if (twistedEnough && wideEnough && dominant) {
+      this.rollEngaged = true;
+    }
+  }
+
+  /**
+   * Fold one sample into the gesture and report the camera motion it earns.
+   */
+  update(sample: TwoFingerSample): TwoFingerMotion {
+    if (!Number.isFinite(sample.dist) || sample.dist <= 0) {
+      return NO_MOTION;
+    }
+    this.arbitrate(sample);
+
+    const motion: TwoFingerMotion = { dollyFactor: null, rollRad: 0, panDx: 0, panDy: 0 };
+
+    if (Math.abs(sample.dist - this.dollyAnchorDist) > this.dollyPanGate.deadZonePx) {
+      const raw = this.dollyAnchorDist / sample.dist;
+      motion.dollyFactor = clamp(
+        raw,
+        1 / this.dollyPanGate.maxStepFactor,
+        this.dollyPanGate.maxStepFactor,
+      );
+      this.dollyAnchorDist = sample.dist;
+    }
+
+    if (this.rollEngaged) {
+      const twist = wrapAngle(sample.angle - this.rollAnchorAngle);
+      if (Math.abs(twist) > this.rollGate.deadZoneRad) {
+        motion.rollRad = clamp(twist, -this.rollGate.maxStepRad, this.rollGate.maxStepRad);
+        this.rollAnchorAngle = sample.angle;
+      }
+    } else {
+      // Track the angle while roll is denied so engaging later starts from the
+      // current pose instead of dumping the whole accumulated twist at once.
+      this.rollAnchorAngle = sample.angle;
+    }
+
+    const { maxPanStepPx } = this.dollyPanGate;
+    motion.panDx = clamp(sample.cx - this.panAnchorCx, -maxPanStepPx, maxPanStepPx);
+    motion.panDy = clamp(sample.cy - this.panAnchorCy, -maxPanStepPx, maxPanStepPx);
+    this.panAnchorCx = sample.cx;
+    this.panAnchorCy = sample.cy;
+
+    return motion;
+  }
+}


### PR DESCRIPTION
Zooming with two fingers on an iPad would rotate the view instead of (or as well as) zooming, and slow pinches often did nothing at all. This is the root cause and four related defects found while tracing it.

## What was wrong

The two-finger handler applied **pinch, roll and pan simultaneously every frame**, each gated by its own per-frame threshold. Two of them were badly matched:

| Channel | Threshold | What it took to fire |
| --- | --- | --- |
| Roll | `0.01 rad`/frame | **2px of finger noise at 150px separation** |
| Dolly | `1.5 px`/frame | **90 px/s (60Hz) – 180 px/s (120Hz)** of pinch speed |

Rotation is measured as an *angle*, so its noise floor scales with `1/separation`. Pinching **in** drives separation down, which makes the roll test easier *exactly as the user zooms*: 2px of tremor reads as 0.57°/frame at 200px apart but **4.6°/frame at 25px** — 275°/s of camera spin. Replaying a realistic pinch through the old code produced **15.9° of unwanted roll**.

Both dead zones were also **high-pass filters, not accumulators** — `lastDist`/`lastAngle` were re-based unconditionally, so anything below the threshold was discarded. On a 120Hz iPad a deliberate slow pinch never reached the 1.5px per event it needed, so the camera refused to zoom and roll was the only channel still responding.

## What changed

A new pure, clock-free `TwoFingerGestureTracker` owns the decision:

- **Roll must earn its way in** — a sustained twist (≥9°), at a separation where the angle means something (≥70px), and only while tangential fingertip travel dominates radial travel by 1.6×. Both are compared in pixels of actual finger movement, so the test holds at any separation.
- **Roll can be shut out** — once radial travel passes 24px the gesture is a pinch **for good**. A latch, not a threshold a jittery frame can beat, and it survives a re-anchor so swapping fingers is not a backdoor.
- **Dead zones accumulate** — each channel keeps its own anchor and moves it only when it emits motion, so slow pinches zoom correctly.
- **Per-event clamps** absorb discontinuities no hand can produce (a contact patch morphing, coalesced events after a stall, a re-anchor).

## Four related defects, same symptom

- **Synthetic `pointercancel` corrupted palm rejection.** `beginTwoFinger` dispatches fake cancels to reset OrbitControls; they travel the host capture phase, where `PointerArbiter` deleted **both live touch verdicts** — destroying group coherence mid-gesture — and the touch tuning dropped `zoomToCursor`. They are now marked and skipped by everything that models physical contacts.
- **A palm could hijack a live pinch.** Verdict inheritance had no upper bound, so a hand settling during a two-finger gesture was admitted and became half the gesture when a real finger lifted. Inheritance is now capped at the 1 → 2 step, which is the only place it is needed to avoid splitting a pair.
- **A lost `pointerup` froze the camera.** A finger released over the toolbar, or the app backgrounded mid-pinch, left `controls.enabled = false` until reload. Three nets now cover it: window-level lifts, `blur`/`visibilitychange`, and a staleness sweep on the next `pointerdown` — deliberately **not** on move, since a stationary finger emits nothing and pausing mid-pinch would otherwise tear down a live gesture.
- **Non-deterministic driving pair.** `pts[0]`/`pts[1]` were read off Map insertion order each frame; the pair is now pinned explicitly and re-anchors without emitting motion when it changes.

## Notes for reviewers

- **The arbitration is unit-tested without a DOM** (`two-finger-gesture.spec.ts`, 15 cases) — that is why it was extracted. Tests replay realistic traces: a pinch carrying wrist rotation, a pinch closing to 20px where angular noise explodes, a deliberate twist that *should* roll, and a 0.5px-per-event slow pinch.
- **I mutation-tested the guard**: removing the pinch lockout fails exactly the three tests that defend it, so they are not vacuous.
- **The tuning constants are reasoned, not measured on device.** `ROLL_ENGAGE_ANGLE_RAD` (9°) and `ROLL_LOCKOUT_PINCH_PX` (24px) are the dials if deliberate roll now feels too hard to trigger.
- **Deliberately out of scope:** `isPalmTouch` rejects all touch while a Pencil merely *hovers*, so on M2+ iPads holding the pencil can suppress two-finger navigation. That is existing, documented, tested behaviour rather than this bug, but it is the likely source of any "sometimes touch does nothing" reports and may deserve a follow-up.

## Verification

- 39/39 viewer scene tests pass (24 existing + 15 new); 4 new arbiter cases cover the synthetic-event and third-contact rules.
- Typecheck clean on all changed files; Prettier clean.
- Docs updated: `viewer/README.md` (two new sections with Mermaid diagrams), `docs/use/interface.md`, and a `CHANGELOG.md` entry.

Full-suite `ng test` and a production build could not run here — both need the generated wasm bindings and the vendored UI checkout, which this worktree has not hydrated. CI covers them.
