### PR TITLE
Ironing, dimensional compensation and a real first-layer height

### DIFF
--- a/AGENTS.md
+++ b/AGENTS.md
@@ -1088,18 +1088,21 @@ capsule/gap renders (`render.py`, `zoom.py`). Compare a change against the
 ### Pipeline Execution Order
 
 ```
-slice_mesh()                         — raw mesh → OuterWall contours per layer
+slice_mesh()                         — raw mesh → OuterWall contours per layer (layer 0 spans first_layer_height)
+apply_dimensional_compensation()     — XY size / hole offset on the raw contours (src/core/compensation.rs)
 generate_arachne_walls()             — replaces OuterWall contours with bead paths
 pre_strip_infill_regions computed    — interior regions snapshotted before wall stripping
 apply_single_wall_restrictions()     — strips inner walls from first/last layers if configured
 interior_regions computed            — per-layer interior (for surfaces), post-strip
 generate_top_bottom_surfaces_with_interior()  — top/bottom solid infill within interior
+  └─ add_ironing_for_region()        — near-dry smoothing sweep over the finished top surface
 add_infill_to_layers()               — sparse infill using pre-strip regions minus solid regions
   ├─ combine_fill_areas()            — stack sparse areas across layers (infill_every_layers);
   │                                    mark forced solid layers (solid_infill_every_layers)
   └─ connect_infill()                — anchor line ends to the perimeter, before the splat filters
 path ordering + flow compensation    — greedy-TSP per role group, then wall-overlap flow scaling
 apply_adhesion()                     — skirt/brim prepended to first layer(s); raft prepends layers + Z-shifts object (src/adhesion/)
+mark_first_layer_height()            — charges layer 0 at first_layer_height via path_heights, after adhesion so the skirt matches
 ```
 
 Order matters critically. Surfaces are computed **after** Arachne walls so that
@@ -1108,6 +1111,41 @@ Order matters critically. Surfaces are computed **after** Arachne walls so that
 last**, after ordering and flow compensation, so its loops are appended cleanly
 and the object's own toolpaths are provably unperturbed — see
 [src/adhesion/README.md](src/adhesion/README.md).
+
+**Dimensional compensation runs first, on the raw contours, and nowhere else.**
+Every later stage measures relative to the contour the wall generator consumed —
+`calculate_interior_region`'s `−0.5·d` correction, the wall-bead-footprint clip,
+adhesion's recovery of the outline by inflating layer-0 `OuterWall` by `d/2` — so
+correcting the contour leaves all of them true. Never offset the bead
+centrelines instead: moving `OuterWall` by δ after generation leaves `InnerWall`
+where it was, and the footprint clip corrects bead-*count* error, not centreline
+displacement. Winding out of the slicer is not guaranteed, so the pass
+normalises with an `EvenOdd` union first and then uses **`NonZero`** throughout;
+`Positive` would discard the CW hole sub-paths and fill every hole solid.
+
+**`first_layer_height` is split across the two ends of the pipeline.** The
+slicer gives layer 0 its own Z span (sampled at its own mid-plane, so an unset
+value reproduces the uniform slicer plane-for-plane and the QA baselines cannot
+move); `mark_first_layer_height` then charges it through `path_heights` *after*
+adhesion, so a skirt sharing that layer's Z is charged at the same height. Both
+ends resolve the value through `resolved_first_layer_height`, which the G-code
+generator also uses to decide which layer gets first-layer speeds and
+temperatures — the two must never disagree about which layer is the first. It is
+suppressed under a raft, which owns bed contact and prints at `layer_height`.
+
+**Ironing is generated in place, where `top_region` is still live**, and must
+touch **no region field**. It is a surface *treatment*, not solid material: were
+its footprint ever folded into `solid_regions`, `add_infill_to_layers` would
+subtract it (grown by a full bead) and punch a hole in the sparse infill
+underneath. It carries its own `ExtrusionRole::Ironing` rather than reusing
+`TopSurface`, because `resolve_width_mm` returns `top_surface_line_width` before
+it ever reads an explicit width — sharing the role would silently iron at full
+flow on any profile that sets one — and because a shared role would merge the
+two into one path-ordering group, letting the TSP interleave ironing with
+not-yet-printed fill. Its flow reduction is folded into the **width**
+(`ironing_spacing × ironing_flow`), deliberately keeping it out of
+`extrusion_for_move`'s `flow_ratio`, which reads a non-positive value as `1.0`
+so a malformed profile cannot zero out a print.
 
 **Perimeter routing & ordering options ([#98](https://github.com/ColdCrabby/slicer/issues/98))** are threaded through several stages:
 

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -38,6 +38,19 @@ issue/PR numbers or repo links in the notes. See the tone rules in
 
 ### Added
 
+- **Ironing** — the top-surface smoothing toggle now does something. Previously
+  it could be switched on in the profile wizard, was documented as working, and
+  logged "not yet implemented" at slice time. A near-dry pass re-melts finished
+  top surfaces flat, with its own type, flow (10 %), spacing (0.1 mm), speed and
+  angle, and its own colour in the preview.
+- **Dimensional compensation** — correct a machine that prints consistently
+  over- or under-sized. **XY size compensation** offsets every contour;
+  **hole compensation** adjusts holes on their own, so a tight press-fit can be
+  freed without moving the outside of the part. Both default to off.
+- **First layer height** — now affects the print instead of only the file
+  header. The bottom layer is sliced and extruded at its own thickness, so a
+  profile asking for 0.24 mm no longer silently prints 0.2 mm. Skirt and brim
+  follow it; a raft suppresses it.
 - **Phone layout** — the whole UI rearranges itself below 640px instead of
   overflowing. Navigation moves to a bottom tab bar, print settings become a
   drawer with a pull tab on the left edge, and Slice sits in a full-width sheet

--- a/docs/use/settings.md
+++ b/docs/use/settings.md
@@ -69,8 +69,8 @@ that touch nothing are wasted plastic and a worse surface.
 | **Infill** | Density, pattern, angle |
 | **Support** | On/off, type, density, overhang threshold |
 | **Speed** | Per-role print speeds and travel speed |
-| **Quality** | Ironing, spiral (vase) mode, other finish options |
-| **Surfaces** | Top and bottom solid layer counts, surface fill behaviour |
+| **Quality** | Bridging, dimensional compensation, other accuracy options |
+| **Surfaces** | Top and bottom solid layer counts, surface fill, ironing |
 | **Adhesion** | Skirt, brim, raft |
 | **Objects** | Print order, G-code run between objects |
 | **Thumbnail** | The preview image embedded in the G-code file |
@@ -92,14 +92,51 @@ doesn't use — so the panel never offers you a control that would do nothing.
 
 ## Two special modes
 
-**Spiral (vase) mode** (Process → Quality) prints a single continuous wall that
+**Spiral (vase) mode** (Process → Walls) prints a single continuous wall that
 climbs as it goes — no seam, no layer changes. For open, single-walled models
 only. Turning it on forces the settings it's incompatible with (extra walls,
 infill, top layers, retraction) off for you, and keeps your bottom layers as the
 base.
 
-**Ironing** (Process → Quality) makes a second, hot, barely-extruding pass over
+**Ironing** (Process → Surfaces) makes a second, hot, barely-extruding pass over
 top surfaces to smooth them. Slow, and only worth it on visible flat tops.
+
+::: details Advanced — tuning the ironing pass
+**Type** chooses what gets swept: every top surface, only the single highest one
+(much faster on a tall model, and usually the only face anyone sees), or all
+solid surfaces.
+
+**Flow** is how much material the pass adds, as a percentage of a normal bead —
+around 10 % is enough to re-melt the surface without raising it. **Spacing** is
+how far apart the passes run; well under a bead width is what flattens the
+ridges between them. **Speed** should stay low, because the nozzle needs dwell
+time to melt what it crosses. **Angle** defaults to following the layer's own
+fill direction; set an explicit angle to cross the fill instead, which flattens
+it more effectively.
+:::
+
+## Getting parts to the right size
+
+A printer lays a bead slightly wider than asked, so parts come out a little
+large and holes a little tight. Both are consistent for a given machine, so both
+can be measured once and corrected (Process → Quality).
+
+**XY size compensation** grows or shrinks every contour by a fixed amount. Print
+a test cube, measure it, and set the difference as a negative value if the cube
+came out oversized. Because the material spreads inward as well as outward, this
+also tightens holes.
+
+**Hole compensation** adjusts holes on their own, so a peg that will not fit can
+be freed without changing the outside of the part.
+
+Both default to off. Start from a measurement, not a guess — and keep the values
+small; a shrink larger than a thin feature will erase it, which the slice log
+warns you about.
+
+**First layer height** (Process → Extrusion) prints the bottom layer thicker
+than the rest. The extra material absorbs what mesh bed levelling only
+approximates, which is why almost every profile sets it. It has no effect when
+you print on a raft, since the raft takes over contact with the bed.
 
 ## Where your settings are saved
 

--- a/src/core/compensation.rs
+++ b/src/core/compensation.rs
@@ -1,0 +1,427 @@
+//! Dimensional compensation — correcting a machine's systematic XY error.
+//!
+//! A printer does not lay a bead exactly where it is told. Squish, die swell and
+//! belt tension conspire to make finished parts consistently a little over- or
+//! under-sized, and holes consistently tight. Neither is a slicing error, so
+//! neither can be fixed by slicing more carefully — the correction is a
+//! deliberate, measured offset applied to the geometry before it is turned into
+//! toolpaths.
+//!
+//! # Why here, and nowhere else
+//!
+//! This pass runs in exactly one place: **between [`slice_mesh`] and wall
+//! generation**, on the raw contours, and it is the only window that works.
+//!
+//! Everything downstream is expressed *relative to the contour the wall
+//! generator consumed* — `calculate_interior_region`'s `−0.5·d` correction, the
+//! wall-bead-footprint clip that surfaces and infill subtract, and adhesion's
+//! recovery of the object outline by inflating layer-0 `OuterWall` beads by
+//! `d/2`. Compensate the contour and every one of those relations stays exactly
+//! true, because the compensated contour simply *becomes* the model surface as
+//! far as the rest of the engine is concerned.
+//!
+//! **Never offset the bead centrelines instead.** Moving `OuterWall` by δ after
+//! generation leaves `InnerWall` where it was, so wall spacing becomes `d ± δ`
+//! and `compute_wall_bead_footprint` reports a footprint that does not match
+//! what is printed. The footprint clip corrects bead-*count* error; it cannot
+//! correct centreline displacement.
+//!
+//! # The two deltas
+//!
+//! They compose, and they are deliberately separate because the two dialects
+//! this engine imports from disagree about what one number should mean:
+//!
+//! | Setting | Effect | Dialect |
+//! | --- | --- | --- |
+//! | `xy_size_compensation` | Uniform inflate of the whole region. Positive grows the part and therefore *tightens* holes. | PrusaSlicer/Slic3r `xy_size_compensation` |
+//! | `xy_hole_compensation` | Adjusts enclosed voids only, applied after the above. Positive *enlarges* holes. | Orca/Bambu `xy_hole_compensation` |
+//!
+//! Splitting them is what lets a press-fit hole be opened up without moving the
+//! part's outside dimensions, and it is why a single signed "contour delta"
+//! field would get imported Orca profiles wrong by `2δ` on every hole.
+//!
+//! # Winding is load-bearing
+//!
+//! The mesh slicer does not guarantee consistent winding (see AGENTS.md §
+//! "Clipper2 Fill Rules"), so a raw `inflate` over its output would grow some
+//! holes and shrink others. The pass therefore normalises with an `EvenOdd`
+//! union first — after which solids are CCW and holes CW — and every subsequent
+//! set operation uses `NonZero`, which honours those CW sub-paths as voids.
+//! `Positive` would discard them and turn every hole solid.
+//!
+//! [`slice_mesh`]: super::slicer::slice_mesh
+
+use clipper2::*;
+
+use super::types::{ExtrusionRole, SliceLayer};
+
+/// What a compensation run changed, for the caller to log.
+///
+/// Compensation can legitimately erase geometry — a negative delta larger than
+/// half a thin rib's width consumes the rib — so the pass counts what it
+/// removed rather than silently fabricating it back. A part that loses features
+/// is telling the user their compensation is too aggressive; a part that
+/// silently keeps them would hide it until the print came out wrong.
+#[derive(Debug, Default, Clone, Copy, PartialEq, Eq)]
+pub struct CompensationReport {
+    /// Layers that held contours before compensation and hold none after.
+    pub emptied_layers: usize,
+    /// Net change in contour count across every layer. Negative means features
+    /// were consumed; positive means an offset split one island into several.
+    pub contour_delta: i64,
+}
+
+impl CompensationReport {
+    /// True when the run removed geometry the user probably wanted to keep.
+    pub fn has_losses(&self) -> bool {
+        self.emptied_layers > 0 || self.contour_delta < 0
+    }
+}
+
+/// Offset every contour to correct a machine's systematic XY error.
+///
+/// Call **immediately after [`slice_mesh`]** and before wall generation; see the
+/// module docs for why no other position is correct. A zero delta pair is a
+/// no-op and returns without touching the layers, so the default configuration
+/// slices byte-identically.
+///
+/// [`slice_mesh`]: super::slicer::slice_mesh
+pub fn apply_dimensional_compensation(
+    layers: &mut [SliceLayer],
+    size_delta_mm: f64,
+    hole_delta_mm: f64,
+) -> CompensationReport {
+    if !is_active(size_delta_mm, hole_delta_mm) {
+        return CompensationReport::default();
+    }
+
+    #[cfg(not(target_arch = "wasm32"))]
+    let compensated: Vec<Paths> = {
+        use rayon::prelude::*;
+        layers
+            .par_iter()
+            .map(|layer| compensate_layer(&layer.paths, size_delta_mm, hole_delta_mm))
+            .collect()
+    };
+    #[cfg(target_arch = "wasm32")]
+    let compensated: Vec<Paths> = layers
+        .iter()
+        .map(|layer| compensate_layer(&layer.paths, size_delta_mm, hole_delta_mm))
+        .collect();
+
+    let mut report = CompensationReport::default();
+
+    for (layer, region) in layers.iter_mut().zip(compensated) {
+        let before = layer.paths.len();
+        let after = region.len();
+        if before > 0 && after == 0 {
+            report.emptied_layers += 1;
+        }
+        report.contour_delta += after as i64 - before as i64;
+
+        // Compensation runs before any other pass has annotated the layer, so
+        // the only parallel array carrying data is `path_roles` — every contour
+        // out of the slicer is an `OuterWall`. Rebuilding both together keeps
+        // them the same length; the remaining arrays stay empty and continue to
+        // resolve through the "shorter array means default" convention.
+        layer.paths = region;
+        layer.path_roles = vec![ExtrusionRole::OuterWall; after];
+    }
+
+    report
+}
+
+/// True when either delta is large enough to change the geometry.
+///
+/// The threshold is 1 nm — far below any meaningful compensation, but above the
+/// float noise a round-tripped profile value can carry.
+fn is_active(size_delta_mm: f64, hole_delta_mm: f64) -> bool {
+    const EPS: f64 = 1e-6;
+    (size_delta_mm.is_finite() && size_delta_mm.abs() > EPS)
+        || (hole_delta_mm.is_finite() && hole_delta_mm.abs() > EPS)
+}
+
+/// Compensate one layer's contours.
+fn compensate_layer(paths: &Paths, size_delta_mm: f64, hole_delta_mm: f64) -> Paths {
+    if paths.is_empty() {
+        return Paths::default();
+    }
+
+    // Normalise winding first: the slicer's contours carry no consistent
+    // orientation, and every step below depends on solids being CCW and holes
+    // CW. `EvenOdd` is the winding-independent rule that establishes it.
+    let mut region = match union(paths.clone(), Paths::default(), FillRule::EvenOdd) {
+        Ok(r) if !r.is_empty() => r,
+        // A degenerate layer that will not normalise is left exactly as it was
+        // rather than dropped: compensation is a correction, not a filter.
+        _ => return paths.clone(),
+    };
+
+    if size_delta_mm.is_finite() && size_delta_mm.abs() > 1e-6 {
+        region = inflate(
+            region,
+            size_delta_mm,
+            JoinType::Round,
+            EndType::Polygon,
+            2.0,
+        );
+        if region.is_empty() {
+            return region;
+        }
+    }
+
+    if hole_delta_mm.is_finite() && hole_delta_mm.abs() > 1e-6 {
+        region = compensate_holes(region, hole_delta_mm);
+    }
+
+    region
+}
+
+/// Resize enclosed voids by `delta` without moving the outer contour.
+///
+/// Works for both signs by *filling every hole solid and re-punching it at the
+/// new size*, rather than adding or removing a ring — a subtraction alone would
+/// silently do nothing for a negative delta, because the material it would
+/// remove is already absent.
+fn compensate_holes(region: Paths, delta_mm: f64) -> Paths {
+    // A hole is a CW sub-path. Reversed, it becomes an ordinary positive
+    // polygon describing the void itself, which is far easier to reason about
+    // than an inside-out one.
+    let voids = Paths::new(
+        region
+            .iter()
+            .filter(|p| p.signed_area() < 0.0)
+            .map(reverse_path)
+            .collect::<Vec<_>>(),
+    );
+    if voids.is_empty() {
+        return region;
+    }
+
+    let Ok(filled) = union(region.clone(), voids.clone(), FillRule::NonZero) else {
+        return region;
+    };
+
+    let resized = inflate(voids, delta_mm, JoinType::Round, EndType::Polygon, 2.0);
+    if resized.is_empty() {
+        // Every void was consumed by a large negative delta — the holes are
+        // filled in, which is exactly what was asked for.
+        return filled;
+    }
+
+    difference(filled, resized, FillRule::NonZero).unwrap_or(region)
+}
+
+/// Reverse a path's vertex order, flipping its orientation and the sign of its
+/// area.
+fn reverse_path(path: &Path) -> Path {
+    let mut points: Vec<(f64, f64)> = path.iter().map(|p| (p.x(), p.y())).collect();
+    points.reverse();
+    Path::from(points)
+}
+
+#[cfg(test)]
+mod tests {
+    use super::*;
+
+    /// A CCW square of side `size` centred on the origin.
+    fn square(size: f64) -> Path {
+        let h = size / 2.0;
+        Path::from(vec![(-h, -h), (h, -h), (h, h), (-h, h)])
+    }
+
+    /// A CW square of side `size` centred on the origin — a hole.
+    fn square_hole(size: f64) -> Path {
+        let h = size / 2.0;
+        Path::from(vec![(-h, -h), (-h, h), (h, h), (h, -h)])
+    }
+
+    fn layer_with(paths: Vec<Path>) -> SliceLayer {
+        let mut layer = SliceLayer::new(0.2);
+        for p in paths {
+            layer.paths.push(p);
+            layer.path_roles.push(ExtrusionRole::OuterWall);
+        }
+        layer
+    }
+
+    /// Longest side of the axis-aligned bounding box of the positive contours.
+    fn outer_extent(paths: &Paths) -> f64 {
+        let (mut lo, mut hi) = (f64::INFINITY, f64::NEG_INFINITY);
+        for p in paths.iter().filter(|p| p.signed_area() > 0.0) {
+            for pt in p.iter() {
+                lo = lo.min(pt.x());
+                hi = hi.max(pt.x());
+            }
+        }
+        hi - lo
+    }
+
+    fn void_area(paths: &Paths) -> f64 {
+        paths
+            .iter()
+            .filter(|p| p.signed_area() < 0.0)
+            .map(|p| p.signed_area().abs())
+            .sum()
+    }
+
+    #[test]
+    fn zero_deltas_are_a_no_op() {
+        let mut layers = vec![layer_with(vec![square(20.0)])];
+        let before = layers[0].paths.clone();
+
+        let report = apply_dimensional_compensation(&mut layers, 0.0, 0.0);
+
+        assert_eq!(report, CompensationReport::default());
+        assert_eq!(
+            layers[0].paths.len(),
+            before.len(),
+            "an off-by-default pass must not touch the geometry at all"
+        );
+    }
+
+    #[test]
+    fn positive_size_compensation_grows_the_part() {
+        let mut layers = vec![layer_with(vec![square(20.0)])];
+
+        apply_dimensional_compensation(&mut layers, 0.25, 0.0);
+
+        let extent = outer_extent(&layers[0].paths);
+        assert!(
+            (extent - 20.5).abs() < 0.05,
+            "20mm square + 0.25mm per side should measure ~20.5mm, got {extent:.3}"
+        );
+    }
+
+    #[test]
+    fn negative_size_compensation_shrinks_the_part() {
+        let mut layers = vec![layer_with(vec![square(20.0)])];
+
+        apply_dimensional_compensation(&mut layers, -0.25, 0.0);
+
+        let extent = outer_extent(&layers[0].paths);
+        assert!(
+            (extent - 19.5).abs() < 0.05,
+            "20mm square - 0.25mm per side should measure ~19.5mm, got {extent:.3}"
+        );
+    }
+
+    /// The PrusaSlicer semantic: one number grows the part, and the material
+    /// necessarily expands *into* the hole.
+    #[test]
+    fn size_compensation_tightens_holes_as_a_side_effect() {
+        let mut layers = vec![layer_with(vec![square(20.0), square_hole(6.0)])];
+        let before = void_area(&layers[0].paths.clone());
+
+        apply_dimensional_compensation(&mut layers, 0.25, 0.0);
+
+        let after = void_area(&layers[0].paths);
+        assert!(
+            after < before,
+            "growing the part must shrink its holes ({before:.2} -> {after:.2} mm²)"
+        );
+    }
+
+    /// The Orca semantic, and the reason the two deltas are separate fields:
+    /// holes open up while the outside stays put.
+    #[test]
+    fn hole_compensation_enlarges_holes_without_moving_the_contour() {
+        let mut layers = vec![layer_with(vec![square(20.0), square_hole(6.0)])];
+        let extent_before = outer_extent(&layers[0].paths.clone());
+        let void_before = void_area(&layers[0].paths.clone());
+
+        apply_dimensional_compensation(&mut layers, 0.0, 0.2);
+
+        let extent_after = outer_extent(&layers[0].paths);
+        let void_after = void_area(&layers[0].paths);
+        assert!(
+            void_after > void_before,
+            "positive hole compensation must enlarge the void ({void_before:.2} -> {void_after:.2} mm²)"
+        );
+        assert!(
+            (extent_after - extent_before).abs() < 0.05,
+            "the outer contour must not move ({extent_before:.3} -> {extent_after:.3} mm)"
+        );
+    }
+
+    /// A subtraction alone would be a silent no-op here — the material it would
+    /// remove is already absent. This is the case the fill-and-re-punch
+    /// implementation exists for.
+    #[test]
+    fn negative_hole_compensation_tightens_holes() {
+        let mut layers = vec![layer_with(vec![square(20.0), square_hole(6.0)])];
+        let void_before = void_area(&layers[0].paths.clone());
+
+        apply_dimensional_compensation(&mut layers, 0.0, -0.2);
+
+        let void_after = void_area(&layers[0].paths);
+        assert!(
+            void_after < void_before,
+            "negative hole compensation must tighten the void ({void_before:.2} -> {void_after:.2} mm²)"
+        );
+    }
+
+    /// Holes survive as holes. Using `FillRule::Positive` anywhere in this pass
+    /// would drop the CW sub-paths and fill every hole with solid material.
+    #[test]
+    fn holes_are_never_filled_in_by_the_fill_rule() {
+        let mut layers = vec![layer_with(vec![square(20.0), square_hole(6.0)])];
+
+        apply_dimensional_compensation(&mut layers, 0.1, 0.0);
+
+        assert!(
+            layers[0].paths.iter().any(|p| p.signed_area() < 0.0),
+            "the hole must still be a CW void after compensation"
+        );
+    }
+
+    /// Winding out of the mesh slicer is not guaranteed, so a CW outer contour
+    /// must still grow rather than shrink.
+    #[test]
+    fn inconsistent_input_winding_is_normalised_before_offsetting() {
+        // Same 20mm square, wound backwards.
+        let reversed = reverse_path(&square(20.0));
+        let mut layers = vec![layer_with(vec![reversed])];
+
+        apply_dimensional_compensation(&mut layers, 0.25, 0.0);
+
+        let extent = outer_extent(&layers[0].paths);
+        assert!(
+            (extent - 20.5).abs() < 0.05,
+            "a CW input contour must still grow to ~20.5mm, got {extent:.3}"
+        );
+    }
+
+    /// An over-aggressive negative delta consumes a small feature. That is the
+    /// honest outcome, and the report is how the user finds out.
+    #[test]
+    fn over_shrinking_reports_the_loss_instead_of_hiding_it() {
+        let mut layers = vec![layer_with(vec![square(0.4)])];
+
+        let report = apply_dimensional_compensation(&mut layers, -1.0, 0.0);
+
+        assert!(
+            layers[0].paths.is_empty(),
+            "a 0.4mm feature cannot survive 1mm of inward compensation"
+        );
+        assert_eq!(report.emptied_layers, 1);
+        assert!(report.has_losses());
+    }
+
+    #[test]
+    fn roles_stay_in_step_with_paths() {
+        let mut layers = vec![layer_with(vec![square(20.0), square_hole(6.0)])];
+
+        apply_dimensional_compensation(&mut layers, 0.15, 0.1);
+
+        assert_eq!(
+            layers[0].paths.len(),
+            layers[0].path_roles.len(),
+            "the parallel arrays must not drift apart"
+        );
+        assert!(layers[0]
+            .path_roles
+            .iter()
+            .all(|r| *r == ExtrusionRole::OuterWall));
+    }
+}

--- a/src/core/mod.rs
+++ b/src/core/mod.rs
@@ -1,5 +1,6 @@
 //! Core slicing operations and data structures
 
+mod compensation;
 mod infill;
 mod objects;
 mod pipeline;
@@ -8,6 +9,7 @@ mod surfaces;
 mod types;
 mod walls;
 
+pub use compensation::{apply_dimensional_compensation, CompensationReport};
 pub use infill::{add_infill_to_layers, InfillConfig};
 pub use objects::{
     merge_meshes, sequential_order, sequential_warnings, slice_plate, ObjectIdentity, ObjectInput,
@@ -16,7 +18,8 @@ pub use objects::{
 pub use pipeline::process_mesh;
 #[cfg(not(target_arch = "wasm32"))]
 pub use pipeline::process_mesh_debug;
-pub use slicer::slice_mesh;
+pub(crate) use pipeline::resolved_first_layer_height;
+pub use slicer::{slice_mesh, slice_mesh_with_first_layer};
 pub use surfaces::{
     generate_top_bottom_surfaces, generate_top_bottom_surfaces_with_interior, SurfaceConfig,
     SurfaceSubTimings,
@@ -38,6 +41,7 @@ mod tests {
     use super::*;
     use crate::infill::SurfacePattern;
     use crate::mesh::types::{Face, Mesh, Vertex};
+    use crate::settings::params::{IroningType, SlicingParams};
     use clipper2::{Path, Paths};
 
     /// Build a simple 10×10×10 mm axis-aligned box mesh (12 triangles).
@@ -1471,6 +1475,7 @@ mod tests {
                 bottom_pattern: SurfacePattern::Rectilinear,
                 internal_solid_pattern: SurfacePattern::Rectilinear,
                 min_infill_extrusion_mm: 0.0,
+                ..Default::default()
             },
             None,
         );
@@ -2115,6 +2120,7 @@ mod tests {
                 bottom_pattern: SurfacePattern::Rectilinear,
                 internal_solid_pattern: SurfacePattern::Rectilinear,
                 min_infill_extrusion_mm: 0.0,
+                ..Default::default()
             },
             None,
         );
@@ -2180,6 +2186,7 @@ mod tests {
                 bottom_pattern: SurfacePattern::Rectilinear,
                 internal_solid_pattern: SurfacePattern::Rectilinear,
                 min_infill_extrusion_mm: 0.0,
+                ..Default::default()
             },
             None,
         );
@@ -2243,6 +2250,7 @@ mod tests {
             bottom_pattern: SurfacePattern::Rectilinear,
             internal_solid_pattern: SurfacePattern::Rectilinear,
             min_infill_extrusion_mm: 0.0,
+            ..Default::default()
         };
 
         let dup = layers_no_anchor[0].clone();
@@ -2351,6 +2359,7 @@ mod tests {
                 bottom_pattern: SurfacePattern::Rectilinear,
                 internal_solid_pattern: SurfacePattern::Rectilinear,
                 min_infill_extrusion_mm: 0.0,
+                ..Default::default()
             },
             Some(&interior_regions),
         );
@@ -2417,6 +2426,7 @@ mod tests {
                 bottom_pattern: SurfacePattern::Rectilinear,
                 internal_solid_pattern: SurfacePattern::Rectilinear,
                 min_infill_extrusion_mm: 0.0,
+                ..Default::default()
             },
             None,
         );
@@ -2541,6 +2551,7 @@ mod tests {
                 bottom_pattern: SurfacePattern::Rectilinear,
                 internal_solid_pattern: SurfacePattern::Rectilinear,
                 min_infill_extrusion_mm: 0.0,
+                ..Default::default()
             },
             None,
         );
@@ -2648,6 +2659,7 @@ mod tests {
                 bottom_pattern: SurfacePattern::Rectilinear,
                 internal_solid_pattern: SurfacePattern::Rectilinear,
                 min_infill_extrusion_mm: 0.0,
+                ..Default::default()
             },
             None,
         );
@@ -2745,6 +2757,7 @@ mod tests {
                 bottom_pattern: SurfacePattern::Rectilinear,
                 internal_solid_pattern: SurfacePattern::Rectilinear,
                 min_infill_extrusion_mm: 0.0,
+                ..Default::default()
             },
             Some(&interior_regions),
         );
@@ -2833,6 +2846,7 @@ mod tests {
                     bottom_pattern: SurfacePattern::Rectilinear,
                     internal_solid_pattern: SurfacePattern::Rectilinear,
                     min_infill_extrusion_mm: 0.0,
+                    ..Default::default()
                 },
                 Some(&interior_regions),
             );
@@ -2862,5 +2876,200 @@ mod tests {
              / porthole / window closure); the opened-interior clip must not \
              suppress real bridges."
         );
+    }
+
+    // ── First-layer height ────────────────────────────────────────────────────
+
+    /// The bottom layer spans `first_layer_height`; everything above it is
+    /// spaced normally. Planes are sampled at the middle of the material each
+    /// layer lays down, so the first sits at `first_h/2` and the second a full
+    /// half of each height above it.
+    #[test]
+    fn first_layer_height_moves_only_the_bottom_of_the_stack() {
+        let mesh = make_cube_mesh();
+
+        let layers = slice_mesh_with_first_layer(&mesh, 0.2, 0.3);
+
+        assert!((layers[0].z - 0.15).abs() < 1e-9, "got {}", layers[0].z);
+        assert!((layers[1].z - 0.40).abs() < 1e-9, "got {}", layers[1].z);
+        assert!((layers[2].z - 0.60).abs() < 1e-9, "got {}", layers[2].z);
+    }
+
+    /// The whole point of keeping the mid-plane convention: an unset first-layer
+    /// height must reproduce the old slicer plane-for-plane, or every committed
+    /// QA baseline moves.
+    #[test]
+    fn an_equal_first_layer_height_is_indistinguishable_from_a_uniform_slice() {
+        let mesh = make_cube_mesh();
+
+        let uniform = slice_mesh(&mesh, 0.2);
+        let explicit = slice_mesh_with_first_layer(&mesh, 0.2, 0.2);
+
+        assert_eq!(uniform.len(), explicit.len());
+        for (a, b) in uniform.iter().zip(explicit.iter()) {
+            assert!((a.z - b.z).abs() < 1e-12, "{} vs {}", a.z, b.z);
+        }
+    }
+
+    /// Geometry is only half of a thicker first layer — the flow has to match,
+    /// or the engine announces 0.3mm and extrudes for 0.2mm.
+    #[test]
+    fn first_layer_height_is_charged_at_its_own_height() {
+        let mesh = make_cube_mesh();
+        let params = SlicingParams {
+            layer_height: 0.2,
+            first_layer_height: 0.3,
+            ..SlicingParams::default()
+        };
+
+        let layers = process_mesh(&mesh, &params, &crate::logging::NullLogger);
+
+        assert!(
+            (0..layers[0].paths.len()).all(|i| layers[0].height_for_path(i) == Some(0.3)),
+            "every path on the bottom layer must be charged at the first-layer height"
+        );
+        assert!(
+            layers[1].path_heights.iter().all(|h| h.is_none()),
+            "layers above the first must keep the global layer height"
+        );
+    }
+
+    /// A raft takes over bed contact, so the remedy for an imperfect bed no
+    /// longer applies to the object — and the raft's own layers are documented
+    /// to print at `layer_height`.
+    #[test]
+    fn a_raft_suppresses_the_first_layer_height() {
+        let mesh = make_cube_mesh();
+        let params = SlicingParams {
+            layer_height: 0.2,
+            first_layer_height: 0.3,
+            adhesion_type: crate::settings::params::AdhesionType::Raft,
+            raft_layers: 2,
+            ..SlicingParams::default()
+        };
+
+        let layers = process_mesh(&mesh, &params, &crate::logging::NullLogger);
+
+        assert!(
+            layers[0].path_heights.iter().all(|h| h.is_none()),
+            "no layer may be re-charged when a raft owns the bed contact"
+        );
+    }
+
+    // ── Ironing ───────────────────────────────────────────────────────────────
+
+    fn ironed(params_fn: impl FnOnce(&mut SlicingParams)) -> Vec<SliceLayer> {
+        let mesh = make_cube_mesh();
+        let mut params = SlicingParams {
+            ironing_enabled: true,
+            ..SlicingParams::default()
+        };
+        params_fn(&mut params);
+        process_mesh(&mesh, &params, &crate::logging::NullLogger)
+    }
+
+    fn ironing_paths(layers: &[SliceLayer]) -> usize {
+        layers
+            .iter()
+            .map(|l| {
+                l.path_roles
+                    .iter()
+                    .filter(|r| **r == ExtrusionRole::Ironing)
+                    .count()
+            })
+            .sum()
+    }
+
+    #[test]
+    fn ironing_off_by_default_emits_nothing() {
+        let mesh = make_cube_mesh();
+        let layers = process_mesh(
+            &mesh,
+            &SlicingParams::default(),
+            &crate::logging::NullLogger,
+        );
+        assert_eq!(ironing_paths(&layers), 0);
+    }
+
+    #[test]
+    fn ironing_sweeps_the_top_surface_when_enabled() {
+        let layers = ironed(|_| {});
+        assert!(
+            ironing_paths(&layers) > 0,
+            "an enabled ironing pass must produce Ironing paths"
+        );
+    }
+
+    /// Ironing is a surface *treatment*, not solid material. If its footprint
+    /// ever reached `solid_regions`, `add_infill_to_layers` would subtract it
+    /// (grown by a full bead) and punch a hole in the sparse infill below.
+    #[test]
+    fn ironing_never_becomes_an_infill_boundary() {
+        let plain = process_mesh(
+            &make_cube_mesh(),
+            &SlicingParams::default(),
+            &crate::logging::NullLogger,
+        );
+        let ironed_layers = ironed(|_| {});
+
+        for (a, b) in plain.iter().zip(ironed_layers.iter()) {
+            assert_eq!(
+                a.solid_regions.len(),
+                b.solid_regions.len(),
+                "ironing must not reshape solid_regions on the layer at z={}",
+                a.z
+            );
+        }
+    }
+
+    /// Sparse infill is generated from `solid_regions`, so the previous
+    /// invariant is only meaningful if the infill itself is untouched too.
+    #[test]
+    fn ironing_leaves_every_other_role_untouched() {
+        let plain = process_mesh(
+            &make_cube_mesh(),
+            &SlicingParams::default(),
+            &crate::logging::NullLogger,
+        );
+        let ironed_layers = ironed(|_| {});
+
+        let count = |layers: &[SliceLayer], role: ExtrusionRole| -> usize {
+            layers
+                .iter()
+                .map(|l| l.path_roles.iter().filter(|r| **r == role).count())
+                .sum()
+        };
+
+        for role in [
+            ExtrusionRole::OuterWall,
+            ExtrusionRole::InnerWall,
+            ExtrusionRole::Infill,
+            ExtrusionRole::TopSurface,
+            ExtrusionRole::BottomSurface,
+        ] {
+            assert_eq!(
+                count(&plain, role),
+                count(&ironed_layers, role),
+                "{role:?} count must not change when ironing is enabled"
+            );
+        }
+    }
+
+    /// `TopmostOnly` is the cheap option — it exists precisely so a tall model
+    /// does not pay for ironing every internal step.
+    #[test]
+    fn topmost_only_irons_a_single_layer() {
+        let all = ironed(|p| p.ironing_type = IroningType::TopSurfaces);
+        let topmost = ironed(|p| p.ironing_type = IroningType::TopmostOnly);
+
+        let layers_with_ironing = |layers: &[SliceLayer]| {
+            layers
+                .iter()
+                .filter(|l| l.path_roles.contains(&ExtrusionRole::Ironing))
+                .count()
+        };
+
+        assert_eq!(layers_with_ironing(&topmost), 1);
+        assert!(layers_with_ironing(&all) >= layers_with_ironing(&topmost));
     }
 }

--- a/src/core/pipeline.rs
+++ b/src/core/pipeline.rs
@@ -5,7 +5,7 @@ use crate::mesh::types::Mesh;
 use crate::settings::params::{SeamPosition, SlicingParams};
 
 use super::infill::{add_infill_to_layers, calculate_interior_region, InfillConfig};
-use super::slicer::slice_mesh;
+use super::slicer::slice_mesh_with_first_layer;
 use super::surfaces::{
     generate_top_bottom_surfaces_with_interior, perimeter_paths_of, prune_redundant_gap_fill,
     SurfaceConfig,
@@ -20,6 +20,10 @@ fn monotonic_surface_role(role: ExtrusionRole, params: &SlicingParams) -> bool {
     match role {
         ExtrusionRole::TopSurface => params.top_surface_pattern.is_monotonic(),
         ExtrusionRole::BottomSurface => params.bottom_surface_pattern.is_monotonic(),
+        // Ironing is a uniform one-way sweep by construction — reversing any of
+        // its lines would drag the hot nozzle back across a stroke it has just
+        // flattened, which is the whole thing the pass exists to avoid.
+        ExtrusionRole::Ironing => true,
         _ => false,
     }
 }
@@ -64,6 +68,87 @@ fn sparse_infill_config(params: &SlicingParams) -> InfillConfig {
     }
 }
 
+/// True when a raft will be printed under the object.
+///
+/// A raft takes over bed contact entirely, which changes the answer to two
+/// questions elsewhere in this file: the object's first layer is no longer the
+/// one that has to cope with an imperfect bed, and it is no longer the layer a
+/// first-layer height was chosen for.
+fn raft_is_active(params: &SlicingParams) -> bool {
+    params.adhesion_type == crate::settings::params::AdhesionType::Raft && params.raft_layers > 0
+}
+
+/// Thickness of the object's bottom layer, in mm.
+///
+/// `first_layer_height` is a bed-contact remedy, so it is deliberately ignored
+/// when a raft is present: the object then starts on plastic, and the raft's own
+/// layers are documented to print at `layer_height` (see the adhesion module).
+/// Falls back to `layer_height` when unset.
+///
+/// Shared with the G-code generator, which needs the same answer to decide which
+/// layer gets first-layer speeds and temperatures — the two must never disagree
+/// about which layer is the first.
+pub(crate) fn resolved_first_layer_height(params: &SlicingParams) -> f64 {
+    if params.first_layer_height > 0.0 && !raft_is_active(params) {
+        params.first_layer_height
+    } else {
+        params.layer_height
+    }
+}
+
+/// Charge every path on the object's bottom layer at `first_h` rather than the
+/// global layer height.
+///
+/// The slicer has already given that layer its own Z span; this is the flow half
+/// of the same fact. It is applied **after** bed adhesion so a skirt or brim —
+/// which sits on the bed at exactly that layer's Z, and is therefore exactly as
+/// thick — is charged correctly too. `path_heights` is the established per-path
+/// height override, so `extrusion_for_move`, the volumetric-speed cap and the
+/// `;HEIGHT:` marker all pick it up with no further plumbing.
+fn mark_first_layer_height(layers: &mut [SliceLayer], first_h: f64, layer_height: f64) {
+    if (first_h - layer_height).abs() < 1e-9 {
+        return;
+    }
+    let Some(layer) = layers.first_mut() else {
+        return;
+    };
+    // Combined sparse infill never touches layer 0, so nothing else can have
+    // written a height override here; a plain fill keeps the array aligned.
+    layer.path_heights = vec![Some(first_h); layer.paths.len()];
+}
+
+/// Run dimensional compensation and report what it cost.
+///
+/// A no-op unless the user configured a delta, so the default pipeline is
+/// untouched. Losses are logged rather than silently repaired: a compensation
+/// large enough to consume a feature is a compensation the user needs to know
+/// about.
+fn apply_compensation(
+    layers: &mut [SliceLayer],
+    params: &SlicingParams,
+    logger: &dyn ProcessLogger,
+) {
+    let report = super::compensation::apply_dimensional_compensation(
+        layers,
+        params.xy_size_compensation,
+        params.xy_hole_compensation,
+    );
+    if report == super::compensation::CompensationReport::default() {
+        return;
+    }
+    logger.log_debug(&format!(
+        "applied dimensional compensation (size {:+.3}mm, hole {:+.3}mm)",
+        params.xy_size_compensation, params.xy_hole_compensation
+    ));
+    if report.emptied_layers > 0 {
+        logger.log_warn(&format!(
+            "dimensional compensation removed every contour from {} layer(s) — the shrink is \
+             larger than those cross-sections",
+            report.emptied_layers
+        ));
+    }
+}
+
 /// Central entry point for the complete slicing pipeline.
 ///
 /// This function processes a mesh through the entire slicing pipeline, including
@@ -105,7 +190,8 @@ pub fn process_mesh(
 
     let t_slicing = PhaseTimer::start(phases::SLICING, logger);
     logger.log_debug("slicing mesh…");
-    let mut layers = slice_mesh(mesh, params.layer_height);
+    let first_h = resolved_first_layer_height(params);
+    let mut layers = slice_mesh_with_first_layer(mesh, params.layer_height, first_h);
     logger.log_info(&format!("sliced into {} layers", layers.len()));
     t_slicing.finish();
 
@@ -113,6 +199,11 @@ pub fn process_mesh(
         logger.log_info("slice cancelled after slicing phase");
         return layers;
     }
+
+    // Dimensional compensation, on the raw contours and nowhere else: every
+    // later stage measures from the contour the wall generator consumed, so
+    // correcting it here leaves all of those relations intact.
+    apply_compensation(&mut layers, params, logger);
 
     // Generate walls FIRST from the raw mesh contours
     logger.log_debug(&format!(
@@ -271,6 +362,10 @@ pub fn process_mesh(
                 top_pattern: params.top_surface_pattern,
                 bottom_pattern: params.bottom_surface_pattern,
                 internal_solid_pattern: params.internal_solid_infill_pattern,
+                ironing_enabled: params.ironing_enabled,
+                ironing_type: params.ironing_type,
+                ironing_spacing: params.ironing_spacing,
+                ironing_angle: params.ironing_angle,
             },
             Some(&interior_regions),
         );
@@ -577,6 +672,10 @@ pub fn process_mesh(
         t_adhesion.finish();
     }
 
+    // The flow half of a thicker first layer, applied last so the skirt or brim
+    // sharing that layer's Z is charged at the same height the object is.
+    mark_first_layer_height(&mut layers, first_h, params.layer_height);
+
     layers
 }
 
@@ -619,8 +718,11 @@ pub fn process_mesh_debug(
         mesh.faces.len()
     ));
 
-    let mut layers = slice_mesh(mesh, params.layer_height);
+    let first_h = resolved_first_layer_height(params);
+    let mut layers = slice_mesh_with_first_layer(mesh, params.layer_height, first_h);
     logger.log_info(&format!("sliced into {} layers", layers.len()));
+
+    apply_compensation(&mut layers, params, logger);
 
     // Snapshot raw contours.
     for (i, layer) in layers.iter().enumerate() {
@@ -709,6 +811,10 @@ pub fn process_mesh_debug(
                 top_pattern: params.top_surface_pattern,
                 bottom_pattern: params.bottom_surface_pattern,
                 internal_solid_pattern: params.internal_solid_infill_pattern,
+                ironing_enabled: params.ironing_enabled,
+                ironing_type: params.ironing_type,
+                ironing_spacing: params.ironing_spacing,
+                ironing_angle: params.ironing_angle,
             },
             Some(&interior_regions),
         );
@@ -777,6 +883,8 @@ pub fn process_mesh_debug(
     ));
 
     crate::flow::compensate(&mut layers, params);
+
+    mark_first_layer_height(&mut layers, first_h, params.layer_height);
 
     layers
 }

--- a/src/core/slicer.rs
+++ b/src/core/slicer.rs
@@ -59,6 +59,46 @@ fn edge_intersect(a: Vertex, b: Vertex, z: f64) -> (f64, f64) {
 /// assert!(!layers.is_empty());
 /// ```
 pub fn slice_mesh(mesh: &Mesh, layer_height: f64) -> Vec<SliceLayer> {
+    slice_mesh_with_first_layer(mesh, layer_height, layer_height)
+}
+
+/// Slice a mesh whose **first layer** is a different thickness from the rest.
+///
+/// A thicker first layer is the standard remedy for an imperfect bed: the extra
+/// material absorbs the variation a mesh bed levels out only approximately, so
+/// almost every shipped profile sets one. Only the bottom-most layer is
+/// affected; everything above it is spaced by `layer_height` as usual.
+///
+/// Layer planes are sampled at the **middle** of the material each layer
+/// deposits, which is what keeps the cross-section representative of the whole
+/// slab rather than of one of its faces. That convention is preserved exactly:
+/// passing `first_layer_height == layer_height` reproduces [`slice_mesh`]
+/// plane-for-plane.
+///
+/// ```text
+///   first_layer_height = 0.24, layer_height = 0.20
+///
+///   0.00 ─────────────────  bed
+///                    · 0.12 ← layer 0 sampled here, prints 0.24mm
+///   0.24 ─────────────────
+///                    · 0.34 ← layer 1 sampled here, prints 0.20mm
+///   0.44 ─────────────────
+/// ```
+///
+/// # Arguments
+/// * `mesh`               – triangle mesh in millimetres
+/// * `layer_height`       – distance between layer planes in mm (must be > 0)
+/// * `first_layer_height` – thickness of the bottom layer in mm; values `<= 0`
+///   fall back to `layer_height`
+///
+/// # Returns
+/// A `Vec<SliceLayer>` ordered from bottom to top. Empty if the mesh has no
+/// faces or `layer_height` is not positive.
+pub fn slice_mesh_with_first_layer(
+    mesh: &Mesh,
+    layer_height: f64,
+    first_layer_height: f64,
+) -> Vec<SliceLayer> {
     if mesh.faces.is_empty() || layer_height <= 0.0 {
         return Vec::new();
     }
@@ -79,13 +119,21 @@ pub fn slice_mesh(mesh: &Mesh, layer_height: f64) -> Vec<SliceLayer> {
         return Vec::new();
     }
 
-    // Layer planes start half a layer above the mesh bottom
-    let first_z = z_min + layer_height * 0.5;
+    // Layer planes are sampled at the middle of the material each layer lays
+    // down, so the first plane sits half a *first* layer above the mesh bottom
+    // and the step into layer 1 spans half of each.
+    let first_h = if first_layer_height > 0.0 {
+        first_layer_height
+    } else {
+        layer_height
+    };
+    let first_z = z_min + first_h * 0.5;
     let layer_count = ((z_max - first_z) / layer_height).ceil() as usize + 1;
 
     let mut layers = Vec::with_capacity(layer_count);
 
     let mut z = first_z;
+    let mut index = 0usize;
     while z < z_max {
         // Sample the cross-section a hair above the nominal layer plane.  A
         // model's horizontal faces (decks, floors) frequently sit *exactly* on a
@@ -108,7 +156,15 @@ pub fn slice_mesh(mesh: &Mesh, layer_height: f64) -> Vec<SliceLayer> {
         }
 
         layers.push(layer);
-        z += layer_height;
+        // Stepping off layer 0 crosses half of it and half of layer 1; every
+        // step after that is a whole `layer_height`. When the two heights are
+        // equal this is exactly `z += layer_height` throughout.
+        z += if index == 0 {
+            (first_h + layer_height) * 0.5
+        } else {
+            layer_height
+        };
+        index += 1;
     }
 
     layers

--- a/src/core/surfaces.rs
+++ b/src/core/surfaces.rs
@@ -5,7 +5,7 @@ use clipper2::*;
 
 use super::types::{ExtrusionRole, SliceLayer};
 use crate::infill::SurfacePattern;
-use crate::settings::params::SlicingParams;
+use crate::settings::params::{IroningType, SlicingParams};
 
 /// Extract only outer-wall paths from a layer for use in surface detection.
 ///
@@ -1669,6 +1669,10 @@ pub fn generate_top_bottom_surfaces(
             top_pattern: SurfacePattern::Rectilinear,
             bottom_pattern: SurfacePattern::Rectilinear,
             internal_solid_pattern: SurfacePattern::Rectilinear,
+            ironing_enabled: false,
+            ironing_type: IroningType::TopSurfaces,
+            ironing_spacing: 0.1,
+            ironing_angle: -1.0,
         },
         None, // No interior regions - use full perimeters
     );
@@ -1773,6 +1777,80 @@ pub struct SurfaceConfig {
     ///
     /// [`SlicingParams::ensure_vertical_shell_thickness`]: crate::settings::params::SlicingParams::ensure_vertical_shell_thickness
     pub ensure_vertical_shell_thickness: bool,
+    /// Sweep finished solid surfaces with a near-dry ironing pass.
+    pub ironing_enabled: bool,
+    /// Which solid surfaces the ironing pass covers.
+    pub ironing_type: IroningType,
+    /// Distance in mm between adjacent ironing passes.
+    pub ironing_spacing: f64,
+    /// Ironing sweep direction in degrees; `-1` follows the layer's own fill
+    /// angle.
+    pub ironing_angle: f64,
+}
+
+impl Default for SurfaceConfig {
+    /// Plain solid surfaces with every optional treatment off.
+    ///
+    /// Exists so a caller — and every test — can name the handful of fields it
+    /// actually cares about and spread the rest. Adding a surface option is then
+    /// additive rather than a breaking change across a dozen call sites.
+    fn default() -> Self {
+        Self {
+            top_layers: 0,
+            bottom_layers: 0,
+            layer_height: 0.2,
+            infill_angle: 45.0,
+            nozzle_diameter_mm: 0.4,
+            solid_surface_line_width_mm: 0.0,
+            min_infill_extrusion_mm: 0.0,
+            bridge_flow_ratio: 0.8,
+            bridge_min_area_mm2: 0.5,
+            bridge_noise_filter_mm: 0.05,
+            bridge_anchor_mm: 0.5,
+            bridge_angle_deg: 0.0,
+            top_pattern: SurfacePattern::Rectilinear,
+            bottom_pattern: SurfacePattern::Rectilinear,
+            internal_solid_pattern: SurfacePattern::Rectilinear,
+            infill_overlap_percent: 0.25,
+            ensure_vertical_shell_thickness: false,
+            ironing_enabled: false,
+            ironing_type: IroningType::TopSurfaces,
+            ironing_spacing: 0.1,
+            ironing_angle: -1.0,
+        }
+    }
+}
+
+/// Append a near-dry ironing sweep over `region`.
+///
+/// Ironing carries no material budget of its own — the G-code generator derives
+/// its width from `ironing_spacing × ironing_flow`, so the sweep re-melts what
+/// the surface fill already deposited rather than adding to it. The region is
+/// therefore the *finished* surface: the same trimmed, wall-band-clipped polygon
+/// the fill used, so the hot nozzle never strays onto a perimeter.
+///
+/// A `Monotonic` pattern joins consecutive lines along the boundary, which keeps
+/// the sweep one continuous stroke instead of hundreds of separate passes each
+/// paying for a travel.
+fn add_ironing_for_region(
+    layer: &mut SliceLayer,
+    region: &Paths,
+    spacing: f64,
+    angle_deg: f64,
+    min_infill_extrusion_mm: f64,
+) {
+    if region.is_empty() {
+        return;
+    }
+    add_solid_infill_for_region(
+        layer,
+        region,
+        ExtrusionRole::Ironing,
+        spacing.max(0.01),
+        angle_deg,
+        min_infill_extrusion_mm,
+        SurfacePattern::Monotonic,
+    );
 }
 
 /// Generate top and bottom solid surface infill for layers.
@@ -2419,6 +2497,15 @@ pub fn generate_top_bottom_surfaces_with_interior(
         })
         .collect();
 
+    // The single highest layer carrying a top surface — the one face a viewer
+    // looks down on, and all that `IroningType::TopmostOnly` sweeps. Resolved
+    // before the loop consumes `regions`.
+    let topmost_top_layer = if config.ironing_enabled {
+        regions.iter().rposition(|(_, _, top, _)| !top.is_empty())
+    } else {
+        None
+    };
+
     // ── Serial apply pass ─────────────────────────────────────────────────────
     for (i, (bridge_region, bottom_region, top_region, raw_unsupported)) in
         regions.into_iter().enumerate()
@@ -2543,6 +2630,43 @@ pub fn generate_top_bottom_surfaces_with_interior(
             #[cfg(not(target_arch = "wasm32"))]
             {
                 infill_ns += t.elapsed().as_nanos();
+            }
+        }
+
+        // Ironing, last on the layer so the sweep runs over a finished surface.
+        //
+        // The paths are appended to `layer.paths` and touch no region field:
+        // ironing is a surface *treatment*, not solid material. Were its
+        // footprint ever folded into `solid_regions`, `add_infill_to_layers`
+        // would subtract it (grown by a full bead) and punch a hole in the
+        // sparse infill underneath.
+        if config.ironing_enabled {
+            let angle = if config.ironing_angle < 0.0 {
+                layer_infill_angle
+            } else {
+                config.ironing_angle
+            };
+            let iron_top = match config.ironing_type {
+                IroningType::TopSurfaces | IroningType::AllSolid => true,
+                IroningType::TopmostOnly => topmost_top_layer == Some(i),
+            };
+            if iron_top {
+                add_ironing_for_region(
+                    &mut layers[i],
+                    &top_region,
+                    config.ironing_spacing,
+                    angle,
+                    min_infill_extrusion_mm,
+                );
+            }
+            if config.ironing_type == IroningType::AllSolid {
+                add_ironing_for_region(
+                    &mut layers[i],
+                    &bottom_region,
+                    config.ironing_spacing,
+                    angle,
+                    min_infill_extrusion_mm,
+                );
             }
         }
 
@@ -2887,6 +3011,7 @@ mod tests {
             top_pattern: SurfacePattern::Rectilinear,
             bottom_pattern: SurfacePattern::Rectilinear,
             internal_solid_pattern: SurfacePattern::Rectilinear,
+            ..Default::default()
         }
     }
 
@@ -3521,6 +3646,7 @@ mod tests {
                 top_pattern: SurfacePattern::Rectilinear,
                 bottom_pattern: SurfacePattern::Rectilinear,
                 internal_solid_pattern: SurfacePattern::Rectilinear,
+                ..Default::default()
             },
             Some(&interior_regions),
         );

--- a/src/core/types.rs
+++ b/src/core/types.rs
@@ -39,6 +39,14 @@ pub enum ExtrusionRole {
     Support,
     /// Skirt or brim line.
     Skirt,
+    /// Near-dry smoothing pass over a finished top surface.
+    ///
+    /// Deposits almost no material — the nozzle re-melts what is already there
+    /// and spreads it flat. A role of its own rather than a variant of
+    /// [`Self::TopSurface`] because it needs its own speed, its own
+    /// acceleration, its own (much reduced) flow, and its own path-ordering
+    /// group so it cannot be interleaved with the fill it is meant to follow.
+    Ironing,
 }
 
 impl ExtrusionRole {
@@ -60,6 +68,7 @@ impl ExtrusionRole {
             Self::GapFill => "Gap infill",
             Self::Support => "Support material",
             Self::Skirt => "Skirt",
+            Self::Ironing => "Ironing",
         }
     }
 
@@ -79,6 +88,7 @@ impl ExtrusionRole {
             Self::GapFill => 0.4,
             Self::Support => 0.4,
             Self::Skirt => 0.4,
+            Self::Ironing => 0.4,
         }
     }
 }

--- a/src/gcode/generator.rs
+++ b/src/gcode/generator.rs
@@ -323,6 +323,20 @@ pub(crate) fn resolve_width_mm(
 ) -> f64 {
     use crate::core::ExtrusionRole;
 
+    // Ironing is fully described by its own two settings and nothing may
+    // override it. The pass sweeps a strip `ironing_spacing` wide but deposits
+    // only `ironing_flow` percent of a full bead into it, and folding that
+    // fraction into the width is what makes the reduction *arithmetic* rather
+    // than a flow ratio: `extrusion_for_move` deliberately reads a non-positive
+    // flow ratio as 1.0 so a malformed profile cannot zero out a print, which
+    // would turn a legitimate "wipe only" ironing setting into a full-width
+    // bead laid at 0.1 mm pitch.
+    if role == ExtrusionRole::Ironing {
+        let spacing = params.ironing_spacing.max(0.0);
+        let flow = params.ironing_flow.clamp(0.0, 100.0) / 100.0;
+        return spacing * flow;
+    }
+
     // Fill roles are laid at their flow spacing (the libslic3r/Orca stadium
     // pitch, ≈ 0.357 mm at a 0.4 mm nozzle / 0.2 mm layers), so each line must
     // deposit `spacing × layer_height` of filament — the volume of the strip it
@@ -1085,6 +1099,20 @@ impl GcodeGenerator {
                     fallback
                 }
             }
+            ExtrusionRole::Ironing => {
+                // Slow is the point: the nozzle needs dwell time to re-melt the
+                // surface it passes over. Falls back to the surface it follows.
+                let s = if params.ironing_speed > 0.0 {
+                    params.ironing_speed
+                } else {
+                    params.top_surface_speed
+                };
+                if s > 0.0 {
+                    s * 60.0
+                } else {
+                    fallback
+                }
+            }
             ExtrusionRole::GapFill => {
                 // Gap fill is a wall-family feature: fall back to perimeter
                 // speed, then print speed.
@@ -1166,6 +1194,8 @@ impl GcodeGenerator {
                 or_normal(params.bridge_acceleration)
             }
             ExtrusionRole::TopSurface => or_normal(params.top_surface_acceleration),
+            // Ironing follows the surface it is smoothing.
+            ExtrusionRole::Ironing => or_normal(params.top_surface_acceleration),
             ExtrusionRole::OuterWall => or_normal(params.outer_wall_acceleration),
             _ => normal,
         };
@@ -1731,12 +1761,24 @@ impl GcodeGenerator {
             // handed an endstop correction.
             let z_str = format!("{:.3}", machine_z(layer.z, params));
             let model_z_str = format!("{:.3}", layer.z);
-            let height_str = format!("{:.3}", params.layer_height);
+            // The height this layer *opens* at. A first layer of its own
+            // thickness (or a combined-infill bead) carries a per-path override,
+            // and announcing the global height here instead would have a viewer
+            // size the opening beads wrong until the first re-announcement.
+            let opening_height = layer
+                .height_for_path(0)
+                .filter(|h| *h > 0.0)
+                .unwrap_or(params.layer_height);
+            let height_str = format!("{:.3}", opening_height);
             // Last `;HEIGHT:` announced on this layer, so a taller combined-infill
             // bead re-announces it and the next ordinary path announces it back.
             let mut last_height: Option<String> = Some(height_str.clone());
-            // Detect first layer: z within half a layer height of layer_height.
-            let is_first_layer = layer.z <= params.layer_height + 1e-6;
+            // The bed-contact layer. Compared by Z rather than by index so a
+            // caller may generate a slab of mid-print layers on its own, and
+            // bounded by the first layer's *own* thickness — which may be
+            // thinner than the rest, in which case a `layer_height` bound would
+            // sweep the second layer in with it.
+            let is_first_layer = layer.z <= crate::core::resolved_first_layer_height(params) + 1e-6;
 
             // Per-layer travel router (opt-in).  Built once per layer so travel
             // hops can detour around outer walls instead of scarring the surface.
@@ -3598,6 +3640,80 @@ mod tests {
                 &params
             ),
             0.5
+        );
+    }
+
+    /// Ironing deposits `ironing_flow` percent of a bead across a strip
+    /// `ironing_spacing` wide, and folding the fraction into the width is what
+    /// keeps that arithmetic out of reach of `extrusion_for_move`'s flow guard.
+    #[test]
+    fn resolve_width_charges_ironing_at_spacing_times_flow() {
+        let mut params = SlicingParams {
+            ironing_spacing: 0.1,
+            ironing_flow: 10.0,
+            ..SlicingParams::default()
+        };
+        assert!(
+            (resolve_width_mm(None, false, crate::core::ExtrusionRole::Ironing, &params) - 0.01)
+                .abs()
+                < 1e-12
+        );
+
+        // A per-role surface width must not leak into ironing: `resolve_width_mm`
+        // returns `top_surface_line_width` before it ever reads an explicit
+        // width, so sharing the TopSurface role would iron at full flow on any
+        // profile that sets one.
+        params.top_surface_line_width = 0.5;
+        params.line_width = 0.6;
+        assert!(
+            (resolve_width_mm(None, false, crate::core::ExtrusionRole::Ironing, &params) - 0.01)
+                .abs()
+                < 1e-12,
+            "no width setting may override the ironing flow calculation"
+        );
+    }
+
+    /// `extrusion_for_move` reads a non-positive flow ratio as 1.0 so a
+    /// malformed profile cannot zero out a print. A "wipe only" ironing setting
+    /// must therefore never travel through that parameter — it would lay a
+    /// full-width bead at 0.1mm pitch across the whole top surface.
+    #[test]
+    fn zero_ironing_flow_deposits_nothing_rather_than_everything() {
+        let params = SlicingParams {
+            ironing_spacing: 0.1,
+            ironing_flow: 0.0,
+            ..SlicingParams::default()
+        };
+
+        let width = resolve_width_mm(None, false, crate::core::ExtrusionRole::Ironing, &params);
+        assert_eq!(width, 0.0);
+
+        let e = extrusion_for_move(10.0, params.layer_height, width, 1.75, 1.0);
+        assert_eq!(e, 0.0, "zero flow must extrude nothing at all");
+    }
+
+    /// Guards the same guard from the other side: a negative or absurd flow is
+    /// clamped rather than inverted.
+    #[test]
+    fn out_of_range_ironing_flow_is_clamped() {
+        let low = SlicingParams {
+            ironing_spacing: 0.1,
+            ironing_flow: -25.0,
+            ..SlicingParams::default()
+        };
+        let high = SlicingParams {
+            ironing_spacing: 0.1,
+            ironing_flow: 400.0,
+            ..SlicingParams::default()
+        };
+        assert_eq!(
+            resolve_width_mm(None, false, crate::core::ExtrusionRole::Ironing, &low),
+            0.0
+        );
+        assert!(
+            (resolve_width_mm(None, false, crate::core::ExtrusionRole::Ironing, &high) - 0.1).abs()
+                < 1e-12,
+            "flow above 100% must cap at a full bead of the ironing strip"
         );
     }
 

--- a/src/gcode_viewer/types.rs
+++ b/src/gcode_viewer/types.rs
@@ -22,6 +22,7 @@
 /// - 15 Brim
 /// - 16 PrimeTower
 /// - 17 InternalBridge
+/// - 18 Ironing
 #[derive(Debug, Clone, Copy, PartialEq, Eq)]
 pub(super) enum Role {
     OuterWall,
@@ -55,11 +56,18 @@ pub(super) enum Role {
     PrimeTower,
     /// Internal bridge infill.
     InternalBridge,
+    /// Near-dry smoothing pass over a finished top surface.
+    Ironing,
 }
 
 impl Role {
     pub(super) fn from_type_comment(s: &str) -> Self {
         let lower = s.to_ascii_lowercase();
+        // Ahead of the "top" test below: ironing sweeps a top surface but is a
+        // role of its own, and its label shares no substring with one.
+        if lower.contains("ironing") {
+            return Self::Ironing;
+        }
         if lower.contains("internal bridge") {
             return Self::InternalBridge;
         }
@@ -140,6 +148,10 @@ impl Role {
             Role::Brim => 15,
             Role::PrimeTower => 16,
             Role::InternalBridge => 17,
+            // Appended, never inserted: this ordinal is the wire format the
+            // TypeScript viewer decodes, so renumbering would recolour every
+            // previously-rendered role.
+            Role::Ironing => 18,
         }
     }
 }

--- a/src/settings/README.md
+++ b/src/settings/README.md
@@ -52,10 +52,49 @@ pattern deposits the same amount. See
 | `top_surface_pattern`           | enum | `monotonic-line`  | Fill pattern for the visible top surface       |
 | `bottom_surface_pattern`        | enum | `monotonic`       | Fill pattern for the bottom surface            |
 | `internal_solid_infill_pattern` | enum | `monotonic`       | Fill pattern for forced internal solid layers  |
+| `ironing_enabled`               | bool | `false`           | Sweep finished top surfaces with a near-dry smoothing pass |
+| `ironing_type`                  | enum | `top_surfaces`    | `top_surfaces` / `topmost_only` / `all_solid`  |
+| `ironing_flow`                  | %    | 10                | Material deposited, as a share of a normal bead |
+| `ironing_spacing`               | mm   | 0.1               | Pitch between ironing passes                   |
+| `ironing_speed`                 | mm/s | 20                | `0` = fall back to `top_surface_speed`         |
+| `ironing_angle`                 | °    | -1                | `-1` = follow the layer's own fill angle       |
 
 Surface patterns: `rectilinear`, `aligned-rectilinear`, `monotonic`,
 `monotonic-line`, `concentric`. "Monotonic" draws every line in the same
 direction, so the nozzle never travels back over a line it just laid.
+
+Ironing carries the `Ironing` role (`;TYPE:Ironing`) and its own speed and
+acceleration. Its width is `ironing_spacing × ironing_flow`, which keeps the
+flow reduction out of the G-code generator's flow-ratio parameter — that
+deliberately reads a non-positive ratio as `1.0`, so routing a "wipe only"
+setting through it would lay a full-width bead at 0.1 mm pitch.
+
+### Dimensional compensation (`params.*`)
+
+| Parameter               | Type | Default | Effect                                                    |
+| ----------------------- | ---- | ------- | --------------------------------------------------------- |
+| `xy_size_compensation`  | mm   | 0       | Grow (+) or shrink (−) every contour; also tightens holes |
+| `xy_hole_compensation`  | mm   | 0       | Enlarge (+) or tighten (−) holes only, applied after      |
+
+Both are applied to the raw contours between slicing and wall generation — the
+only point at which the rest of the pipeline's measurements stay true. See
+[src/core/compensation.rs](../core/compensation.rs).
+
+`xy_size_compensation` follows the PrusaSlicer/Slic3r meaning (one number, and
+growing the part necessarily tightens its holes); `xy_hole_compensation` follows
+Orca/Bambu's separate hole delta. They are separate fields because collapsing
+them into one signed value gets imported Orca profiles wrong by `2δ` on every
+hole.
+
+### First layer (`params.*`)
+
+| Parameter            | Type | Default | Effect                                              |
+| -------------------- | ---- | ------- | ---------------------------------------------------- |
+| `first_layer_height` | mm   | 0       | Thickness of the bottom layer; `0` = use `layer_height` |
+
+Affects both geometry and flow: the slicer gives layer 0 its own Z span, and the
+generator charges it at that height via `path_heights`. Suppressed when a raft
+is present, since the raft then owns bed contact.
 
 ### Bridge & overhang (`params.*`)
 

--- a/src/settings/params.rs
+++ b/src/settings/params.rs
@@ -443,6 +443,26 @@ pub enum BrimType {
     Ears,
 }
 
+/// Which solid surfaces the ironing pass sweeps.
+///
+/// Mirrors the PrusaSlicer (`top`/`topmost`/`solid`) and OrcaSlicer
+/// (`top surfaces`/`topmost surface only`/`all solid surfaces`) enumerations so
+/// an imported profile maps onto one of these without loss.
+#[derive(Debug, Clone, Copy, PartialEq, Eq, Default, Serialize, Deserialize, JsonSchema)]
+#[serde(rename_all = "snake_case")]
+pub enum IroningType {
+    /// Every exposed top surface, on any layer (the common case).
+    #[default]
+    TopSurfaces,
+    /// Only the single highest top surface of the model — the one face a
+    /// viewer actually looks down on, at a fraction of the print-time cost.
+    TopmostOnly,
+    /// Every solid surface, including the internal solid floors that brace
+    /// sparse infill. Rarely useful: those surfaces are buried under later
+    /// layers, so the finish is invisible and the time is spent regardless.
+    AllSolid,
+}
+
 /// How a plate holding several objects is printed.
 ///
 /// The developer-facing rationale (how each order flows through the slicing
@@ -2001,11 +2021,84 @@ Caps print speed so the hotend can keep up with the flow.
     pub raft_air_gap: f64,
 
     #[schemars(
-        description = "Iron top surfaces for a smoother finish. Ironing pass pending.",
+        description = "Grow (positive) or shrink (negative) every contour by this many mm, on every layer.
+
+Corrects a printer that consistently prints parts slightly over- or under-sized.
+Because the material expands inward as well as outward, a positive value also
+makes holes *smaller* — use `xy_hole_compensation` to correct holes separately.
+**Typical:** -0.1 to 0.1. `0` = off.",
+        extend("x-group" = "Quality")
+    )]
+    #[serde(default = "SlicingParams::default_xy_size_compensation")]
+    pub xy_size_compensation: f64,
+
+    #[schemars(
+        description = "Enlarge (positive) or tighten (negative) holes by this many mm, on every layer.
+
+Applied after `xy_size_compensation` and only to enclosed voids, so a press-fit
+hole can be opened up without changing the part's outside dimensions. **Typical:**
+0 to 0.1. `0` = off.",
+        extend("x-group" = "Quality")
+    )]
+    #[serde(default = "SlicingParams::default_xy_hole_compensation")]
+    pub xy_hole_compensation: f64,
+
+    #[schemars(
+        description = "Iron top surfaces for a smoother finish.
+
+A second, nearly dry pass that re-melts the surface and spreads it flat. Slow —
+it re-traverses the whole surface at a fraction of the fill spacing — so it is
+worth it on visible flat tops and little else.",
         extend("x-group" = "Surfaces")
     )]
     #[serde(default = "SlicingParams::default_ironing_enabled")]
     pub ironing_enabled: bool,
+
+    #[schemars(
+        description = "Which surfaces the ironing pass sweeps.",
+        extend("x-group" = "Surfaces", "x-relevant-when" = serde_json::json!({"field": "ironing_enabled", "equals": true}))
+    )]
+    #[serde(default)]
+    pub ironing_type: IroningType,
+
+    #[schemars(
+        description = "Material deposited during ironing, as a percentage of a normal solid-fill bead.
+
+Just enough to re-melt the surface without adding height. **Typical:** 8–15 %.",
+        extend("x-group" = "Surfaces", "x-relevant-when" = serde_json::json!({"field": "ironing_enabled", "equals": true}))
+    )]
+    #[serde(default = "SlicingParams::default_ironing_flow")]
+    pub ironing_flow: f64,
+
+    #[schemars(
+        description = "Distance in mm between adjacent ironing passes.
+
+Much finer than the fill spacing — this is what flattens the ridges between
+beads. **Typical:** 0.1–0.2.",
+        extend("x-group" = "Surfaces", "x-relevant-when" = serde_json::json!({"field": "ironing_enabled", "equals": true}))
+    )]
+    #[serde(default = "SlicingParams::default_ironing_spacing")]
+    pub ironing_spacing: f64,
+
+    #[schemars(
+        description = "Ironing speed in mm/s. `0` = fall back to the top-surface speed.
+
+Slow is the point: the nozzle needs dwell time to re-melt what it passes over.
+**Typical:** 15–30 mm/s.",
+        extend("x-group" = "Surfaces", "x-relevant-when" = serde_json::json!({"field": "ironing_enabled", "equals": true}))
+    )]
+    #[serde(default = "SlicingParams::default_ironing_speed")]
+    pub ironing_speed: f64,
+
+    #[schemars(
+        description = "Ironing sweep direction in degrees. `-1` = follow the layer's own surface fill angle.
+
+Set an explicit angle to cross the fill direction, which flattens the ridges
+more effectively than ironing along them.",
+        extend("x-group" = "Surfaces", "x-relevant-when" = serde_json::json!({"field": "ironing_enabled", "equals": true}))
+    )]
+    #[serde(default = "SlicingParams::default_ironing_angle")]
+    pub ironing_angle: f64,
 
     #[schemars(
         description = "Custom start G-code block, inserted before the first print move. `null` = flavor default.",
@@ -2285,6 +2378,13 @@ impl Default for SlicingParams {
             raft_layers: Self::default_raft_layers(),
             raft_air_gap: Self::default_raft_air_gap(),
             ironing_enabled: Self::default_ironing_enabled(),
+            ironing_type: IroningType::default(),
+            ironing_flow: Self::default_ironing_flow(),
+            ironing_spacing: Self::default_ironing_spacing(),
+            ironing_speed: Self::default_ironing_speed(),
+            ironing_angle: Self::default_ironing_angle(),
+            xy_size_compensation: Self::default_xy_size_compensation(),
+            xy_hole_compensation: Self::default_xy_hole_compensation(),
             start_gcode: None,
             end_gcode: None,
             layer_gcode: None,
@@ -2472,6 +2572,32 @@ impl SlicingParams {
     fn default_ironing_enabled() -> bool {
         false
     }
+    /// 10 % of a solid bead — enough to re-melt the surface, not enough to
+    /// raise it. Matches the PrusaSlicer/Orca default.
+    fn default_ironing_flow() -> f64 {
+        10.0
+    }
+    /// 0.1 mm, well under a bead width, so each pass overlaps its neighbour and
+    /// the ridges between fill lines are spread rather than traced.
+    fn default_ironing_spacing() -> f64 {
+        0.1
+    }
+    fn default_ironing_speed() -> f64 {
+        20.0
+    }
+    /// `-1` = follow the layer's own surface fill angle.
+    fn default_ironing_angle() -> f64 {
+        -1.0
+    }
+    /// Off. Dimensional compensation corrects a *specific* machine's error, so
+    /// there is no useful non-zero default — and a non-zero one would silently
+    /// resize every part the engine slices.
+    fn default_xy_size_compensation() -> f64 {
+        0.0
+    }
+    fn default_xy_hole_compensation() -> f64 {
+        0.0
+    }
     fn default_thumbnail_enabled() -> bool {
         true
     }
@@ -2500,17 +2626,11 @@ impl SlicingParams {
     ///    registry); this is the same honesty for every other front end.
     ///
     /// Implementation checklist (remove the branch here when each lands):
-    /// - `TODO(profiles): ironing` — top-surface ironing pass.
     /// - `TODO(profiles): supports` — support generation (`normal`/`tree`,
     ///   density). Only `support_threshold_angle` is honoured today.
     /// - `TODO(profiles): multimaterial` — more than one extruder.
     pub fn unsupported_feature_warnings(&self) -> Vec<String> {
         let mut w = Vec::new();
-        if self.ironing_enabled {
-            w.push(
-                "ironing is enabled but the ironing pass is not yet implemented — ignored".into(),
-            );
-        }
         if self.support_enabled {
             w.push(
                 "supports are enabled but support generation is not yet implemented — ignored"

--- a/tests/qa/mod.rs
+++ b/tests/qa/mod.rs
@@ -209,6 +209,11 @@ pub fn canon_role(t: &str) -> String {
     let l = t.trim().to_ascii_lowercase();
     let key = if l.contains("bridge") {
         "bridge"
+    } else if l.contains("ironing") {
+        // Ahead of the "top" test: ironing sweeps a top surface but is measured
+        // separately, and without this it would fall through to `other` and trip
+        // the "new role appeared" check the moment anyone enables it.
+        "ironing"
     } else if l.contains("overhang") {
         "overhang_wall"
     } else if l.contains("skirt") || l.contains("brim") {

--- a/ui/src/app/components/viewer/gcode-layer-renderer.ts
+++ b/ui/src/app/components/viewer/gcode-layer-renderer.ts
@@ -301,6 +301,7 @@ const ROLE_ID_TO_NAME: Record<number, RoleName> = {
   15: 'brim',
   16: 'primeTower',
   17: 'internalBridge',
+  18: 'ironing',
 };
 
 const _dummy = new Object3D();
@@ -413,6 +414,7 @@ function emptyRoleCounts(): Record<RoleName, number> {
     bridge: 0,
     internalBridge: 0,
     topSurface: 0,
+    ironing: 0,
     bottomSurface: 0,
     support: 0,
     supportInterface: 0,

--- a/ui/src/app/services/gcode-preview.ts
+++ b/ui/src/app/services/gcode-preview.ts
@@ -16,6 +16,7 @@ export type RoleName =
   | 'bridge'
   | 'internalBridge'
   | 'topSurface'
+  | 'ironing'
   | 'bottomSurface'
   | 'support'
   | 'supportInterface'
@@ -39,6 +40,7 @@ export const ROLE_COLORS_DARK: RoleColorPalette = {
   bridge: 0x0057ff,
   internalBridge: 0x3a7bff,
   topSurface: 0xff3355,
+  ironing: 0xffd0a0,
   bottomSurface: 0x00bbff,
   support: 0x7dff00,
   supportInterface: 0xb8ff5a,
@@ -60,6 +62,7 @@ export const ROLE_COLORS_LIGHT: RoleColorPalette = {
   bridge: 0x2e5bd6,
   internalBridge: 0x5775dd,
   topSurface: 0xd1263f,
+  ironing: 0xb5763c,
   bottomSurface: 0x1592c4,
   support: 0x7f9c1f,
   supportInterface: 0x95b13a,
@@ -89,6 +92,7 @@ export const ROLE_LABELS: Record<RoleName, string> = {
   bridge: 'Bridge',
   internalBridge: 'Internal Bridge',
   topSurface: 'Top Surface',
+  ironing: 'Ironing',
   bottomSurface: 'Bottom Surface',
   support: 'Support',
   supportInterface: 'Support Interface',
@@ -122,6 +126,7 @@ export const ROLE_ORDER: readonly RoleName[] = [
   'bridge',
   'internalBridge',
   'topSurface',
+  'ironing',
   'bottomSurface',
   'support',
   'supportInterface',
@@ -151,6 +156,7 @@ export const ROLE_GROUPS: readonly RoleGroup[] = [
       'bridge',
       'internalBridge',
       'topSurface',
+      'ironing',
       'bottomSurface',
     ],
   },


### PR DESCRIPTION
Three settings every mature PrusaSlicer/Orca profile sets, none of which the engine honoured. **All three default to off, so the eight committed QA baselines are untouched** — the quality gate passes with no drift.

Closes #94
Closes #104

## Ironing

This one was a live correctness bug, not just a gap. The toggle already shipped in the profile wizard and `docs/use/settings.md` already described it as working, while the engine logged *"ironing is enabled but the ironing pass is not yet implemented — ignored"* and did nothing. A user could enable it, read that it smooths their top surface, and get a log line.

There is now a real pass: a near-dry sweep that re-melts finished top surfaces flat, with type (all top surfaces / topmost only / all solid), flow, spacing, speed and angle.

Two design decisions worth reviewing:

**It carries its own `ExtrusionRole::Ironing` rather than reusing `TopSurface`.** Reuse breaks in four independent places — `resolve_width_mm` returns `top_surface_line_width` *before* it ever reads an explicit width, so a shared role would silently iron at full flow on any profile that sets one (and the default is `0.0`, so that bug would only fire on imported profiles); ironing needs its own speed and acceleration; and path groups are contiguous runs of equal role, so sharing one would let the greedy TSP interleave ironing with fill it is supposed to follow.

**The flow reduction is folded into the width** (`ironing_spacing × ironing_flow`) rather than passed as a flow ratio. `extrusion_for_move` deliberately reads a non-positive flow ratio as `1.0` so a malformed profile cannot zero out a print — so routing a legitimate `ironing_flow = 0` ("wipe only") through it would have laid a **full-width bead at 0.1 mm pitch across the entire top surface**. Pinned by `zero_ironing_flow_deposits_nothing_rather_than_everything`.

The generation happens in place where `top_region` is still live, and touches **no region field**: ironing is a surface treatment, not solid material, and folding its footprint into `solid_regions` would make `add_infill_to_layers` subtract it (grown by a full bead) and punch a hole in the sparse infill underneath.

## Dimensional compensation

Offsets contours between slicing and wall generation — the only point where the rest of the pipeline's measurements stay true. Everything downstream (`calculate_interior_region`'s `−0.5·d` correction, the wall-bead-footprint clip, adhesion's `d/2` outline recovery) is expressed relative to the contour the wall generator consumed, so correcting *that* leaves all of them intact.

**Size and hole deltas are separate fields on purpose.** PrusaSlicer's single `xy_size_compensation` grows the part and therefore tightens holes; Orca's `xy_hole_compensation` enlarges holes directly. Mapping both onto one signed value would get imported Orca profiles wrong by `2δ` on every hole.

Two Clipper2 details that are load-bearing: winding out of the mesh slicer is not guaranteed, so the pass normalises with an `EvenOdd` union first and then uses **`NonZero`** throughout (`Positive` would discard the CW hole sub-paths and fill every hole solid); and holes are resized by *filling them and re-punching at the new size*, because a subtraction alone silently does nothing for a negative delta — the material it would remove is already absent.

Over-aggressive shrinks are reported rather than repaired: a delta large enough to consume a feature is something the user needs to hear about.

## First layer height

Previously it affected only the file header — the shipped default process profile sets `0.24`, `stats.rs` wrote `; first_layer_height = 0.24` into every file, and the engine then printed `0.2`.

The slicer now gives layer 0 its own Z span, **sampled at its own mid-plane so an unset value reproduces the old slicer plane-for-plane** (this is what keeps the QA baselines still). The flow half is applied through the existing `path_heights` override *after* adhesion, so a skirt or brim sharing that layer's Z is charged at the same thickness. Suppressed under a raft, which owns bed contact and is documented to print at `layer_height`.

Both ends and the G-code generator's first-layer detection resolve through one shared `resolved_first_layer_height`, so they cannot disagree about which layer is the first.

## Drive-by fixes

- **The layer-change `;HEIGHT:` marker** announced the global layer height before the paths corrected it, so a viewer sized the opening beads wrong until the first re-announcement.
- **First-layer detection** was bounded by `layer_height`, which swept the *second* layer in whenever the first was thinner than the rest. Now bounded by the first layer's own thickness.
- **`SurfaceConfig` gained a `Default`**, so adding a surface option stops breaking a dozen call sites.

## Verification

- `cargo test` — 824 lib tests + all integration suites pass (24 new).
- `cargo test --test slicing_quality -- --ignored` — **passes with no baseline drift**.
- `cargo clippy --all-targets --all-features` — 7 warnings, byte-identical to the pre-change count, none in touched files.
- `cargo fmt --check` clean.
- Verified end-to-end on a 20 mm cube: `-0.3 mm` compensation moves the printed X span 19.600 → 19.000 (0.3/side); `first_layer_height = 0.3` puts the first plane at Z 0.150 and opens the layer at `;HEIGHT:0.300`; ironing emits `;TYPE:Ironing` with per-move E deltas of ~0.0005 mm.

## Deliberately not here

Elephant-foot compensation, the third part of #104. It is an **L**, not an M, and it is the riskiest change in this area: it perturbs the *comparison* between layers 0 and 1, which feeds bridge detection, bottom-surface detection and overhang classification. `raw_unsupported[1] = perimeters[1] − inflate(perimeters[0], +d/2)` is empty only while `δ < d/2` — 0.2 mm on a 0.4 mm nozzle — so a 0.25 mm elephant-foot value (well within normal) would silently classify the entire second-layer perimeter as an overhang and print it at bridge speed and flow. Doing it properly needs a medial-axis-limited offset (a plain shrink deletes thin first-layer features), a raft gate, and Orca's `elefant_foot_compensation_layers` taper — which incidentally dissolves that cliff by construction. Tracked separately.
