### PR TITLE
ios: install a standalone build on an iPad, no dev server attached

### DIFF
--- a/.github/skills/test-changes/SKILL.md
+++ b/.github/skills/test-changes/SKILL.md
@@ -1,6 +1,6 @@
 ---
 name: test-changes
-description: Start the parts needed to test a change, hand the user the access details (URL, etc.), then give a short, concise bullet-point checklist of what to test by hand — targeted at the platform they name — remote+web (the default), the wasm browser slicer, the Tauri desktop app, or iOS/iPadOS. Use when the user says "what should I test", "how do I test this", "give me a test plan", "let me test it", "I'll test it", "test on desktop / iPad / wasm", or asks what to check now that the change is done.
+description: Start the parts needed to test a change, hand the user the access details (URL, etc.), then give a short, concise bullet-point checklist of what to test by hand — targeted at the platform they name — remote+web (the default), the wasm browser slicer, the Tauri desktop app, or iOS/iPadOS (a real iPhone/iPad unless they ask for the simulator). Use when the user says "what should I test", "how do I test this", "give me a test plan", "let me test it", "I'll test it", "test on desktop / iPad / iPhone / wasm", or asks what to check now that the change is done.
 ---
 
 # Get the User Testing
@@ -15,7 +15,9 @@ front of.
 
 Start the pieces the chosen platform needs as **background/detached** processes,
 then hand the user the access details. Never block or poll waiting on a dev
-server — start it, do a quick liveness check, and move on.
+server — start it, do a quick liveness check, and move on. The one exception is
+a device install, which is a build that has to finish before there is anything
+to test.
 
 **Every dev server runs on a random seed.** `pnpm run dev` rolls a three-digit
 seed (200–999) and derives every port from it — UI on `4<seed>`, engine on
@@ -23,12 +25,13 @@ seed (200–999) and derives every port from it — UI on `4<seed>`, engine on
 free. That is what keeps this session off the ports of the other checkout,
 worktree or teammate already running on this host. **Never hardcode 4213/5201.**
 
-| Platform            | Start (background)                                                              | Give the user                          |
+| Platform            | Start                                                                           | Give the user                          |
 | ------------------- | ------------------------------------------------------------------------------- | -------------------------------------- |
-| Remote + web        | `pnpm run dev`                                                                  | **http://localhost:4\<seed\>/**        |
-| Wasm browser slicer | `pnpm run hydrate:web-slicer` first, then `pnpm run dev:web-slicer`             | **http://localhost:4\<seed\>/** (no backend) |
-| Tauri desktop       | `pnpm run dev:desktop`                                                          | The app window opens — no URL          |
-| iOS / iPadOS        | `pnpm run ios:dev`                                                              | The iPad simulator opens — no URL      |
+| Remote + web        | `pnpm run dev` (background)                                                     | **http://localhost:4\<seed\>/**        |
+| Wasm browser slicer | `pnpm run hydrate:web-slicer` first, then `pnpm run dev:web-slicer` (background) | **http://localhost:4\<seed\>/** (no backend) |
+| Tauri desktop       | `pnpm run dev:desktop` (background)                                             | The app window opens — no URL          |
+| iPhone / iPad       | `pnpm run ios:install` — a build; wait for it                                   | The app is on the device — no URL      |
+| iOS Simulator       | `pnpm run ios:dev` (background)                                                 | The simulator opens — no URL           |
 | CLI                 | Nothing to serve — give the exact command to run                                | The command line                       |
 
 - **Read the seed back, don't guess it.** The launcher prints its banner first:
@@ -48,9 +51,27 @@ worktree or teammate already running on this host. **Never hardcode 4213/5201.**
 - **Reuse your own, never someone else's.** If *this* session already has a
   stack up, reuse it. A server on some other port belongs to another instance —
   leave it alone and roll a fresh seed instead of killing it.
-- **iOS is the one fixed-port flow.** `pnpm run ios:dev` uses the port pinned in
-  `tauri.conf.json` because the generated Xcode project builds against it. If it
-  is busy, that is the one case worth sorting out by hand.
+- **iOS means the real device unless they say "simulator".** Glass is the only
+  place printers, touch, Pencil and on-device speed behave truthfully, and
+  `ios:install` ships the **release** build — so it also catches production-only
+  breakage a dev server hides. It is a build, not a server — ~4 minutes warm,
+  longer on a cold cargo cache — so let it finish, or you are describing an app
+  that is not installed yet.
+- **Pre-flight the device.** `pnpm run ios:install --list` first; with two paired
+  the script refuses to guess, so pass `--device '<name>'`. A first install also
+  needs Developer Mode (Settings → Privacy & Security) and a one-time **Trust**
+  (Settings → General → VPN & Device Management → Developer App) — the script
+  catches the first, nothing warns about the second, so put it in the handover
+  line. Then report the **expiry it prints**: a free signature lasts seven days,
+  and `pnpm run ios:install --renew` resets the clock.
+- **Iterating on UI? Live reload on hardware is `tauri ios dev --host`**, not
+  `ios:dev`: `scripts/ios-dev.sh` always resolves a *simulator* name, so
+  `ios:dev --host` still lands on the simulator. Live reload keeps the Mac in the
+  loop (same network, dev server up); the release install does not.
+- **iOS is the one fixed-port flow.** Both `pnpm run ios:dev` and
+  `tauri ios dev --host` use the port pinned in `tauri.conf.json`, because the
+  generated Xcode project builds against it. If it is busy, that is the one case
+  worth sorting out by hand. `ios:install` needs no port at all.
 - **Fresh workspace? Hydrate before anything else.** If `ui/src/generated/`
   (or `ui/src/generated/scene-wasm/`) is missing — a brand-new clone, or after
   `pnpm install` alone — every platform's UI build fails with `Cannot find
@@ -86,17 +107,32 @@ remote + web.**
 | _nothing_, "web", "browser", "the UI", "server", "cloud"  | Remote + web        |
 | "wasm", "web-slicer", "browser slicer", "no backend"      | Wasm browser slicer |
 | "desktop", "tauri", "the app", "native"                   | Tauri desktop       |
-| "iPad", "iOS", "iPadOS", "iPhone", "mobile", "simulator"  | iOS / iPadOS        |
+| "iPad", "iOS", "iPadOS", "iPhone", "phone", "mobile"      | iPhone / iPad       |
+| "simulator", "sim", "emulator", "I don't have it with me" | iOS Simulator       |
 | "CLI", "headless", "terminal"                             | CLI                 |
 
 Plain "web" means remote + web — route to the wasm slicer only on an explicit
-signal. If they name several platforms, write one block each and keep only what
-is unique to that platform.
+signal. **Anything Apple-mobile means a real device**: route to the simulator
+only when they ask for it by name, or when `--list` shows nothing connected — and
+in that case say you fell back, so they can plug in instead. If they name several
+platforms, write one block each and keep only what is unique to that platform.
 
 **Only ask for checks the chosen platform can actually prove.** These surfaces
 differ in what runs where, so a passing check on one says nothing about another.
 When the change matters somewhere the user isn't testing, note it in one line
 rather than smuggling it into the list.
+
+Two Apple-specific splits are easy to get wrong:
+
+- **The simulator cannot prove** LAN printers (it never shows the local-network
+  prompt a device does), real touch or long-press, Apple Pencil, on-device
+  slicing speed, or anything about signing and standalone operation. Send those
+  checks to hardware or leave them out.
+- **iPhone and iPad are different layouts, not different sizes.** A phone is
+  under the 640px `handheld()` breakpoint and gets the tab bar, settings drawer
+  and slice sheet; an iPad keeps the desktop layout. A layout change verified on
+  one says nothing about the other — and if *only* the phone layout is in
+  question, a narrowed browser window proves it in seconds instead of minutes.
 
 If the change needs a rebuild before it is even running on that surface, make
 that the first line — otherwise they test the old build.

--- a/.gitignore
+++ b/.gitignore
@@ -33,7 +33,12 @@ ui-desktop/src-tauri/gen/apple/build/
 ui-desktop/src-tauri/gen/apple/Externals/
 ui-desktop/src-tauri/gen/apple/Pods/
 ui-desktop/src-tauri/gen/apple/.tauri/
-ui-desktop/src-tauri/gen/apple/*.xcodeproj/project.xcworkspace/
+# `project.xcworkspace/contents.xcworkspacedata` is part of the project, not user
+# state: `tauri ios build` passes it to `xcodebuild -workspace`, so a checkout
+# without it fails with "project.xcworkspace does not exist". Only the per-user
+# and Xcode-managed files beneath it are ignored.
+ui-desktop/src-tauri/gen/apple/*.xcodeproj/project.xcworkspace/xcuserdata/
+ui-desktop/src-tauri/gen/apple/*.xcodeproj/project.xcworkspace/xcshareddata/
 ui-desktop/src-tauri/gen/apple/*.xcodeproj/xcuserdata/
 ui-desktop/src-tauri/gen/apple/*.xcworkspace/xcuserdata/
 

--- a/AGENTS.md
+++ b/AGENTS.md
@@ -467,6 +467,11 @@ the UI and `tauri-build` compiles it into the binary.
 `--export-method debugging` → `xcrun devicectl device install app`. It needs no
 paid Apple Developer Program membership.
 
+- **The app is universal** (`TARGETED_DEVICE_FAMILY = "1,2"`), so iPhone and
+  iPad take the same path — the script filters on `platform == "iOS"` and never
+  on device type. **It refuses to pick between two paired devices**, because
+  guessing wrong costs a multi-minute build and would only be mentioned in
+  passing; `--device` names one.
 - **A free Apple ID signs for seven days**, so the script is expected to be
   re-run and prints the profile's expiry after every install. Automatic signing
   *reuses* a still-valid profile, so a plain rebuild on day six inherits one day

--- a/AGENTS.md
+++ b/AGENTS.md
@@ -457,6 +457,43 @@ Supporting details:
   is broken. All images of a version share one asset, so deleting a duplicate
   breaks the survivor — purge with `simctl runtime delete all` and re-download.
 
+### Standalone installs — `pnpm run ios:install`
+
+`tauri ios dev` installs an app pinned to the `devUrl` in `tauri.conf.json`, so
+it is a white screen the moment the Mac's dev server stops. **A device that has
+to keep working needs the release build**, where `beforeBuildCommand` produces
+the UI and `tauri-build` compiles it into the binary.
+[scripts/ios-install.sh](scripts/ios-install.sh) is that path: release build →
+`--export-method debugging` → `xcrun devicectl device install app`. It needs no
+paid Apple Developer Program membership.
+
+- **A free Apple ID signs for seven days**, so the script is expected to be
+  re-run and prints the profile's expiry after every install. Automatic signing
+  *reuses* a still-valid profile, so a plain rebuild on day six inherits one day
+  — `--renew` deletes the cached profiles for the bundle ID first, which is the
+  only way to actually reset the clock. Do not paper over this by re-installing
+  and assuming a fresh week.
+- **The team ID is the signing certificate's `OU`, not the identifier in its
+  common name.** A personal team has no Membership page to read it off, so the
+  script extracts it from the keychain — and only from certificates
+  `security find-identity -v` still considers valid, or an expired cert from an
+  old employer turns a working machine into "several teams found".
+- **`tauri ios build` writes `DEVELOPMENT_TEAM` into `project.pbxproj`**, which
+  is committed. The script restores the file from an EXIT trap so one
+  contributor's team ID never lands in everyone else's checkout, and clears a
+  line left behind by an interrupted run before snapshotting — otherwise the
+  next run preserves the leftover forever. Anything else the CLI mutates in
+  `gen/apple` needs the same treatment.
+- **`*.xcodeproj/project.xcworkspace/contents.xcworkspacedata` must stay
+  tracked.** `tauri ios build` passes it to `xcodebuild -workspace`, so a
+  checkout without it fails with a bare `project.xcworkspace does not exist`
+  before the build starts. `.gitignore` therefore ignores only the `xcuserdata`
+  and `xcshareddata` beneath it — not the directory.
+- **macOS ships bash 3.2.** The iOS helper scripts run on a stock machine, so no
+  `mapfile`, no `${var,,}`, no associative arrays. Splitting a concatenated PEM
+  stream with `awk` and a NUL separator does not work in the awk macOS ships
+  either — the loop is plain `read`.
+
 ## Phones — one breakpoint, two answers
 
 A handset is not a small desktop: the chrome that surrounds the 3D view (a 60px
@@ -1602,5 +1639,5 @@ infill within the ring.
 
 ---
 
-**Last Updated**: 2026-08-31 (docs site consumes the shared UI design tokens; UI bundle-chunking contract)  
+**Last Updated**: 2026-08-31 (standalone iOS installs on a free Apple ID; docs site consumes the shared UI design tokens; UI bundle-chunking contract)  
 **Maintainer Guidance**: Keep this file in sync with project structure changes, new conventions, or significant architectural decisions.

--- a/BUILDING.md
+++ b/BUILDING.md
@@ -26,7 +26,13 @@ on macOS; run `pnpm run ios:doctor` to check.
 pnpm run ios:init     # once — generates ui-desktop/src-tauri/gen/apple
 pnpm run ios:dev      # run on an iPad simulator
 pnpm run ios:build    # release .ipa → ui-desktop/src-tauri/gen/apple/build/arm64/
+pnpm run ios:install  # build + install a standalone app on a connected iPad
 ```
+
+`ios:install` is the one that leaves something usable behind: it compiles the UI
+into the app instead of pointing it at a dev server, signs it with a free Apple
+ID, and installs it over the existing pairing. No paid Apple Developer Program —
+the trade is that a free signature lasts seven days, after which you re-run it.
 
 Details → [ui-desktop/README.md](ui-desktop/README.md).
 
@@ -49,5 +55,5 @@ pnpm run hydrate:web-slicer    # Full WASM slicer (includes polygon clipping)
 
 ```bash
 make build-release  build-windows  build-macos  build-wasm
-make ios-doctor  ios-init  ios-dev  ios-build      # macOS + Xcode only
+make ios-doctor  ios-init  ios-dev  ios-build  ios-install      # macOS + Xcode only
 ```

--- a/BUILDING.md
+++ b/BUILDING.md
@@ -31,8 +31,9 @@ pnpm run ios:install  # build + install a standalone app on a connected iPad
 
 `ios:install` is the one that leaves something usable behind: it compiles the UI
 into the app instead of pointing it at a dev server, signs it with a free Apple
-ID, and installs it over the existing pairing. No paid Apple Developer Program —
-the trade is that a free signature lasts seven days, after which you re-run it.
+ID, and installs it over the existing pairing. The app is universal, so it works
+on an iPhone as well as an iPad. No paid Apple Developer Program — the trade is
+that a free signature lasts seven days, after which you re-run it.
 
 Details → [ui-desktop/README.md](ui-desktop/README.md).
 

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -47,6 +47,12 @@ issue/PR numbers or repo links in the notes. See the tone rules in
 - **Reload prompt for stale tabs** — if a page can no longer be loaded because
   the app was redeployed under an open tab, the existing update banner now
   offers a reload instead of the click doing nothing.
+- **Keep the app on an iPad without a Mac attached** — `pnpm run ios:install`
+  builds the release app, signs it with a free Apple ID and installs it on a
+  connected iPad, so it keeps working after the dev server stops. No paid Apple
+  Developer Program: the trade is that a free signature lasts seven days, and
+  re-running with `--renew` resets the clock without touching your models,
+  profiles or settings.
 
 ### Changed
 

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -47,12 +47,12 @@ issue/PR numbers or repo links in the notes. See the tone rules in
 - **Reload prompt for stale tabs** — if a page can no longer be loaded because
   the app was redeployed under an open tab, the existing update banner now
   offers a reload instead of the click doing nothing.
-- **Keep the app on an iPad without a Mac attached** — `pnpm run ios:install`
-  builds the release app, signs it with a free Apple ID and installs it on a
-  connected iPad, so it keeps working after the dev server stops. No paid Apple
-  Developer Program: the trade is that a free signature lasts seven days, and
-  re-running with `--renew` resets the clock without touching your models,
-  profiles or settings.
+- **Keep the app on an iPhone or iPad without a Mac attached** —
+  `pnpm run ios:install` builds the release app, signs it with a free Apple ID
+  and installs it on a connected device, so it keeps working after the dev
+  server stops. No paid Apple Developer Program: the trade is that a free
+  signature lasts seven days, and re-running with `--renew` resets the clock
+  without touching your models, profiles or settings.
 
 ### Changed
 

--- a/Makefile
+++ b/Makefile
@@ -1,4 +1,4 @@
-.PHONY: build build-release build-windows build-macos build-wasm clean test fmt lint help dev changelog-draft ios-doctor ios-setup ios-init ios-simulator ios-dev ios-build
+.PHONY: build build-release build-windows build-macos build-wasm clean test fmt lint help dev changelog-draft ios-doctor ios-setup ios-init ios-simulator ios-dev ios-build ios-install
 
 help:
 	@echo "Slicer Engine - Build Targets"
@@ -25,6 +25,7 @@ help:
 	@echo "  ios-simulator      - Boot an iPad simulator"
 	@echo "  ios-dev            - Run the app on an iPad simulator with live reload"
 	@echo "  ios-build          - Build a release .ipa"
+	@echo "  ios-install        - Build and install a standalone app on a connected iPad"
 
 build:
 	cargo build --verbose
@@ -67,6 +68,9 @@ ios-dev:
 
 ios-build:
 	pnpm run ios:build
+
+ios-install:
+	@bash scripts/ios-install.sh
 
 test:
 	cargo test --verbose

--- a/Makefile
+++ b/Makefile
@@ -25,7 +25,7 @@ help:
 	@echo "  ios-simulator      - Boot an iPad simulator"
 	@echo "  ios-dev            - Run the app on an iPad simulator with live reload"
 	@echo "  ios-build          - Build a release .ipa"
-	@echo "  ios-install        - Build and install a standalone app on a connected iPad"
+	@echo "  ios-install        - Build and install a standalone app on a connected iPhone/iPad"
 
 build:
 	cargo build --verbose

--- a/SETUP.md
+++ b/SETUP.md
@@ -237,7 +237,7 @@ pnpm run ios:dev       # build + run on an iPad simulator, with live reload
 
 `pnpm run ios:doctor` reports without changing anything, and names the exact command to fix whatever is missing.
 
-To keep the app on a real iPad — no dev server, no paid Apple Developer Program — build the standalone app and install it over the pairing you already have:
+To keep the app on a real iPhone or iPad — no dev server, no paid Apple Developer Program — build the standalone app and install it over the pairing you already have:
 
 ```bash
 pnpm run ios:install

--- a/SETUP.md
+++ b/SETUP.md
@@ -237,6 +237,14 @@ pnpm run ios:dev       # build + run on an iPad simulator, with live reload
 
 `pnpm run ios:doctor` reports without changing anything, and names the exact command to fix whatever is missing.
 
+To keep the app on a real iPad — no dev server, no paid Apple Developer Program — build the standalone app and install it over the pairing you already have:
+
+```bash
+pnpm run ios:install
+```
+
+A free Apple ID signs for seven days; re-run it (`-- --renew`) to reset the clock. Your models, profiles and settings survive the reinstall.
+
 Full walkthrough, device selection, physical-device signing, and troubleshooting → **[ui-desktop/README.md](ui-desktop/README.md)**.
 
 ---

--- a/package.json
+++ b/package.json
@@ -24,6 +24,7 @@
     "ios:dev": "scripts/ios-dev.sh",
     "ios:open": "pnpm --filter slicer-ui-desktop exec tauri ios dev --open",
     "ios:build": "pnpm --filter slicer-ui-desktop exec tauri ios build",
+    "ios:install": "scripts/ios-install.sh",
     "build:wasm": "cargo build --lib --target wasm32-unknown-unknown --release && wasm-bindgen target/wasm32-unknown-unknown/release/slicer_engine.wasm --target web --out-dir ui/src/generated/scene-wasm --out-name scene_engine",
     "build:wasm:web-slicer": "cargo build --lib --target wasm32-unknown-unknown --release --features web-slicer && wasm-bindgen target/wasm32-unknown-unknown/release/slicer_engine.wasm --target web --out-dir ui/src/generated/scene-wasm --out-name scene_engine",
     "gen-schemas": "cargo run -- gen-schemas --output-dir ui/src/schemas",

--- a/scripts/ios-doctor.sh
+++ b/scripts/ios-doctor.sh
@@ -1,7 +1,7 @@
 #!/usr/bin/env bash
 #
 # ios-doctor.sh — verify (and optionally repair) the toolchain needed to build
-# and run Cold Crabby on the iOS/iPadOS Simulator.
+# and run Cold Crabby on the iOS/iPadOS Simulator or a physical iPad.
 #
 # Building a Tauri app for iOS needs more than "Rust + Xcode": the iOS SDK only
 # ships with the full Xcode app (not Command Line Tools), Rust needs the two
@@ -238,12 +238,33 @@ else
   hint "pnpm run ios:init"
 fi
 
-if [[ -n "${TAURI_APPLE_DEVELOPMENT_TEAM:-}" ]]; then
-  ok "TAURI_APPLE_DEVELOPMENT_TEAM=$TAURI_APPLE_DEVELOPMENT_TEAM"
+# ── Signing (physical devices only) ──────────────────────────────────────────
+head_ "Signing"
+
+# shellcheck source=lib/apple-team.sh
+. "$(cd "$(dirname "${BASH_SOURCE[0]}")" && pwd)/lib/apple-team.sh"
+
+teams=()
+while IFS= read -r line; do
+  if [[ -n "$line" ]]; then
+    teams+=("$line")
+  fi
+done < <(detect_apple_teams)
+
+override="${APPLE_DEVELOPMENT_TEAM:-${TAURI_APPLE_DEVELOPMENT_TEAM:-}}"
+
+if [[ -n "$override" ]]; then
+  ok "team $override (from the environment)"
+elif [[ ${#teams[@]} -eq 1 ]]; then
+  ok "team ${teams[0]} (from the keychain)"
+elif [[ ${#teams[@]} -gt 1 ]]; then
+  warn "several signing teams in the keychain: ${teams[*]}"
+  hint "Pick one: APPLE_DEVELOPMENT_TEAM=<id> pnpm run ios:install"
 else
-  warn "TAURI_APPLE_DEVELOPMENT_TEAM is unset"
-  hint "Only needed for physical devices and App Store builds; the Simulator does not sign."
-  hint "Find it at https://developer.apple.com/account → Membership details → Team ID."
+  warn "no Apple signing certificate in the keychain"
+  hint "The Simulator does not sign, so this only blocks builds for a real device."
+  hint "A free Apple ID is enough: Xcode → Settings → Accounts → add your Apple ID,"
+  hint "then Manage Certificates… → + → Apple Development."
 fi
 
 # ── Summary ──────────────────────────────────────────────────────────────────
@@ -258,4 +279,5 @@ fi
 printf '%sReady to build for iOS%s' "$GREEN" "$RESET"
 [[ $warnings -gt 0 ]] && printf ' (%d warning(s))' "$warnings"
 printf '. Minimum deployment target: iOS %s.\n' "$MIN_IOS"
-printf 'Next: %spnpm run ios:init%s, then %spnpm run ios:dev%s\n' "$BOLD" "$RESET" "$BOLD" "$RESET"
+printf 'Next: %spnpm run ios:init%s, then %spnpm run ios:dev%s (simulator) or %spnpm run ios:install%s (real iPad)\n' \
+  "$BOLD" "$RESET" "$BOLD" "$RESET" "$BOLD" "$RESET"

--- a/scripts/ios-install.sh
+++ b/scripts/ios-install.sh
@@ -1,13 +1,16 @@
 #!/usr/bin/env bash
 #
-# ios-install.sh — put a standalone build on a physical iPad or iPhone.
+# ios-install.sh — put a standalone build on a physical iPhone or iPad.
 #
 # `pnpm run ios:dev` leaves the app pointed at the Angular dev server running on
 # this Mac, so it goes blank the moment that process stops. This builds the
 # *release* app instead: the whole UI is compiled into the binary and the
 # slicing engine already runs on-device, so nothing is fetched at runtime. It
 # then signs the result with a free Apple ID and installs it over the pairing
-# you already have. Afterwards the iPad prints with no Mac anywhere in sight.
+# you already have. Afterwards the device prints with no Mac anywhere in sight.
+#
+# The app is universal (iPhone and iPad), so this script does not care which one
+# is plugged in. With more than one paired it refuses to guess — pass --device.
 #
 # No paid Apple Developer Program membership is involved. The trade is time: a
 # free Apple ID signs for seven days, after which iOS refuses to launch the app
@@ -16,7 +19,7 @@
 # Usage:
 #   scripts/ios-install.sh                        # build, sign, install
 #   scripts/ios-install.sh --list                 # show connected devices, then exit
-#   scripts/ios-install.sh --device 'Max iPad'    # pick a device by name
+#   scripts/ios-install.sh --device 'Max iPhone'  # pick a device by name
 #   scripts/ios-install.sh --reinstall            # install the last build, skip building
 #   scripts/ios-install.sh --renew                # discard the cached profile first
 #   scripts/ios-install.sh --launch               # start the app once it is installed
@@ -176,8 +179,8 @@ fi
 
 if [[ -z "$devices" ]]; then
   die "no iOS device is connected." \
-      "Plug the iPad in (or keep it on the same Wi-Fi once paired), unlock it," \
-      "and tap Trust if it asks. Then: scripts/ios-install.sh --list"
+      "Plug the iPhone or iPad in (or keep it on the same Wi-Fi once paired)," \
+      "unlock it, and tap Trust if it asks. Then: scripts/ios-install.sh --list"
 fi
 
 if [[ -n "$requested_device" ]]; then
@@ -185,6 +188,17 @@ if [[ -n "$requested_device" ]]; then
   [[ -n "$match" ]] || die "no connected iOS device named '$requested_device'." \
       "Available: $(cut -f2 <<<"$devices" | paste -sd', ' -)"
 else
+  # Never guess between devices. Picking the first one alphabetically would send
+  # a multi-minute build to the wrong phone/tablet and only say so in passing.
+  paired_count="$(awk -F'\t' '$5 == "paired"' <<<"$devices" | wc -l | tr -d ' ')"
+  if [[ "$paired_count" -gt 1 ]]; then
+    printf 'error: %s connected devices are paired — name the one you want.\n' "$paired_count" >&2
+    while IFS=$'\t' read -r _ name model _ pairing _; do
+      [[ "$pairing" == "paired" ]] || continue
+      printf "         scripts/ios-install.sh --device '%s'   # %s\n" "$name" "$model" >&2
+    done <<<"$devices"
+    exit 1
+  fi
   match="$(head -1 <<<"$devices")"
 fi
 

--- a/scripts/ios-install.sh
+++ b/scripts/ios-install.sh
@@ -1,0 +1,375 @@
+#!/usr/bin/env bash
+#
+# ios-install.sh — put a standalone build on a physical iPad or iPhone.
+#
+# `pnpm run ios:dev` leaves the app pointed at the Angular dev server running on
+# this Mac, so it goes blank the moment that process stops. This builds the
+# *release* app instead: the whole UI is compiled into the binary and the
+# slicing engine already runs on-device, so nothing is fetched at runtime. It
+# then signs the result with a free Apple ID and installs it over the pairing
+# you already have. Afterwards the iPad prints with no Mac anywhere in sight.
+#
+# No paid Apple Developer Program membership is involved. The trade is time: a
+# free Apple ID signs for seven days, after which iOS refuses to launch the app
+# until you run this again. `--renew` forces a fresh seven-day profile.
+#
+# Usage:
+#   scripts/ios-install.sh                        # build, sign, install
+#   scripts/ios-install.sh --list                 # show connected devices, then exit
+#   scripts/ios-install.sh --device 'Max iPad'    # pick a device by name
+#   scripts/ios-install.sh --reinstall            # install the last build, skip building
+#   scripts/ios-install.sh --renew                # discard the cached profile first
+#   scripts/ios-install.sh --launch               # start the app once it is installed
+#
+# Overrides: IOS_DEVICE (device name), APPLE_DEVELOPMENT_TEAM (signing team ID).
+set -euo pipefail
+
+cd "$(git rev-parse --show-toplevel 2>/dev/null || echo .)"
+
+readonly GEN_APPLE="ui-desktop/src-tauri/gen/apple"
+readonly BUILD_DIR="$GEN_APPLE/build/arm64"
+readonly TAURI_CONF="ui-desktop/src-tauri/tauri.conf.json"
+
+if [[ -t 1 ]]; then
+  BOLD=$'\033[1m'; DIM=$'\033[2m'; GREEN=$'\033[32m'; YELLOW=$'\033[33m'; RESET=$'\033[0m'
+else
+  BOLD=''; DIM=''; GREEN=''; YELLOW=''; RESET=''
+fi
+
+step() { printf '\n%s==>%s %s%s%s\n' "$GREEN" "$RESET" "$BOLD" "$1" "$RESET"; }
+note() { printf '    %s%s%s\n' "$DIM" "$1" "$RESET"; }
+die()  { printf 'error: %s\n' "$1" >&2; shift; for line in "$@"; do printf '       %s\n' "$line" >&2; done; exit 1; }
+
+usage() {
+  # Print the leading comment block (everything between the shebang and the
+  # first line of code) as the usage text.
+  awk 'NR > 1 && /^#/ { sub(/^# ?/, ""); print; next } NR > 1 { exit }' "$0"
+}
+
+staging="$(mktemp -d -t ios-install)"
+
+# Set once the build path is taken; see the DEVELOPMENT_TEAM note below.
+pbxproj=""
+
+cleanup() {
+  if [[ -n "$pbxproj" && -f "$staging/project.pbxproj.orig" ]]; then
+    cp "$staging/project.pbxproj.orig" "$pbxproj"
+  fi
+  rm -rf "$staging"
+}
+trap cleanup EXIT
+
+do_build=1
+do_renew=0
+do_launch=0
+list_only=0
+requested_device="${IOS_DEVICE:-}"
+team="${APPLE_DEVELOPMENT_TEAM:-${TAURI_APPLE_DEVELOPMENT_TEAM:-}}"
+
+while [[ $# -gt 0 ]]; do
+  case "$1" in
+    -h|--help)   usage; exit 0 ;;
+    # `pnpm run ios:install -- --renew` forwards the separator verbatim, so
+    # accept it as the no-op it is rather than rejecting the documented form.
+    --)          shift ;;
+    --list)      list_only=1; shift ;;
+    --reinstall) do_build=0; shift ;;
+    --renew)     do_renew=1; shift ;;
+    --launch)    do_launch=1; shift ;;
+    --device)    requested_device="${2:?--device needs a name}"; shift 2 ;;
+    --team)      team="${2:?--team needs a team ID}"; shift 2 ;;
+    *)           die "unknown argument '$1'" "Run with --help for usage." ;;
+  esac
+done
+
+# ── Toolchain ────────────────────────────────────────────────────────────────
+#
+# Same hard requirement as ios-dev.sh: the Tauri CLI shells out to `xcodebuild`
+# with a sanitized environment, so `DEVELOPER_DIR` cannot rescue a checkout that
+# still points at the Command Line Tools — and those ship no iOS SDK.
+if [[ "$(xcode-select -p 2>/dev/null)" == *CommandLineTools* ]]; then
+  if [[ -d /Applications/Xcode.app/Contents/Developer ]]; then
+    die "Xcode is installed but the Command Line Tools are still selected." \
+        "'tauri ios build' ignores DEVELOPER_DIR, so this must be fixed globally:" \
+        "" \
+        "  sudo xcode-select -s /Applications/Xcode.app"
+  fi
+  die "the full Xcode app is required (Command Line Tools have no iOS SDK)." \
+      "Run scripts/ios-doctor.sh for the full diagnosis."
+fi
+
+[[ -d "$GEN_APPLE" ]] || die "the iOS Xcode project has not been generated yet." "Run: pnpm run ios:init"
+
+xcodeproj="$(find "$GEN_APPLE" -maxdepth 1 -name '*.xcodeproj' -print -quit 2>/dev/null || true)"
+[[ -n "$xcodeproj" ]] || die "no .xcodeproj found under $GEN_APPLE." "Run: pnpm run ios:init"
+
+# The Angular build imports the WASM scene bindings and the generated types, and
+# fails with an unrelated-looking module-resolution error when they are absent.
+if [[ $do_build -eq 1 && ! -f ui/src/generated/scene-wasm/scene_engine.js ]]; then
+  die "the generated WASM bindings are missing, so the UI cannot build." "Run: pnpm run hydrate"
+fi
+
+# ── Device ───────────────────────────────────────────────────────────────────
+#
+# `devicectl` replaced the old device tooling in Xcode 15; without it there is
+# no supported way to install onto a device from a script.
+xcrun devicectl --version >/dev/null 2>&1 || \
+  die "'xcrun devicectl' is unavailable — Xcode 15 or newer is required to install onto a device." \
+      "Run scripts/ios-doctor.sh for the full diagnosis."
+
+# Prints "<identifier>\t<name>\t<model>\t<os>\t<pairing>\t<developer mode>" per
+# connected iOS device, paired ones first — those are the ones we can install to.
+list_ios_devices() {
+  local json
+  json="$(mktemp -t ios-devices)"
+  xcrun devicectl list devices --json-output "$json" >/dev/null 2>&1 || true
+  python3 - "$json" <<'PY'
+import json, sys
+
+try:
+    with open(sys.argv[1]) as handle:
+        data = json.load(handle)
+except (OSError, ValueError):
+    sys.exit(0)
+
+rows = []
+for device in data.get("result", {}).get("devices", []):
+    hardware = device.get("hardwareProperties", {})
+    props = device.get("deviceProperties", {})
+    connection = device.get("connectionProperties", {})
+    if hardware.get("platform") != "iOS":
+        continue
+    pairing = connection.get("pairingState", "unknown")
+    rows.append((
+        0 if pairing == "paired" else 1,
+        props.get("name", "?"),
+        [
+            device.get("identifier", ""),
+            props.get("name", "?"),
+            hardware.get("marketingName") or hardware.get("deviceType", "?"),
+            props.get("osVersionNumber", "?"),
+            pairing,
+            props.get("developerModeStatus", "unknown"),
+        ],
+    ))
+
+rows.sort(key=lambda row: (row[0], row[1]))
+for _, _, fields in rows:
+    print("\t".join(fields))
+PY
+  rm -f "$json"
+}
+
+devices="$(list_ios_devices)"
+
+if [[ $list_only -eq 1 ]]; then
+  if [[ -z "$devices" ]]; then
+    echo "No iOS devices are connected."
+  else
+    printf '%-28s %-24s %-8s %-10s %s\n' "DEVICE" "MODEL" "OS" "PAIRING" "DEVELOPER MODE"
+    while IFS=$'\t' read -r _ name model os pairing devmode; do
+      printf '%-28s %-24s %-8s %-10s %s\n' "$name" "$model" "$os" "$pairing" "$devmode"
+    done <<<"$devices"
+  fi
+  exit 0
+fi
+
+if [[ -z "$devices" ]]; then
+  die "no iOS device is connected." \
+      "Plug the iPad in (or keep it on the same Wi-Fi once paired), unlock it," \
+      "and tap Trust if it asks. Then: scripts/ios-install.sh --list"
+fi
+
+if [[ -n "$requested_device" ]]; then
+  match="$(awk -F'\t' -v want="$requested_device" '$2 == want {print; exit}' <<<"$devices")"
+  [[ -n "$match" ]] || die "no connected iOS device named '$requested_device'." \
+      "Available: $(cut -f2 <<<"$devices" | paste -sd', ' -)"
+else
+  match="$(head -1 <<<"$devices")"
+fi
+
+IFS=$'\t' read -r device_id device_name device_model device_os device_pairing device_devmode <<<"$match"
+
+[[ "$device_pairing" == "paired" ]] || die "'$device_name' is not paired with this Mac ($device_pairing)." \
+    "Connect it by cable, unlock it, and tap Trust This Computer."
+
+# iOS 16+ will not run a locally-signed app until Developer Mode is on, and the
+# toggle only appears after a signed build has been offered to the device once.
+if [[ "$device_devmode" != "enabled" ]]; then
+  die "Developer Mode is $device_devmode on '$device_name'." \
+      "On the device: Settings → Privacy & Security → Developer Mode → on, then reboot." \
+      "If that row is missing, connect the device to Xcode once to make it appear."
+fi
+
+# ── Signing team ─────────────────────────────────────────────────────────────
+#
+# The team ID is the Organizational Unit of the signing certificate, *not* the
+# identifier printed in its common name. A free Apple ID gets a "personal team"
+# that has no Membership page to read it off, so take it from the keychain.
+# shellcheck source=lib/apple-team.sh
+. "$(cd "$(dirname "${BASH_SOURCE[0]}")" && pwd)/lib/apple-team.sh"
+
+if [[ -z "$team" ]]; then
+  # `mapfile` would be tidier, but macOS still ships bash 3.2 and these scripts
+  # have to run on a stock machine.
+  detected=()
+  while IFS= read -r line; do
+    if [[ -n "$line" ]]; then
+      detected+=("$line")
+    fi
+  done < <(detect_apple_teams)
+  case ${#detected[@]} in
+    0) die "no Apple signing certificate found in the keychain." \
+           "Open Xcode → Settings → Accounts, add your Apple ID (free is fine)," \
+           "then pick the team and press 'Manage Certificates…' → + → Apple Development." ;;
+    1) team="${detected[0]}" ;;
+    *) die "several signing teams found: ${detected[*]}" \
+           "Choose one: APPLE_DEVELOPMENT_TEAM=<id> scripts/ios-install.sh" ;;
+  esac
+fi
+
+bundle_id="$(python3 -c 'import json,sys; print(json.load(open(sys.argv[1]))["identifier"])' "$TAURI_CONF")"
+
+step "$bundle_id → $device_name"
+note "$device_model · iOS $device_os · team $team"
+
+# ── Renew ────────────────────────────────────────────────────────────────────
+#
+# Automatic signing reuses a cached profile while it is still valid, so a
+# rebuild on day six inherits one day rather than starting a fresh week.
+# Deleting the app's profiles makes Xcode mint a new seven-day one.
+if [[ $do_renew -eq 1 ]]; then
+  step "Discarding cached provisioning profiles for $bundle_id"
+  removed=0
+  for dir in "$HOME/Library/Developer/Xcode/UserData/Provisioning Profiles" \
+             "$HOME/Library/MobileDevice/Provisioning Profiles"; do
+    [[ -d "$dir" ]] || continue
+    while IFS= read -r -d '' profile; do
+      app_id="$(security cms -D -i "$profile" 2>/dev/null | plutil -extract Entitlements.application-identifier raw -o - - 2>/dev/null || true)"
+      if [[ "$app_id" == *".$bundle_id" ]]; then
+        rm -f "$profile"
+        removed=$((removed + 1))
+      fi
+    done < <(find "$dir" -maxdepth 1 -name '*.mobileprovision' -print0 2>/dev/null)
+  done
+  note "$removed profile(s) removed"
+fi
+
+# ── Build ────────────────────────────────────────────────────────────────────
+#
+# `--export-method debugging` is Xcode's development export: the only one a free
+# Apple ID can produce, and all a directly-installed app needs. The release
+# build runs `beforeBuildCommand`, so the production UI is compiled into the
+# binary and the app never looks for a dev server.
+if [[ $do_build -eq 1 ]]; then
+  [[ -f "$xcodeproj/project.xcworkspace/contents.xcworkspacedata" ]] || \
+    die "$xcodeproj/project.xcworkspace is missing." \
+        "'tauri ios build' passes it to xcodebuild -workspace. Regenerate it with:" \
+        "  pnpm run ios:init"
+
+  # The Tauri CLI writes DEVELOPMENT_TEAM into project.pbxproj on every build,
+  # and that file is committed. Left alone it would put one contributor's team
+  # ID in everybody else's checkout, so it is restored on exit — including when
+  # a long build is interrupted. The team is supplied per-build through the
+  # environment and does not belong in the repository.
+  pbxproj="$xcodeproj/project.pbxproj"
+
+  # An interrupt before this existed can have left the line behind, and
+  # snapshotting *that* would preserve it forever. Drop it first, but only when
+  # git confirms nothing else in the file differs from HEAD.
+  if git rev-parse --git-dir >/dev/null 2>&1 && ! git diff --quiet -- "$pbxproj" 2>/dev/null; then
+    if [[ -z "$(git diff -U0 -- "$pbxproj" | sed -n '/^[+-][^+-]/p' | grep -v DEVELOPMENT_TEAM)" ]]; then
+      git checkout -- "$pbxproj"
+      note "cleared a DEVELOPMENT_TEAM line left over from an interrupted run"
+    else
+      note "$pbxproj has local edits; they will be preserved"
+    fi
+  fi
+
+  cp "$pbxproj" "$staging/project.pbxproj.orig"
+
+  step "Building the release app (this takes a while on a cold cache)"
+  build_status=0
+  APPLE_DEVELOPMENT_TEAM="$team" \
+    pnpm --filter slicer-ui-desktop exec tauri ios build \
+      --target aarch64 --export-method debugging || build_status=$?
+
+  if [[ $build_status -ne 0 ]]; then
+    printf '\n' >&2
+    die "the iOS build failed." \
+        "Common causes, in the order they bite:" \
+        "  • Xcode has no Apple ID — add one under Xcode → Settings → Accounts." \
+        "  • '$bundle_id' is registered to somebody else's team. Bundle IDs are" \
+        "    globally unique, so change \"identifier\" in $TAURI_CONF" \
+        "    to something of your own and re-run: pnpm run ios:init" \
+        "  • The free tier allows 10 app IDs per 7 days and 3 apps per device."
+  fi
+fi
+
+ipa="$(ls -t "$BUILD_DIR"/*.ipa 2>/dev/null | head -1 || true)"
+[[ -n "$ipa" ]] || die "no .ipa found in $BUILD_DIR." \
+    "Run without --reinstall to build one."
+
+# ── Install ──────────────────────────────────────────────────────────────────
+unzip -q "$ipa" -d "$staging"
+app="$(find "$staging/Payload" -maxdepth 1 -name '*.app' -print -quit 2>/dev/null || true)"
+[[ -n "$app" ]] || die "'$ipa' contains no .app bundle."
+
+step "Installing $(basename "$app") on $device_name"
+xcrun devicectl device install app --device "$device_id" "$app"
+
+if [[ $do_launch -eq 1 ]]; then
+  step "Launching"
+  # A never-trusted developer certificate makes this fail with a bare "app is
+  # damaged"-style error, which is expected on a first install — say so instead
+  # of failing the whole run.
+  xcrun devicectl device process launch --device "$device_id" "$bundle_id" || {
+    note "Could not launch — trust the developer certificate first (see below)."
+  }
+fi
+
+# ── Expiry ───────────────────────────────────────────────────────────────────
+#
+# The seven-day clock is the whole reason this script exists, so report the
+# actual date rather than leaving the user to find out when the app stops.
+expires=""
+profile="$app/embedded.mobileprovision"
+if [[ -f "$profile" ]]; then
+  raw="$(security cms -D -i "$profile" 2>/dev/null | plutil -extract ExpirationDate raw -o - - 2>/dev/null || true)"
+  # "2026-09-07T13:24:19Z" — drop the zone marker and any fractional seconds so
+  # BSD `date` can parse it.
+  stamp="${raw%Z}"
+  stamp="${stamp%%.*}"
+  if [[ -n "$stamp" ]] && epoch="$(date -j -u -f '%Y-%m-%dT%H:%M:%S' "$stamp" '+%s' 2>/dev/null)"; then
+    remaining=$(( epoch - $(date +%s) ))
+    if [[ $remaining -le 0 ]]; then
+      expires="$(date -r "$epoch" '+%a %-d %b %Y, %H:%M') — already expired"
+    else
+      # Round *up*: a profile minted moments ago has 6 days 23 hours left, and
+      # truncating that to "6" makes a fresh signature look like a stale one.
+      days=$(( (remaining + 86399) / 86400 ))
+      expires="$(date -r "$epoch" '+%a %-d %b %Y, %H:%M') ($days day(s) left)"
+    fi
+  fi
+fi
+
+printf '\n%sInstalled.%s ' "$GREEN$BOLD" "$RESET"
+if [[ -n "$expires" ]]; then
+  printf 'Signed until %s%s%s\n' "$BOLD" "$expires" "$RESET"
+else
+  printf 'A free Apple ID signs for 7 days.\n'
+fi
+
+cat <<EOF
+
+${BOLD}On the iPad, once:${RESET}
+  Settings → General → VPN & Device Management → Developer App → Trust
+
+${BOLD}When it expires:${RESET}
+  scripts/ios-install.sh --renew        ${DIM}# rebuild, re-sign, reinstall${RESET}
+  ${DIM}Your models, profiles and settings stay put — the app is replaced, not removed.${RESET}
+EOF
+
+if [[ "$(cut -f1 -d$'\t' <<<"$devices" | wc -l | tr -d ' ')" -gt 1 ]]; then
+  printf '\n%sOther connected devices:%s scripts/ios-install.sh --list\n' "$YELLOW" "$RESET"
+fi

--- a/scripts/lib/apple-team.sh
+++ b/scripts/lib/apple-team.sh
@@ -1,0 +1,45 @@
+#!/usr/bin/env bash
+#
+# apple-team.sh — resolve the Apple *team ID* used to sign iOS builds.
+#
+# Sourced by ios-doctor.sh and ios-install.sh; not runnable on its own.
+#
+# The team ID is the Organizational Unit of the signing certificate — *not* the
+# identifier printed in parentheses in its common name, which is a per-Apple-ID
+# value and will not sign anything. A free Apple ID is issued a "personal team"
+# that has no Membership page to look the ID up on, so the only reliable source
+# is the certificate sitting in the keychain.
+#
+# Everything here has to run on a stock macOS bash 3.2: no `mapfile`, no
+# associative arrays.
+
+# Prints one team ID per line, deduplicated. Silent (and returns 0) when the
+# machine has no usable signing certificate.
+detect_apple_teams() {
+  local valid pem line fingerprint
+
+  # Only certificates the keychain still considers usable. Without this filter
+  # an expired certificate from a previous team turns a perfectly good machine
+  # into "several teams found" and forces the user to disambiguate by hand.
+  valid="$(security find-identity -v -p codesigning 2>/dev/null | awk '$2 ~ /^[0-9A-F]{40}$/ { print $2 }')"
+  [[ -n "$valid" ]] || return 0
+
+  {
+    security find-certificate -a -c "Apple Development" -p 2>/dev/null
+    security find-certificate -a -c "iPhone Developer" -p 2>/dev/null
+  } | {
+    # Split the concatenated PEM stream by hand: `openssl x509` reads only the
+    # first certificate, and splitting on a NUL separator does not survive the
+    # awk that macOS ships.
+    pem=""
+    while IFS= read -r line; do
+      pem="$pem$line"$'\n'
+      [[ "$line" == "-----END CERTIFICATE-----" ]] || continue
+      fingerprint="$(printf '%s' "$pem" | openssl x509 -noout -fingerprint -sha1 2>/dev/null | tr -d ':' | sed 's/.*=//')"
+      if [[ -n "$fingerprint" ]] && grep -qF "$fingerprint" <<<"$valid"; then
+        printf '%s' "$pem" | openssl x509 -noout -subject 2>/dev/null
+      fi
+      pem=""
+    done
+  } | sed -n 's/.*OU *= *\([A-Za-z0-9]*\).*/\1/p' | sort -u
+}

--- a/ui-desktop/README.md
+++ b/ui-desktop/README.md
@@ -360,7 +360,22 @@ features for web developers**, then use **Develop → Simulator → localhost**.
 
 ---
 
-## Physical iPads
+## Physical iPhones and iPads
+
+The app is **universal** (`TARGETED_DEVICE_FAMILY = "1,2"`), so everything below
+applies to an iPhone exactly as it does to an iPad — same script, same signing,
+same seven-day clock. The UI adapts on its own: an iPhone falls under the
+handheld breakpoint and gets the bottom tab bar, settings drawer and slice
+sheet described in [ui/README.md](../ui/README.md#phones), and iOS draws the
+context menu as a bottom sheet rather than the popover it uses on iPad.
+
+The only wrinkle is having both plugged in at once. The script will not guess
+between them — a wrong choice costs a multi-minute build — so it lists them and
+asks:
+
+```bash
+pnpm run ios:install --device 'Max iPhone'
+```
 
 There are two ways onto a real device and they answer different questions.
 
@@ -385,13 +400,13 @@ Both need signing — the simulator needs none, a real device needs all of it:
   Decline it and every printer looks permanently offline; re-enable under
   **Settings → Cold Crabby → Local Network**.
 
-### Keeping it on the iPad, with no Mac and no Apple Developer Program
+### Keeping it on the device, with no Mac and no Apple Developer Program
 
 `tauri ios dev` installs an app whose `devUrl` points at the Angular dev server
 on your Mac, so it is a white screen the moment that process stops. Turning the
-iPad into something you can actually print from means shipping the *release*
-app, where the whole UI is compiled into the binary and the slicing engine —
-which already runs on-device — has nothing left to phone home to.
+iPhone or iPad into something you can actually print from means shipping the
+*release* app, where the whole UI is compiled into the binary and the slicing
+engine — which already runs on-device — has nothing left to phone home to.
 
 ```bash
 pnpm run ios:install
@@ -399,7 +414,7 @@ pnpm run ios:install
 
 That is the whole story: build, sign with your free Apple ID, install over the
 pairing you already have. There is no paid Apple Developer Program membership
-anywhere in it, and afterwards the iPad slices with the Mac switched off.
+anywhere in it, and afterwards the device slices with the Mac switched off.
 
 ```mermaid
 flowchart LR
@@ -447,7 +462,7 @@ Useful flags:
 
 ```bash
 pnpm run ios:install -- --list                 # what is connected
-pnpm run ios:install -- --device 'Max iPad'    # pick one by name
+pnpm run ios:install -- --device 'Max iPhone'  # required when two are paired
 pnpm run ios:install -- --reinstall            # install the last build, skip building
 pnpm run ios:install -- --launch               # start the app afterwards
 ```

--- a/ui-desktop/README.md
+++ b/ui-desktop/README.md
@@ -358,29 +358,126 @@ opens the project instead of running it.
 Safari owns the inspector for iOS. Enable **Safari → Settings → Advanced → Show
 features for web developers**, then use **Develop → Simulator → localhost**.
 
-### Release build
+---
+
+## Physical iPads
+
+There are two ways onto a real device and they answer different questions.
+
+| | `tauri ios dev --host` | `pnpm run ios:install` |
+| --- | --- | --- |
+| Where the UI comes from | streamed from this Mac | compiled into the app |
+| Survives closing the terminal | no — the app goes blank | yes |
+| Rebuild to see a UI change | no, it live-reloads | yes, a few minutes |
+| For | editing the front-end | *using* the slicer |
+
+Both need signing — the simulator needs none, a real device needs all of it:
+
+- **Team ID.** Detected from the signing certificate in your keychain, or set
+  `APPLE_DEVELOPMENT_TEAM` explicitly. It is the certificate's **OU**, not the
+  identifier printed in its common name, and a free Apple ID has no Membership
+  page to read it off — which is why `ios-install.sh` digs it out for you.
+- **The dev server must be reachable over the network** *for the dev loop only*.
+  `tauri ios dev --host` publishes the address as `TAURI_DEV_HOST` and rewrites
+  the dev URL to match. The Angular dev server already binds `0.0.0.0`, so it
+  will answer.
+- **Local network permission.** iOS prompts once, on the first printer probe.
+  Decline it and every printer looks permanently offline; re-enable under
+  **Settings → Cold Crabby → Local Network**.
+
+### Keeping it on the iPad, with no Mac and no Apple Developer Program
+
+`tauri ios dev` installs an app whose `devUrl` points at the Angular dev server
+on your Mac, so it is a white screen the moment that process stops. Turning the
+iPad into something you can actually print from means shipping the *release*
+app, where the whole UI is compiled into the binary and the slicing engine —
+which already runs on-device — has nothing left to phone home to.
+
+```bash
+pnpm run ios:install
+```
+
+That is the whole story: build, sign with your free Apple ID, install over the
+pairing you already have. There is no paid Apple Developer Program membership
+anywhere in it, and afterwards the iPad slices with the Mac switched off.
+
+```mermaid
+flowchart LR
+    A["ng build<br/><i>beforeBuildCommand</i>"] --> B["cargo --release<br/>aarch64-apple-ios"]
+    B --> C["xcodebuild archive<br/><i>-allowProvisioningUpdates</i>"]
+    C --> D["export<br/><i>method: debugging</i>"]
+    D --> E["devicectl install"]
+
+    style A fill:#e3f2fd
+    style E fill:#fff9c4
+```
+
+**The price of not paying is seven days.** A free Apple ID gets a *personal
+team*, and personal teams sign for a week; on day eight iOS refuses to launch
+the app until it is re-signed. Re-running the script fixes that, and your
+models, profiles and settings survive because the app is *replaced*, not
+removed:
+
+```bash
+pnpm run ios:install -- --renew
+```
+
+`--renew` matters because automatic signing happily reuses a profile that is
+still technically valid, so a plain rebuild on day six inherits one day rather
+than starting a fresh week. It deletes the cached profiles for this bundle ID
+first, which forces Xcode to mint a new one. The script prints the expiry date
+either way, so you never have to guess.
+
+The other limits of a free account, in the order they bite:
+
+| Limit | What it means here |
+| --- | --- |
+| App IDs are globally unique | If somebody else registered `com.maxscopp.slicerengine`, pick your own `identifier` in `tauri.conf.json` and re-run `ios:init`. |
+| 10 App IDs per 7 days | Only a problem if you keep renaming the bundle. |
+| 3 side-loaded apps per device | Uninstall an old build before the fourth. |
+| No push, App Groups or iCloud | None of which the slicer uses. |
+
+**One tap on the device, once per certificate:** Settings → General → VPN &
+Device Management → Developer App → Trust. Until then iOS installs the app but
+will not launch it. Developer Mode (Settings → Privacy & Security) must also be
+on; the script refuses to continue if it is not, because the install otherwise
+fails with a far less obvious error.
+
+Useful flags:
+
+```bash
+pnpm run ios:install -- --list                 # what is connected
+pnpm run ios:install -- --device 'Max iPad'    # pick one by name
+pnpm run ios:install -- --reinstall            # install the last build, skip building
+pnpm run ios:install -- --launch               # start the app afterwards
+```
+
+#### Two things it cleans up after Tauri
+
+Both exist because `gen/apple` is a *committed* Xcode project, which is unusual
+and makes anything the build writes into it everybody's problem:
+
+- **`tauri ios build` writes `DEVELOPMENT_TEAM` into `project.pbxproj`.** That
+  would put one contributor's team ID into everyone else's checkout, so the
+  script snapshots the file and restores it on exit — including when you
+  interrupt a long build — and clears the line if an earlier run was killed
+  before it could. The team is supplied per-build through the environment and
+  does not belong in the repository.
+- **`project.xcworkspace/contents.xcworkspacedata` must stay tracked.**
+  `tauri ios build` passes it to `xcodebuild -workspace`; a checkout without it
+  fails with a bare `project.xcworkspace does not exist` long before anything
+  interesting happens. Only the `xcuserdata`/`xcshareddata` beneath it are
+  ignored.
+
+### Release build (no install)
 
 ```bash
 pnpm run ios:build
 ```
 
-The `.ipa` lands in `ui-desktop/src-tauri/gen/apple/build/arm64/`.
-
----
-
-## Physical iPads
-
-The simulator needs no signing; a real device needs all of it.
-
-- **Team ID.** Set `TAURI_APPLE_DEVELOPMENT_TEAM` to the value from
-  [developer.apple.com](https://developer.apple.com/account) → Membership
-  details. Without it Xcode cannot sign the app.
-- **The dev server must be reachable over the network.** `tauri ios dev --host`
-  publishes the address as `TAURI_DEV_HOST` and rewrites the dev URL to match.
-  The Angular dev server already binds `0.0.0.0`, so it will answer.
-- **Local network permission.** iOS prompts once, on the first printer probe.
-  Decline it and every printer looks permanently offline; re-enable under
-  **Settings → Cold Crabby → Local Network**.
+The `.ipa` lands in `ui-desktop/src-tauri/gen/apple/build/arm64/`. This is what
+`ios:install` runs underneath; use it directly when you want the artifact
+rather than a device.
 
 ---
 
@@ -416,7 +513,7 @@ entries there exist for concrete reasons:
 ## See also
 
 - [`src/lib.rs`](src-tauri/src/lib.rs) — the entry point
-- [`scripts/ios-doctor.sh`](../scripts/ios-doctor.sh) · [`ios-simulator.sh`](../scripts/ios-simulator.sh) · [`ios-dev.sh`](../scripts/ios-dev.sh)
+- [`scripts/ios-doctor.sh`](../scripts/ios-doctor.sh) · [`ios-simulator.sh`](../scripts/ios-simulator.sh) · [`ios-dev.sh`](../scripts/ios-dev.sh) · [`ios-install.sh`](../scripts/ios-install.sh)
 - [SETUP.md](../SETUP.md) — prerequisites for every surface
 - [AGENTS.md](../AGENTS.md) — "Native shell targets" contract
 - [Tauri: iOS distribution](https://v2.tauri.app/distribute/app-store/)

--- a/ui-desktop/src-tauri/gen/apple/slicer-ui-desktop.xcodeproj/project.xcworkspace/contents.xcworkspacedata
+++ b/ui-desktop/src-tauri/gen/apple/slicer-ui-desktop.xcodeproj/project.xcworkspace/contents.xcworkspacedata
@@ -1,0 +1,7 @@
+<?xml version="1.0" encoding="UTF-8"?>
+<Workspace
+   version = "1.0">
+   <FileRef
+      location = "self:">
+   </FileRef>
+</Workspace>


### PR DESCRIPTION
`pnpm run ios:dev` installs an app pinned to the Angular dev server's `devUrl`, so the iPad goes blank the moment that process stops. This adds a way to leave a **working** app on a device — no Mac attached, and no paid Apple Developer Program.

```bash
pnpm run ios:install          # build, sign, install
pnpm run ios:install --renew  # weekly, when the signature expires
```

[`scripts/ios-install.sh`](scripts/ios-install.sh) does release build → `--export-method debugging` (the only export a free Apple ID can produce) → `xcrun devicectl device install app`. The release build compiles the UI into the binary, and the slicing engine already runs on-device, so nothing is fetched at runtime.

## Why `--renew` exists

A free Apple ID signs for seven days. Automatic signing happily reuses a still-valid profile, so a plain rebuild on day six inherits **one** day rather than starting a fresh week. `--renew` deletes the cached profiles for the bundle ID first, which is the only way to actually reset the clock. Measured on a real iPad: without it, 6 days; with it, 7. The expiry date is printed after every install rather than left for the user to discover.

## Three bugs found while getting this to work

These are the parts most worth reviewing — each is a pre-existing problem this change surfaced.

- **`project.xcworkspace` was gitignored**, but `tauri ios build` passes it to `xcodebuild -workspace`. Any fresh clone or worktree failed with a bare `project.xcworkspace does not exist` before the build started. The ignore now covers only the `xcuserdata`/`xcshareddata` beneath it; `contents.xcworkspacedata` is tracked. Verified both ways with `git check-ignore`.
- **`tauri ios build` writes `DEVELOPMENT_TEAM` into the committed `project.pbxproj`**, which would put one contributor's team ID into everyone else's checkout. The script restores the file from an EXIT trap (so interrupting a long build is safe) and clears a leftover line from a previously-killed run before snapshotting — I hit exactly that mid-development, which is why the self-heal exists. It only self-heals when git confirms nothing *else* in the file differs.
- **`ios:doctor` asked for `TAURI_APPLE_DEVELOPMENT_TEAM`** and pointed users at a Membership page that free accounts do not have. The team ID is the signing certificate's **OU**, not the identifier in its common name, so both scripts now read it from the keychain — filtered to certificates `security find-identity -v` still considers valid, or an expired cert turns a working machine into "several teams found".

## Notes for reviewers

- **New `scripts/lib/` directory.** `detect_apple_teams` is shared by the doctor and the installer specifically so the two cannot disagree about which team signs. It is a small departure from the repo's self-contained-script pattern — happy to duplicate the ~25 lines instead if you'd rather.
- **macOS ships bash 3.2**, so no `mapfile` and no associative arrays. Splitting a concatenated PEM stream with `awk` and a NUL separator also does not survive the awk macOS ships; the loop is plain `read`.
- **No engine, UI or Rust changes.** Shell scripts, docs, ignore rules, and the two new script entry points only.

## Verification

Everything below was run against a physical iPad Pro 13-inch (M4) on iOS 26.5:

- Full build → sign → install → launch, with the app confirmed running and **nothing listening on `:4213`** — so the UI is genuinely bundled, not streamed.
- `--renew` end to end: expiry moved forward, confirming a genuinely new profile rather than a reused one.
- `--list`, `--reinstall`, `--launch`, `--help`, and both `pnpm run ios:install --list` and `... -- --list` (pnpm forwards the bare `--`, which the parser now accepts).
- `git status` clean after every run — the `pbxproj` restore and self-heal both work.
- `ios:doctor` reports the team from the keychain.
- `pnpm run docs:build` passes (BUILDING/SETUP/AGENTS/CHANGELOG all publish to the docs site).

## Docs

[ui-desktop/README.md](ui-desktop/README.md) carries the full walkthrough — dev-loop vs. standalone comparison table, the seven-day trade, free-tier limits (bundle IDs are globally unique, 3 apps per device), and the one-time Trust tap. [BUILDING.md](BUILDING.md) and [SETUP.md](SETUP.md) point at it, [AGENTS.md](AGENTS.md) records the contracts for future work, and CHANGELOG has an Unreleased entry.