### PR TITLE
ui: make the slicer usable on an iPad, not just narrow

### DIFF
--- a/AGENTS.md
+++ b/AGENTS.md
@@ -533,8 +533,21 @@ everything that adapts goes through one of them — never an ad-hoc `max-width`.
 - **A phone matches all three, so source order decides.** Where two blocks set
   the same property at the same specificity, order them **compact → handheld →
   coarse-pointer** and prefer setting a value in exactly one of them. This is a
-  live foot-gun: `compact()`'s roomier 46vh inspector ceiling silently overrode
-  the phone's deliberate 34vh one until the blocks were swapped.
+  live foot-gun: a roomier `compact()` ceiling once silently overrode the
+  phone's deliberate one, because both set `max-height` and the wrong block came
+  last.
+- **Size a floating panel by the room above it, not by a `vh` fraction.** A
+  fraction is wrong in both directions at once — too small on a short landscape
+  viewport, too generous on a tall portrait one — so the G-code inspector
+  scrolled on a landscape iPad while wasting space in portrait. The rail card is
+  bounded instead by `100dvh` minus the chrome that actually precedes it
+  (titlebar, safe area, toolbar inset, its own margins), and the inspector simply
+  opens to its natural height inside that. Two things make the squeeze safe when
+  the room really does run out: the inspector carries `min-height: 0` so flexbox
+  may shrink it, and the slice row is `flex: none` so the loss never lands on the
+  Slice button. If `dvh` is unsupported the whole `calc()` is invalid and
+  `max-height` falls back to `none` — the old unbounded behaviour, not a broken
+  one.
 - **`html.is-handheld` / `html.is-coarse-pointer` exist only to reach the shared
   components.** [\_handheld.scss](ui/src/styles/base/_handheld.scss) adapts the
   *layout* of `@coldcrabby/ui` primitives that live in another repo (stacking

--- a/AGENTS.md
+++ b/AGENTS.md
@@ -457,39 +457,85 @@ Supporting details:
   is broken. All images of a version share one asset, so deleting a duplicate
   breaks the survivor — purge with `simctl runtime delete all` and re-download.
 
-## Phones — one breakpoint, two answers
+## Phones and tablets — three questions, never one
 
 A handset is not a small desktop: the chrome that surrounds the 3D view (a 60px
 nav rail, a 280px docked settings column, a 380px slice rail) is wider than the
-screen. The UI therefore has **one** definition of "phone", and everything that
-adapts goes through it — never an ad-hoc `max-width` query.
+screen. A **tablet** is the case a single flag gets wrong in both directions — an
+iPad has a desktop's width and a phone's input. Treat it as a phone and it loses
+a docked column it has room for; treat it as a desktop and every panel floating
+over the plate stays open forever, with no cursor to dismiss it, over targets
+sized for a mouse. So there are **three** questions, asked separately, and
+everything that adapts goes through one of them — never an ad-hoc `max-width`.
 
-- **`handheld()`** in [ui/src/styles/\_breakpoints.scss](ui/src/styles/_breakpoints.scss)
-  is the SCSS half: 640px wide, plus a **width-bounded** short-landscape arm so a
-  docked-but-short desktop window is not mistaken for a handset. Tablets keep the
-  desktop layout deliberately — an iPad has the width and the pointer precision.
-  Component styles reach it with `@use 'breakpoints' as *;` (`src/styles` is on
-  the Sass `includePaths`).
-- **[`Viewport`](ui/src/app/services/viewport.ts)** is the TypeScript half, for
-  decisions CSS cannot make — *which controls exist* (the projection toggle, the
-  operation-pipeline inspector) and *whether the settings column may dock at
-  all*. **Its `HANDHELD_MEDIA_QUERY` is a copy of the mixin's condition and the
-  two must never diverge**, or chrome ends up styled for one layout and wired for
-  the other. Keep layout itself in media queries so a phone lays out correctly
-  before any script runs.
-- **`html.is-handheld` exists only to reach the shared components.**
-  [ui/src/styles/base/\_handheld.scss](ui/src/styles/base/_handheld.scss) adapts
-  `@coldcrabby/ui` primitives that live in another repo (stacking
-  `nexus-field-row`, growing 34px controls to 40px). A primitive's `:host` block
-  compiles to an attribute selector, which a bare element selector loses to; the
-  class buys exactly that specificity without `!important`. It is set before
-  first paint by the inline script in `index.html` and kept live by `Viewport`,
-  which `AppShell` constructs so it exists on every route.
+| Question                               | SCSS mixin         | Signal              | Matches                       |
+| -------------------------------------- | ------------------ | ------------------- | ----------------------------- |
+| May the layout keep its desktop shape? | `handheld()`       | `isHandheld()`      | phones                        |
+| Must chrome over the scene fold away?  | `compact()`        | `isCompact()`       | phones, tablets, ≤1024px      |
+| How big must a target be?              | `coarse-pointer()` | `isCoarsePointer()` | phones, tablets, touchscreens |
+
+- **All three live in exactly two files** —
+  [ui/src/styles/\_breakpoints.scss](ui/src/styles/_breakpoints.scss) and
+  [`Viewport`](ui/src/app/services/viewport.ts) — **and their query strings are
+  copies of each other that must never diverge**, or chrome ends up styled for
+  one answer and wired for another. `handheld()` keeps its **width-bounded**
+  short-landscape arm so a docked-but-short desktop window is not mistaken for a
+  handset. Component styles reach the mixins with `@use 'breakpoints' as *;`
+  (`src/styles` is on the Sass `includePaths`).
+- **Width and pointer are orthogonal — do not collapse them into one flag.**
+  `compact()` is about *room*; `coarse-pointer()` is about *precision*. A narrow
+  desktop window needs the first and not the second; a 12.9" iPad needs the
+  second and arguably not the first. Size a target by the pointer, fold a panel
+  by the room. CSS decides layout, TypeScript decides *which controls exist*, and
+  layout stays in media queries so a page lays out correctly before any script.
+- **A phone matches all three, so source order decides.** Where two blocks set
+  the same property at the same specificity, order them **compact → handheld →
+  coarse-pointer** and prefer setting a value in exactly one of them. This is a
+  live foot-gun: `compact()`'s roomier 46vh inspector ceiling silently overrode
+  the phone's deliberate 34vh one until the blocks were swapped.
+- **`html.is-handheld` / `html.is-coarse-pointer` exist only to reach the shared
+  components.** [\_handheld.scss](ui/src/styles/base/_handheld.scss) adapts the
+  *layout* of `@coldcrabby/ui` primitives that live in another repo (stacking
+  `nexus-field-row`, trimming modal gutters);
+  [\_touch.scss](ui/src/styles/base/_touch.scss) adapts their *size* (34px
+  controls to 44px, an 18px slider thumb to 26px — the layer scrubber is a drag
+  gesture and was the worst offender). A primitive's `:host` block compiles to an
+  attribute selector, which a bare element selector loses to; the class buys
+  exactly that specificity without `!important`. Both are set before first paint
+  by the inline script in `index.html` and kept live by `Viewport`, which
+  `AppShell` constructs so they exist on every route.
+- **Anything floating over the plate must fold, and remember.** The G-code
+  inspector and the object list both take a header-with-a-chevron that keeps the
+  one readout worth having (`Layer 42 / 180`, the object count) and hides the
+  rest. The preference is a **tri-state**: `null` until the user states one, at
+  which point the derived default (`!isCompact()`) stops applying and their
+  choice persists across sessions *and* viewports. Do not add a floating panel
+  without one.
 - **Dropping a control is a legitimate answer, hiding a needed one is not.** The
-  viewport cube goes because a drag gizmo has no touch equivalent; projection and
-  the pipeline inspector go because eleven pill buttons do not fit and neither is
-  part of getting a model sliced. Anything on the path to a slice — the object
-  tools, add, undo/redo, the G-code toggle, Slice itself — stays.
+  viewport cube goes on a phone because a drag gizmo has no touch equivalent;
+  projection and the pipeline inspector go because eleven pill buttons do not fit
+  and neither is part of getting a model sliced. Anything on the path to a slice
+  — the object tools, add, undo/redo, the G-code toggle, Slice itself — stays.
+- **Hover-intent must never be armed by a control that unmounts.** The sidebar's
+  peek was armed by the host's own `mouseenter`; hovering the "Print settings"
+  tab opened the drawer, which `@if`-unmounted the tab, which put the pointer on
+  the scene, which fired the matching `mouseleave` — an open/close oscillation
+  that read as flickering. Both arming and closing are now **pointer geometry**
+  (a document `pointermove` compared against the collapsed host's left edge, and
+  against the panel's right edge) rather than element events, because a panel
+  that mounts, unmounts and slides under a stationary pointer emits enter/leave
+  pairs that say nothing about intent. **An invisible edge strip is not the
+  answer** — it needs `pointer-events: auto` to receive `mouseenter`, and since
+  the collapsed host is zero-width it lands on the leftmost slice of the 3D scene
+  for its whole height, swallowing camera drags, click-to-select and (the sidebar
+  being a *sibling* of `<main>`) file drops. The same reasoning applies to the
+  tab's *position*: permanent affordances hang under the toolbar, not at
+  `top: 50%`, which is where the model is.
+- **The `tooltip` directive contributes no accessible name.** An icon-only button
+  whose only label is `[tooltip]` is unlabelled to VoiceOver *and* unlabelled on
+  a tablet, which has no hover to reveal it. Give every icon-only control an
+  `aria-label` mirroring its tooltip at the call site — the directive is in the
+  shared repo and is not ours to change here.
 - **Pinch-to-zoom belongs to the browser everywhere except the 3D canvas.** The
   viewport meta carries no `user-scalable=no` / `maximum-scale`, and
   `touch-action: none` sits on the viewer's `:host`
@@ -499,9 +545,9 @@ adapts goes through it — never an ad-hoc `max-width` query.
   low-vision user has on a phone, and an outright accessibility failure. Lock a
   gesture on the specific surface that claims it; never on the document.
 
-The layout contract (tab bar, drawer, bottom sheet, chip strip) is catalogued in
-[ui/README.md](ui/README.md#phones); the user-facing tour is in
-[docs/use/interface.md](docs/use/interface.md).
+The layout contract (tab bar, drawer, bottom sheet, chip strip, the fold pattern)
+is catalogued in [ui/README.md](ui/README.md#phones-and-tablets); the user-facing
+tour is in [docs/use/interface.md](docs/use/interface.md).
 
 ## Printer connectivity & G-code cache
 

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -29,6 +29,10 @@ issue/PR numbers or repo links in the notes. See the tone rules in
 
 ### Fixed
 
+- **The "Print settings" tab no longer flickers when you hover it** — pointing at
+  the tab used to open the drawer, which hid the tab, which closed the drawer, in
+  a loop. Resting at the very edge of the screen still peeks at the panel; the
+  tab itself now only responds to a click.
 - **Dialogs no longer collapse in Safari** — a dialog with a body ("Running in
   your browser", "What's New", the operation pipeline) drew as a title with the
   buttons jammed underneath and its content squashed to one clipped line. It now
@@ -38,6 +42,19 @@ issue/PR numbers or repo links in the notes. See the tone rules in
 
 ### Added
 
+- **Fold the G-code legend out of the way** — the inspector now has a header you
+  can tap to collapse it to a single row, keeping the layer counter and the Slice
+  button in place. It starts folded on tablets, phones and narrow windows, open
+  on a large screen, and remembers whichever you choose.
+- **Tablet layout** — an iPad keeps the full desktop arrangement but stops
+  leaving panels open over the plate: the G-code inspector and the object list
+  both start folded, and the print-settings tab moved out of the middle of the
+  screen, where the model is. Applies to any window under 1024px, so Split View
+  and a docked desktop window get it too.
+- **Finger-sized controls on touch screens** — buttons, dropdowns, legend chips
+  and the layer slider are now sized for a fingertip on every touch device rather
+  than only on phones. The layer slider's grip went from 18px to 26px; scrubbing
+  through layers on a tablet was the worst of it.
 - **Phone layout** — the whole UI rearranges itself below 640px instead of
   overflowing. Navigation moves to a bottom tab bar, print settings become a
   drawer with a pull tab on the left edge, and Slice sits in a full-width sheet

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -44,13 +44,17 @@ issue/PR numbers or repo links in the notes. See the tone rules in
 
 - **Fold the G-code legend out of the way** — the inspector now has a header you
   can tap to collapse it to a single row, keeping the layer counter and the Slice
-  button in place. It starts folded on tablets, phones and narrow windows, open
-  on a large screen, and remembers whichever you choose.
+  button in place. Unfolded it sizes itself to the room actually available, so on
+  an iPad the whole legend and both sliders are visible without scrolling. It
+  starts folded on tablets, phones and narrow windows, open on a large screen,
+  and remembers whichever you choose.
 - **Tablet layout** — an iPad keeps the full desktop arrangement but stops
   leaving panels open over the plate: the G-code inspector and the object list
   both start folded, and the print-settings tab moved out of the middle of the
-  screen, where the model is. Applies to any window under 1024px, so Split View
-  and a docked desktop window get it too.
+  screen, where the model is. Opening the settings drawer no longer dims the
+  plate behind it — you are peeking at the settings, not leaving the model.
+  Applies to any window under 1024px, so Split View and a docked desktop window
+  get it too.
 - **Finger-sized controls on touch screens** — buttons, dropdowns, legend chips
   and the layer slider are now sized for a fingertip on every touch device rather
   than only on phones. The layer slider's grip went from 18px to 26px; scrubbing

--- a/docs/use/interface.md
+++ b/docs/use/interface.md
@@ -16,8 +16,10 @@ Nothing is hidden behind menus.
 └──────────────┴─────────────────────────────────────┴──────────────┘
 ```
 
-That's the layout on a computer or a tablet. A phone gets the same tools in a
-one-handed arrangement — see [On a phone](#on-a-phone) at the end.
+That's the layout on a computer. A tablet gets the same one with the side panels
+folded down so the plate stays the biggest thing on screen — see
+[On a tablet](#on-a-tablet). A phone gets the same tools in a one-handed
+arrangement — see [On a phone](#on-a-phone).
 
 ## The 3D view
 
@@ -97,6 +99,10 @@ Appears when you switch to preview. Colour the toolpaths by role, speed,
 temperature and more; hide path types you don't care about; scrub through layers
 and through individual moves. See [Reading the preview](/use/preview).
 
+Tap its **G-code** header to fold it away when the legend is in front of what
+you're trying to see — the layer counter stays, the Slice button stays put, and
+the slicer remembers what you chose.
+
 ## Notifications
 
 Messages appear bottom-left — top of the screen on a phone, where the sheet
@@ -147,6 +153,25 @@ Windows — whatever your system accent is set to.
 **Settings → General** has the graphics knobs: field of view, anti-aliasing,
 render resolution and preview detail. Turn them down on a weak GPU, up on a good
 one.
+
+## On a tablet
+
+An iPad has the screen for the full layout but not the mouse, so two things
+change: everything is bigger, and nothing that floats over the plate stays open
+on its own.
+
+- **Panels start folded.** The G-code inspector and the objects list each show
+  just a header — `G-code · 42 / 180`, `Objects 2`. Tap a header to open it, tap
+  again to fold. Your choice sticks from then on.
+- **Print settings are a drawer**, reached from the tab on the left edge just
+  below the toolbar. Tap it to open, tap outside to close. It's out of the middle
+  of the screen on purpose: that's where your model is.
+- **Everything is finger-sized.** Buttons, dropdowns, the layer slider and the
+  legend chips are all sized for a fingertip rather than a cursor.
+
+Split View and Slide Over shrink the window, and the layout follows: below about
+1024 points wide you get the folded arrangement on any device, including a
+narrow window on a desktop.
 
 ## On a phone
 

--- a/docs/use/interface.md
+++ b/docs/use/interface.md
@@ -165,7 +165,10 @@ on its own.
   again to fold. Your choice sticks from then on.
 - **Print settings are a drawer**, reached from the tab on the left edge just
   below the toolbar. Tap it to open, tap outside to close. It's out of the middle
-  of the screen on purpose: that's where your model is.
+  of the screen on purpose: that's where your model is, and the plate stays
+  visible behind the drawer rather than being dimmed out.
+- **Panels use the room they have.** Unfolded, the G-code inspector shows its
+  whole legend and both sliders without scrolling.
 - **Everything is finger-sized.** Buttons, dropdowns, the layer slider and the
   legend chips are all sized for a fingertip rather than a cursor.
 

--- a/docs/use/preview.md
+++ b/docs/use/preview.md
@@ -45,6 +45,11 @@ The legend and its controls are a tall panel sitting over the plate. Tap the
 **G-code** header at the top of the panel to fold it down to a single row — the
 layer counter stays visible, and the Slice button stays where it was.
 
+Unfolded, the panel takes as much room as the screen has, so on a tablet or a
+desktop the whole legend and both sliders are visible at once. It only scrolls
+when the window is genuinely too short — and even then the Slice button stays
+put.
+
 On a tablet or phone it starts folded, since the panel would otherwise cover
 most of what you're trying to look at. On a large screen it starts open. Either
 way, once you fold or unfold it yourself the slicer remembers, and stops

--- a/docs/use/preview.md
+++ b/docs/use/preview.md
@@ -39,6 +39,17 @@ Roles are grouped so you can toggle a whole family at once: **Shell**,
   you can follow the nozzle through a tricky bit.
 - **Hover** any line for its role, layer, Z height, width, height and speed.
 
+## Folding it away
+
+The legend and its controls are a tall panel sitting over the plate. Tap the
+**G-code** header at the top of the panel to fold it down to a single row — the
+layer counter stays visible, and the Slice button stays where it was.
+
+On a tablet or phone it starts folded, since the panel would otherwise cover
+most of what you're trying to look at. On a large screen it starts open. Either
+way, once you fold or unfold it yourself the slicer remembers, and stops
+guessing.
+
 ## What to look for
 
 **Before your first print of a model:**

--- a/ui/README.md
+++ b/ui/README.md
@@ -219,6 +219,16 @@ Until the user folds or unfolds one, the default is derived; afterwards their
 choice is remembered across sessions **and viewports**, because a stated
 preference outranks a guess.
 
+**Unfolded, a panel gets the room that is actually there.** The rail card is
+bounded by `100dvh` minus the chrome above it — titlebar, safe area, toolbar
+inset, its own margins — and the inspector opens to its natural height inside
+that, so on any iPad the whole legend and both sliders are visible without
+scrolling. A `vh` fraction cannot do this: the same number is too small in
+landscape and too generous in portrait. When the room genuinely runs out (a short
+desktop window, a phone) the inspector is the thing that shrinks and scrolls —
+`min-height: 0` lets flexbox squeeze it, and `flex: none` on the slice row means
+the Slice button is never what gets clipped.
+
 What changes on a phone specifically, and why:
 
 | Surface               | Phone form               | Reason                                                                                            |
@@ -242,7 +252,13 @@ edge. Two things about it are deliberate:
 - **It hangs just under the toolbar, not at `top: 50%`.** Vertically centred is
   precisely where the model sits, which is the worst place for a permanent
   affordance. The dock nub shares the same anchor, so toggling the drawer changes
-  the control's form without moving it.
+  the control's form without moving it. Its hover state is **tone and elevation
+  only, never a transform** — the tab's left edge is flush against the nav rail,
+  so nudging it sideways tears a gap open between the two.
+- **The peek has no backdrop.** The scrim element stays (it is what gives touch a
+  tap-outside-to-close gesture) but it is fully transparent: a peek is not a
+  modal, and the point of peeking at the settings is to keep watching the plate
+  while you change them.
 - **The tab does not arm the hover peek — the pointer's own position does.**
   While the peek was armed by the host's own `mouseenter`, hovering the tab
   opened the drawer, which unmounted the tab, which put the pointer on the scene,

--- a/ui/README.md
+++ b/ui/README.md
@@ -138,12 +138,25 @@ lands, `pnpm vendor:ui` brings it in.
 
 ---
 
-## Phones
+## Phones and tablets
 
 The desktop layout assumes horizontal room the slicer does not have on a
 handset: a 60px nav rail, a 280px docked settings column and a 380px slice rail
 add up to more than a 390px screen _is_. Rather than a second app, the same
 shell rearranges itself.
+
+A tablet is the case a single "is it small?" flag gets wrong in both directions.
+An iPad has a desktop's width and a phone's input. Treat it as a phone and it
+loses a docked settings column it has ample room for; treat it as a desktop —
+which is what a lone `handheld()` did — and every panel that floats over the
+plate stays open forever, with no cursor to dismiss it, over targets sized for a
+mouse. So the shell asks three separate questions and answers them independently.
+
+| Question                               | CSS                | TypeScript          | True on                       |
+| -------------------------------------- | ------------------ | ------------------- | ----------------------------- |
+| May the layout keep its desktop shape? | `handheld()`       | `isHandheld()`      | phones                        |
+| Must chrome over the scene fold away?  | `compact()`        | `isCompact()`       | phones, tablets, ≤1024px      |
+| How big must a target be?              | `coarse-pointer()` | `isCoarsePointer()` | phones, tablets, touchscreens |
 
 ```mermaid
 flowchart LR
@@ -151,34 +164,62 @@ flowchart LR
       direction LR
       dr[nav rail] --- ds[settings column] --- dsc[scene] --- drc[slice rail]
     end
+    subgraph T["Tablet"]
+      direction LR
+      tr[nav rail] --- ts[settings drawer] --- tsc[scene] --- trc[folded rail]
+    end
     subgraph P["Phone"]
       direction TB
       pt[toolbar] --- psc[scene] --- prc[slice sheet] --- pn[tab bar]
     end
-    D -->|"handheld()"| P
+    D -->|"compact()"| T
+    T -->|"handheld()"| P
 ```
 
-- **One definition of "phone".** [`styles/_breakpoints.scss`](src/styles/_breakpoints.scss)
-  provides `handheld()` — 640px wide, plus a bounded short-landscape arm for a
-  handset held sideways. Tablets keep the desktop layout: an iPad has the width
-  for a docked column and the pointer precision for the gizmos. Anything that
-  adapts goes through the mixin, so the layout switches over as one piece.
-- **CSS decides the layout; TypeScript decides the controls.**
-  [`services/viewport.ts`](src/app/services/viewport.ts) answers the same
-  question for code that must _not render_ something (the projection toggle, the
-  operation-pipeline inspector, the sidebar's docked state). Its query string is
-  a copy of the mixin's and **must stay identical**. Layout itself stays in media
-  queries so a phone lays out correctly before any script runs.
-- **`html.is-handheld` is for the shared components only.**
-  [`styles/base/_handheld.scss`](src/styles/base/_handheld.scss) adapts
-  `@coldcrabby/ui` primitives we do not own — stacking `nexus-field-row`,
-  growing 34px controls to 40px, trimming modal gutters. A component's own
-  `:host` block compiles to an attribute selector, which a plain element
-  selector loses to; the class buys exactly the specificity needed without
-  `!important`. It is set before first paint by the inline script in
-  `index.html`, and `Viewport` keeps it live.
+- **One definition of each.** [`styles/_breakpoints.scss`](src/styles/_breakpoints.scss)
+  holds all three mixins and [`services/viewport.ts`](src/app/services/viewport.ts)
+  holds their three signals. **The query strings are copies of each other and
+  must stay identical** — CSS switches the layout, TypeScript switches the
+  _controls_ (which ones render at all, whether the settings column may dock),
+  and a disagreement shows up as chrome styled for one answer and wired for
+  another. Layout itself stays in media queries so a page lays out correctly
+  before any script runs.
+- **Width and pointer are orthogonal; do not conflate them.** `compact()` is
+  about _room_, `coarse-pointer()` about _precision_. A narrow desktop window
+  needs the first and not the second; a 12.9" iPad needs the second and not
+  obviously the first. Size a target with the pointer, fold a panel with the room.
+- **Source order matters more than usual.** A phone matches all three queries,
+  so where two blocks set the same property at the same specificity the later
+  one wins. Order them **compact → handheld → coarse-pointer**, and prefer
+  setting a value in exactly one of them.
+- **`html.is-handheld` / `html.is-coarse-pointer` are for the shared components
+  only.** [`_handheld.scss`](src/styles/base/_handheld.scss) adapts the layout of
+  `@coldcrabby/ui` primitives we do not own (stacking `nexus-field-row`, trimming
+  modal gutters); [`_touch.scss`](src/styles/base/_touch.scss) adapts their
+  _size_ (34px controls to 44px, an 18px slider thumb to 26px). A component's own
+  `:host` block compiles to an attribute selector, which a plain element selector
+  loses to; the class buys exactly the specificity needed without `!important`.
+  Both are set before first paint by the inline script in `index.html`, and
+  `Viewport` keeps them live.
 
-What changes, and why:
+### Folding the chrome over the plate
+
+Everything that hovers over the 3D scene can be folded to a header, because on a
+tablet there is no cursor to move away from it and on a phone it is most of the
+screen. The pattern is the same in each: a full-width header button with a
+chevron, the one readout worth keeping while folded, and a preference that
+persists once the user states it.
+
+| Panel            | Header keeps | Default folded |
+| ---------------- | ------------ | -------------- |
+| G-code inspector | Layer N / M  | `isCompact()`  |
+| Object list      | Object count | `isCompact()`  |
+
+Until the user folds or unfolds one, the default is derived; afterwards their
+choice is remembered across sessions **and viewports**, because a stated
+preference outranks a guess.
+
+What changes on a phone specifically, and why:
 
 | Surface               | Phone form               | Reason                                                                                            |
 | --------------------- | ------------------------ | ------------------------------------------------------------------------------------------------- |
@@ -192,6 +233,29 @@ What changes, and why:
 | Viewport cube         | Hidden                   | A click-and-drag widget with no touch equivalent, in the corner a phone can least spare           |
 | Projection · pipeline | Hidden                   | Eleven pill buttons do not fit; neither is part of getting a model sliced                         |
 | Object list           | Collapsible chip         | Expanded it covers a third of the plate it describes                                              |
+
+### The edge tab, and why hover is armed by geometry
+
+Collapsed, the settings drawer leaves a **"Print settings" tab** on the left
+edge. Two things about it are deliberate:
+
+- **It hangs just under the toolbar, not at `top: 50%`.** Vertically centred is
+  precisely where the model sits, which is the worst place for a permanent
+  affordance. The dock nub shares the same anchor, so toggling the drawer changes
+  the control's form without moving it.
+- **The tab does not arm the hover peek — the pointer's own position does.**
+  While the peek was armed by the host's own `mouseenter`, hovering the tab
+  opened the drawer, which unmounted the tab, which put the pointer on the scene,
+  which fired the matching `mouseleave` — open, close, open. Arming now reads
+  `clientX` from a document `pointermove` while the panel is collapsed, so there
+  is no element to unmount. **Do not "simplify" this back to an invisible edge
+  strip**: the strip would need `pointer-events: auto` to receive `mouseenter`,
+  the collapsed host is zero-width, and it would therefore lie over the leftmost
+  slice of the 3D scene for its whole height — swallowing camera drags,
+  click-to-select and, since the sidebar is a _sibling_ of `<main>`, file drops.
+  Closing is the same idea: pointer geometry measured against the panel's edge,
+  not `mouseleave`, because a panel that mounts, unmounts and slides under a
+  stationary pointer emits enter/leave pairs that say nothing about intent.
 
 ---
 

--- a/ui/src/app/components/3d-view-toolbar/3d-view-toolbar.html
+++ b/ui/src/app/components/3d-view-toolbar/3d-view-toolbar.html
@@ -1,13 +1,17 @@
+<!-- Every button here is icon-only, and the `tooltip` directive contributes no
+     accessible name — on a tablet there is no hover to reveal it either, so
+     each one carries an explicit `aria-label` mirroring its tooltip. -->
 <div class="view-group">
   @if (showSecondaryViewTools()) {
+    @let projectionLabel =
+      selectedView() === 'ortho'
+        ? 'Orthographic projection — switch to perspective'
+        : 'Perspective projection — switch to orthographic';
     <button
       class="reset-view-button"
       type="button"
-      [tooltip]="
-        selectedView() === 'ortho'
-          ? 'Orthographic projection — switch to perspective'
-          : 'Perspective projection — switch to orthographic'
-      "
+      [tooltip]="projectionLabel"
+      [attr.aria-label]="projectionLabel"
       [tooltipShortcut]="keyboardShortcuts.shortcutFor('toggle-projection')"
       (click)="toggleProjection()"
     >
@@ -21,6 +25,7 @@
     class="reset-view-button"
     type="button"
     [tooltip]="'Reset camera to default position'"
+    aria-label="Reset camera to default position"
     (click)="resetView()"
   >
     <nexus-icon name="home"></nexus-icon>
@@ -30,14 +35,15 @@
        shows sliced toolpaths, so placing or adding a model would change
        something the user cannot see. -->
   @if (editingPlate()) {
+    @let gravityLabel =
+      gravityEnabled()
+        ? 'Gravity on — objects drop to floor after every move'
+        : 'Gravity off — objects stay where placed';
     <button
       class="reset-view-button"
       type="button"
-      [tooltip]="
-        gravityEnabled()
-          ? 'Gravity on — objects drop to floor after every move'
-          : 'Gravity off — objects stay where placed'
-      "
+      [tooltip]="gravityLabel"
+      [attr.aria-label]="gravityLabel"
       [tooltipShortcut]="keyboardShortcuts.shortcutFor('toggle-gravity')"
       [class.active]="gravityEnabled()"
       [attr.aria-pressed]="gravityEnabled()"
@@ -51,6 +57,7 @@
       type="button"
       [disabled]="addingObjects()"
       [tooltip]="'Add a model to this plate'"
+      aria-label="Add a model to this plate"
       (click)="promptAddObjects()"
     >
       <nexus-icon name="plus"></nexus-icon>
@@ -66,6 +73,7 @@
       type="button"
       [disabled]="!canUndo()"
       [tooltip]="'Undo the last change'"
+      aria-label="Undo the last change"
       [tooltipShortcut]="keyboardShortcuts.shortcutFor('undo')"
       (click)="undo()"
     >
@@ -77,6 +85,7 @@
       type="button"
       [disabled]="!canRedo()"
       [tooltip]="'Redo the last undone change'"
+      aria-label="Redo the last undone change"
       [tooltipShortcut]="keyboardShortcuts.shortcutFor('redo')"
       (click)="redo()"
     >
@@ -107,6 +116,7 @@
         <button
           radioButtonValue="translate"
           [tooltip]="'Select &amp; move — click to select, drag handles to translate'"
+          aria-label="Select and move"
           [tooltipShortcut]="keyboardShortcuts.shortcutFor('object-mode-translate')"
         >
           <nexus-icon name="cursor-pointer"></nexus-icon>
@@ -114,6 +124,7 @@
         <button
           radioButtonValue="rotate"
           [tooltip]="'Rotate around an axis'"
+          aria-label="Rotate around an axis"
           [tooltipShortcut]="keyboardShortcuts.shortcutFor('object-mode-rotate')"
         >
           <nexus-icon name="crop-rotate-br"></nexus-icon>
@@ -121,6 +132,7 @@
         <button
           radioButtonValue="scale"
           [tooltip]="'Scale along axes'"
+          aria-label="Scale along axes"
           [tooltipShortcut]="keyboardShortcuts.shortcutFor('object-mode-scale')"
         >
           <nexus-icon name="enlarge"></nexus-icon>
@@ -128,6 +140,7 @@
         <button
           radioButtonValue="pullToFloor"
           [tooltip]="'Pull a face to the floor'"
+          aria-label="Pull a face to the floor"
           [tooltipShortcut]="keyboardShortcuts.shortcutFor('object-mode-pull-to-floor')"
         >
           <nexus-icon name="constrained-surface"></nexus-icon>
@@ -143,6 +156,7 @@
         [class.active]="placementOpen()"
         [attr.aria-expanded]="placementOpen()"
         [tooltip]="'Place objects — ' + placementSummary()"
+        [attr.aria-label]="'Place objects — ' + placementSummary()"
         [tooltipShortcut]="keyboardShortcuts.shortcutFor('place-objects')"
         (click)="togglePlacement()"
       >
@@ -159,12 +173,14 @@
 
 <div class="view-group">
   @if (hasSliceResult()) {
+    @let viewLabel = viewMode() === 'gcode' ? 'Switch to model view' : 'Switch to G-code preview';
     <button
       class="reset-view-button"
       type="button"
       [class.active]="viewMode() === 'gcode'"
       [attr.aria-pressed]="viewMode() === 'gcode'"
-      [tooltip]="viewMode() === 'gcode' ? 'Switch to model view' : 'Switch to G-code preview'"
+      [tooltip]="viewLabel"
+      [attr.aria-label]="viewLabel"
       [tooltipShortcut]="keyboardShortcuts.shortcutFor('toggle-view-mode')"
       (click)="toggleViewMode()"
     >
@@ -177,6 +193,7 @@
       class="reset-view-button"
       type="button"
       [tooltip]="'Show operation pipeline'"
+      aria-label="Show operation pipeline"
       (click)="showOperationPipeline()"
     >
       <nexus-icon name="developer"></nexus-icon>

--- a/ui/src/app/components/3d-view-toolbar/3d-view-toolbar.scss
+++ b/ui/src/app/components/3d-view-toolbar/3d-view-toolbar.scss
@@ -154,17 +154,24 @@
     display: none;
   }
 
-  .reset-view-button,
-  .button-radio-group button {
-    width: 40px;
-    height: 40px;
-    --icon-size: 19px;
-  }
-
   /* The tool cards are centred on a cluster that can now sit anywhere along a
      wrapped row, so cap them to the screen rather than to their own content. */
   .tool-panels {
     max-width: calc(100vw - 2 * var(--spacing-sm));
+  }
+}
+
+/* Every one of these is a primary action on the plate — select, rotate, add,
+   undo, switch to G-code — and at 34px they were sized for a cursor. Keyed to
+   the pointer rather than the viewport, so it covers the tablet that took the
+   desktop layout as well as the phone. One rule, one number: the phone block
+   above deliberately sets no size of its own. */
+@include coarse-pointer {
+  .reset-view-button,
+  .button-radio-group button {
+    width: 44px;
+    height: 44px;
+    --icon-size: 20px;
   }
 }
 

--- a/ui/src/app/components/objects-panel/objects-panel.scss
+++ b/ui/src/app/components/objects-panel/objects-panel.scss
@@ -257,20 +257,39 @@
     // A quarter of the screen at most — the plate has to stay the subject.
     max-height: 26vh;
   }
+}
+
+// Fingertip sizing, keyed to the pointer so a tablet gets it too. A 22px action
+// under a 34px row was a cursor's target; on touch these were the two buttons
+// most likely to hit the wrong row.
+@include coarse-pointer {
+  .op-head-toggle {
+    min-height: 44px;
+  }
 
   .op-row {
     min-height: 44px;
   }
 
-  // Row actions reveal on hover, which a finger cannot do. Show them outright.
+  // Row actions reveal on hover, which a finger cannot do. Selecting the row
+  // also reveals them, but that makes duplicating a two-tap affair and leaves
+  // the actions undiscoverable until then — so show them outright.
   .op-row-actions {
     opacity: 1;
   }
 
   .op-action {
-    height: 32px;
-    min-width: 32px;
+    height: 36px;
+    min-width: 36px;
 
-    --icon-size: 16px;
+    --icon-size: 17px;
+  }
+
+  // The list is a nested scroller inside a floating card; without this iOS
+  // hands the gesture to the page instead of the list.
+  .op-list {
+    -webkit-overflow-scrolling: touch;
+    touch-action: pan-y;
+    overscroll-behavior: contain;
   }
 }

--- a/ui/src/app/components/objects-panel/objects-panel.ts
+++ b/ui/src/app/components/objects-panel/objects-panel.ts
@@ -53,13 +53,14 @@ export class ObjectsPanel {
   /**
    * Whether the list may be folded away to its header.
    *
-   * On a desktop the panel costs a corner of a large scene and is worth having
-   * open; on a phone the same list covers a third of the plate it describes. So
-   * phones get a header that collapses — the object count stays visible, the
-   * rows come back on tap — and every other size keeps the list open with no
-   * extra control to explain.
+   * On a large desktop scene the panel costs a corner and is worth having open;
+   * anywhere tighter the same list covers a third of the plate it describes,
+   * and on a touch device there is no cursor to move away from it. So compact
+   * viewports and tablets get a header that collapses — the object count stays
+   * visible, the rows come back on tap — while a roomy desktop keeps the list
+   * open with no extra control to explain.
    */
-  protected readonly collapsible = computed(() => this.viewport.isHandheld());
+  protected readonly collapsible = computed(() => this.viewport.isCompact());
 
   private readonly userExpanded = signal(false);
 

--- a/ui/src/app/components/placement-panel/placement-panel.scss
+++ b/ui/src/app/components/placement-panel/placement-panel.scss
@@ -1,3 +1,5 @@
+@use 'breakpoints' as *;
+
 :host {
   display: block;
   pointer-events: none;
@@ -184,5 +186,14 @@
   &:disabled {
     opacity: 0.4;
     cursor: not-allowed;
+  }
+}
+
+/* Matches the transform card's header actions — same row, same size. */
+@include coarse-pointer {
+  .pp-action {
+    width: 36px;
+    height: 36px;
+    --icon-size: 17px;
   }
 }

--- a/ui/src/app/components/slice-segment-bar/slice-segment-bar.html
+++ b/ui/src/app/components/slice-segment-bar/slice-segment-bar.html
@@ -1,4 +1,41 @@
-<div class="insp-shell" [class.is-open]="revealed()">
+<!-- Header: the fold control, and the one readout worth keeping while folded.
+     Sits outside the animated shell so the summary stays legible at every
+     frame of the collapse rather than sliding away with the thing it
+     summarises. -->
+@if (revealed()) {
+  <button
+    class="insp-toggle"
+    type="button"
+    [class.is-open]="expanded()"
+    [attr.aria-expanded]="expanded()"
+    [attr.aria-label]="
+      (expanded() ? 'Hide' : 'Show') + ' G-code legend and controls — layer ' + layerSummary()
+    "
+    (click)="toggleExpanded()"
+  >
+    <span class="insp-toggle-chevron" aria-hidden="true">
+      <svg width="14" height="14" viewBox="0 0 24 24" fill="none" stroke="currentColor">
+        <polyline
+          points="6 9 12 15 18 9"
+          stroke-width="2.5"
+          stroke-linecap="round"
+          stroke-linejoin="round"
+        />
+      </svg>
+    </span>
+    <span class="insp-toggle-title">G-code</span>
+    <!-- Only while folded: expanded, the layer section below owns this readout
+         and a second copy 300px away is noise. -->
+    @if (!expanded()) {
+      <span class="insp-toggle-summary" aria-hidden="true">
+        <span class="cur">{{ preview.layerMax() + 1 }}</span>
+        <span class="tot">/ {{ preview.layerCount() }}</span>
+      </span>
+    }
+  </button>
+}
+
+<div class="insp-shell" [class.is-open]="revealed() && expanded()">
   <div
     class="inspector"
     #inspector

--- a/ui/src/app/components/slice-segment-bar/slice-segment-bar.scss
+++ b/ui/src/app/components/slice-segment-bar/slice-segment-bar.scss
@@ -8,14 +8,18 @@
    The inspector is the tallest thing floating over the plate, so it gets the
    same header-with-a-chevron treatment as the object list: the one readout
    worth keeping stays visible, the rest folds away. Quiet chrome — no border,
-   no fill at rest — because it is on screen the entire time the preview is. */
+   no fill at rest — because it is on screen the entire time the preview is.
+
+   Folded, this row plus the card's padding is the entire cost of the inspector,
+   so it is kept close to the height of its own text rather than padded out to a
+   button's usual size. It sits flush against the divider below it — the divider
+   is the separation, and a margin on top of it only doubles the gap. */
 .insp-toggle {
   display: flex;
   align-items: center;
-  gap: var(--spacing-sm);
+  gap: var(--spacing-xs);
   width: 100%;
-  min-height: 34px;
-  margin-bottom: var(--spacing-xs);
+  min-height: 26px;
   padding: 0 var(--spacing-xs);
   border: 1px solid transparent;
   border-radius: var(--radius-md);
@@ -116,10 +120,14 @@
    pixel range — the easing curve maps 1:1 to the visible motion. The mask
    pins a soft fade to the bottom edge at every frame. */
 .insp-shell {
-  --inspector-fade: 24px;
+  --inspector-fade: 16px;
 
   overflow: hidden;
   max-height: 0;
+  /* Lets flexbox squeeze the shell when the card runs out of room. Without it a
+     flex item refuses to shrink below its content, and the overflow lands on
+     the card instead — clipping the Slice button off the bottom. */
+  min-height: 0;
 
   -webkit-mask-image: linear-gradient(
     to bottom,
@@ -137,6 +145,18 @@
        declare --inspector-height locally here — a local declaration would shadow
        the inherited host value and always win. */
     max-height: var(--inspector-height, 600px);
+    /* Only bites where the card's bound is tighter than the natural height —
+       a short window, or a phone. The scrollbar itself stays hidden: this is a
+       small panel floating over the scene, the mask already fades the cut edge
+       to say "more below", and a stripe would show through the whole reveal
+       animation, when the content is mid-way out by definition. */
+    overflow-y: auto;
+    scrollbar-width: none;
+
+    &::-webkit-scrollbar {
+      width: 0;
+      height: 0;
+    }
   }
 }
 
@@ -164,8 +184,11 @@
   flex-direction: column;
   gap: 10px;
 
+  /* Clearance for the mask's fade, so the last slider is never drawn into it.
+     Kept equal to --inspector-fade: any more is dead space at the bottom of the
+     tallest panel on screen. */
   &:last-child {
-    padding-bottom: var(--spacing-lg);
+    padding-bottom: var(--inspector-fade, 16px);
   }
 }
 
@@ -445,16 +468,12 @@
   flex-shrink: 0;
 }
 
-/* A tablet has the height a phone lacks but still cannot spare the whole plate,
-   and unfolding is now a deliberate act — so the ceiling is generous rather
-   than strict, and the inspector scrolls inside it.
-
-   Must come *before* the phone rule below: a phone matches both queries, the
-   two set the same property at the same specificity, and the phone's tighter
-   ceiling is the one that has to win. */
+/* A tablet has room for the whole inspector — the card above now bounds it by
+   the space actually available, so the only job left here is to let it shrink
+   and scroll on the rare viewport where that space runs out. No `vh` cap: it
+   would either waste room in portrait or force scrolling in landscape. */
 @include compact {
   .insp-shell.is-open {
-    max-height: min(var(--inspector-height, 600px), 46vh);
     overflow-y: auto;
     overscroll-behavior: contain;
     -webkit-overflow-scrolling: touch;
@@ -463,9 +482,8 @@
 
 /* ── Phone ────────────────────────────────────────────────────────────────
    In the bottom sheet the inspector shares a card with the Slice button, and
-   the button must never be the thing that scrolls out of reach. So the
-   inspector takes a fixed share of the screen and scrolls within it — the
-   mask already fades its bottom edge, which reads as "there is more below". */
+   the button must never be the thing that scrolls out of reach. A phone has
+   genuinely too little height for both, so here the fixed share is right. */
 @include handheld {
   .insp-shell.is-open {
     max-height: min(var(--inspector-height, 600px), 34vh);

--- a/ui/src/app/components/slice-segment-bar/slice-segment-bar.scss
+++ b/ui/src/app/components/slice-segment-bar/slice-segment-bar.scss
@@ -4,6 +4,113 @@
   display: contents;
 }
 
+/* ── Fold header ─────────────────────────────────────────────────────────
+   The inspector is the tallest thing floating over the plate, so it gets the
+   same header-with-a-chevron treatment as the object list: the one readout
+   worth keeping stays visible, the rest folds away. Quiet chrome — no border,
+   no fill at rest — because it is on screen the entire time the preview is. */
+.insp-toggle {
+  display: flex;
+  align-items: center;
+  gap: var(--spacing-sm);
+  width: 100%;
+  min-height: 34px;
+  margin-bottom: var(--spacing-xs);
+  padding: 0 var(--spacing-xs);
+  border: 1px solid transparent;
+  border-radius: var(--radius-md);
+  background: transparent;
+  color: var(--color-text-secondary);
+  cursor: pointer;
+  user-select: none;
+  -webkit-user-select: none;
+  touch-action: manipulation;
+  animation: insp-toggle-in var(--duration-normal) var(--ease-decelerate);
+  transition:
+    background-color var(--duration-fast) var(--ease-standard),
+    color var(--duration-fast) var(--ease-standard);
+
+  &:hover {
+    background: var(--color-surface-hover);
+    color: var(--color-text-primary);
+  }
+
+  &:focus-visible {
+    outline: none;
+    border-color: var(--color-focus-ring);
+    box-shadow: inset 0 0 0 1px var(--color-focus-ring);
+  }
+}
+
+.insp-toggle-chevron {
+  flex: none;
+  display: inline-grid;
+  place-items: center;
+  color: var(--color-text-tertiary);
+  /* Folded points right, open points down — the direction the content will go. */
+  transform: rotate(-90deg);
+  transition: transform var(--inspector-duration, 440ms)
+    var(--inspector-ease, cubic-bezier(0.16, 1, 0.3, 1));
+
+  .insp-toggle.is-open & {
+    transform: rotate(0deg);
+  }
+}
+
+.insp-toggle-title {
+  flex: 1;
+  text-align: left;
+  font-size: var(--font-size-2xs);
+  font-weight: var(--font-weight-semibold);
+  letter-spacing: 0.04em;
+  text-transform: uppercase;
+  color: var(--color-text-tertiary);
+}
+
+.insp-toggle-summary {
+  flex: none;
+  display: flex;
+  align-items: baseline;
+  gap: 4px;
+  font-family: var(--font-family-mono);
+  font-variant-numeric: tabular-nums;
+
+  .cur {
+    font-size: var(--font-size-sm);
+    font-weight: var(--font-weight-mono-emphasis);
+    font-variation-settings: 'wght' var(--font-weight-mono-emphasis);
+    color: var(--color-text-primary);
+    line-height: 1;
+  }
+
+  .tot {
+    font-size: var(--font-size-2xs);
+    color: var(--color-text-tertiary);
+    line-height: 1;
+  }
+}
+
+@keyframes insp-toggle-in {
+  from {
+    opacity: 0;
+    transform: translateY(4px);
+  }
+  to {
+    opacity: 1;
+    transform: translateY(0);
+  }
+}
+
+@media (prefers-reduced-motion: reduce) {
+  .insp-toggle {
+    animation: none;
+  }
+
+  .insp-toggle-chevron {
+    transition: none;
+  }
+}
+
 /* Animated reveal: JS measures the inspector's natural scrollHeight before
    opening and sets --inspector-height so max-height animates over the exact
    pixel range — the easing curve maps 1:1 to the visible motion. The mask
@@ -338,22 +445,62 @@
   flex-shrink: 0;
 }
 
+/* A tablet has the height a phone lacks but still cannot spare the whole plate,
+   and unfolding is now a deliberate act — so the ceiling is generous rather
+   than strict, and the inspector scrolls inside it.
+
+   Must come *before* the phone rule below: a phone matches both queries, the
+   two set the same property at the same specificity, and the phone's tighter
+   ceiling is the one that has to win. */
+@include compact {
+  .insp-shell.is-open {
+    max-height: min(var(--inspector-height, 600px), 46vh);
+    overflow-y: auto;
+    overscroll-behavior: contain;
+    -webkit-overflow-scrolling: touch;
+  }
+}
+
 /* ── Phone ────────────────────────────────────────────────────────────────
    In the bottom sheet the inspector shares a card with the Slice button, and
    the button must never be the thing that scrolls out of reach. So the
    inspector takes a fixed share of the screen and scrolls within it — the
    mask already fades its bottom edge, which reads as "there is more below". */
 @include handheld {
-  .insp-shell {
-    &.is-open {
-      max-height: min(var(--inspector-height, 600px), 34vh);
-      overflow-y: auto;
-      overscroll-behavior: contain;
-    }
+  .insp-shell.is-open {
+    max-height: min(var(--inspector-height, 600px), 34vh);
+  }
+}
+
+/* ── Fingertip sizing ────────────────────────────────────────────────────
+   Keyed to the pointer, not the viewport: these are the same targets on a
+   phone and on a 12.9" iPad, and only the latter was missing the treatment. */
+@include coarse-pointer {
+  .insp-toggle {
+    min-height: 44px;
   }
 
-  /* Role chips are a grid of small targets; a finger needs the taller row. */
+  /* 36px rather than the 44px floor: the legend is ~15 chips in a wrap grid, and
+     44 would add ~150px of card for a control used far less than the sliders
+     below it. This clears the 26px cursor size by enough to stop being a
+     coin-flip while keeping the legend scannable in one glance. */
   .role-badge {
-    min-height: 32px;
+    min-height: 36px;
+    padding: 0 12px 0 10px;
+  }
+
+  .stack-toggle {
+    width: 40px;
+    height: 40px;
+  }
+
+  /* The gradient doubles as a scrub track, so it is a drag target — 12px of it
+     is unaimable. Grow the bar and pad the row to keep the legend's rhythm. */
+  .scalar-gradient {
+    height: 20px;
+  }
+
+  .scalar-legend {
+    min-height: 40px;
   }
 }

--- a/ui/src/app/components/slice-segment-bar/slice-segment-bar.ts
+++ b/ui/src/app/components/slice-segment-bar/slice-segment-bar.ts
@@ -25,6 +25,10 @@ import {
 } from '../../services/gcode-preview';
 import { Select, type SelectOption, Slider } from '@coldcrabby/ui';
 import { ViewerControl } from '../../services/viewer-control';
+import { Viewport } from '../../services/viewport';
+
+/** Where the user's fold preference for the inspector is remembered. */
+const STORAGE_EXPANDED_KEY = 'nexus.inspector.expanded';
 
 @Component({
   selector: 'nexus-slice-segment-bar',
@@ -37,6 +41,7 @@ import { ViewerControl } from '../../services/viewer-control';
 export class SliceSegmentBar {
   protected readonly preview = inject(GcodePreview);
   private readonly viewerControl = inject(ViewerControl);
+  private readonly viewport = inject(Viewport);
   private readonly destroyRef = inject(DestroyRef);
   private readonly hostEl = inject(ElementRef<HTMLElement>);
 
@@ -59,6 +64,54 @@ export class SliceSegmentBar {
 
   /** Clamped top index for the layer slider (avoids a −¹1 max during reslice). */
   protected readonly layerMaxIndex = computed(() => Math.max(0, this.preview.layerCount() - 1));
+
+  /**
+   * Whether the legend and controls are showing, as opposed to just the header.
+   *
+   * The inspector is a legend, two dropdowns and two sliders stacked on top of
+   * the Slice button — worth its space on a desktop, and squarely in the way
+   * everywhere else. It is the tallest thing floating over the plate, and on a
+   * touch device there is no cursor to move away from it, so without a fold it
+   * simply stays there.
+   *
+   * `null` means the user has never said, in which case the room available
+   * decides: open where there is a large scene and a cursor, folded on a
+   * tablet, a phone or a narrow window. Once the user folds or unfolds it once,
+   * that answer is theirs and is remembered across sessions and viewports.
+   */
+  private readonly expandedPreference = signal(this.readExpanded());
+
+  protected readonly expanded = computed(
+    () => this.expandedPreference() ?? !this.viewport.isCompact(),
+  );
+
+  /** Spoken form of the header readout, for the toggle's accessible name. */
+  protected readonly layerSummary = computed(
+    () => `${this.preview.layerMax() + 1} of ${this.preview.layerCount()}`,
+  );
+
+  protected toggleExpanded(): void {
+    const next = !this.expanded();
+    this.expandedPreference.set(next);
+    this.saveExpanded(next);
+  }
+
+  private readExpanded(): boolean | null {
+    try {
+      const stored = localStorage.getItem(STORAGE_EXPANDED_KEY);
+      return stored === null ? null : stored === 'true';
+    } catch {
+      return null;
+    }
+  }
+
+  private saveExpanded(expanded: boolean): void {
+    try {
+      localStorage.setItem(STORAGE_EXPANDED_KEY, String(expanded));
+    } catch {
+      /* storage unavailable — the preference is simply not remembered */
+    }
+  }
 
   constructor() {
     effect(() => {

--- a/ui/src/app/components/transform-panel/transform-panel.scss
+++ b/ui/src/app/components/transform-panel/transform-panel.scss
@@ -1,3 +1,5 @@
+@use 'breakpoints' as *;
+
 // Axis indicator hues intentionally mirror the on-canvas gizmo handles
 // (gizmo.ts AXIS_COLORS) so the numeric fields read as the same X/Y/Z the
 // user drags in 3D. These are functional axis cues, not theme colours.
@@ -156,5 +158,17 @@ $axis-z: #3498db;
   }
   &[data-axis='Z'] {
     background: color-mix(in oklab, #{$axis-z} 82%, transparent);
+  }
+}
+
+/* The card's own buttons — centre, drop, reset rotation, reset scale — are
+   36px targets under a fingertip rather than 26px ones under a cursor. Not the
+   full 44px: they sit in a tight header row beside the title, and the card is
+   already the widest thing floating over the plate. */
+@include coarse-pointer {
+  .tp-action {
+    width: 36px;
+    height: 36px;
+    --icon-size: 17px;
   }
 }

--- a/ui/src/app/nexus/layout/slicing-shell/slicing-shell.scss
+++ b/ui/src/app/nexus/layout/slicing-shell/slicing-shell.scss
@@ -99,8 +99,10 @@ $default-inset: 40px;
     padding: var(--spacing-md);
     min-height: 0;
 
-    // When the G-code inspector is open, give the slice-control row a clear
-    // visual separation from the inspector content above it.
+    // Once the G-code inspector is present, give the slice-control row a clear
+    // visual separation from the content above it. Keyed to the inspector's
+    // header rather than its open body: folded, the header is still a row above
+    // the Slice button and still needs the rule.
     // Transitions match the inspector expand so nothing jumps mid-animation.
     ::ng-deep nexus-slice-control .slice-block {
       padding-top: 0;
@@ -110,7 +112,7 @@ $default-inset: 40px;
         border-color var(--inspector-duration) var(--inspector-ease);
     }
 
-    &:has(.insp-shell.is-open) ::ng-deep nexus-slice-control .slice-block {
+    &:has(.insp-toggle) ::ng-deep nexus-slice-control .slice-block {
       padding-top: var(--spacing-md);
       border-color: var(--color-border-light);
     }

--- a/ui/src/app/nexus/layout/slicing-shell/slicing-shell.scss
+++ b/ui/src/app/nexus/layout/slicing-shell/slicing-shell.scss
@@ -99,6 +99,20 @@ $default-inset: 40px;
     padding: var(--spacing-md);
     min-height: 0;
 
+    // Bound the card by the room actually above it — titlebar, toolbar and its
+    // own margins — rather than letting the inspector guess with a `vh`
+    // fraction. Guessing is what made a 500px inspector scroll on a landscape
+    // iPad while leaving space unused in portrait: the same fraction is too
+    // small on a short viewport and too large on a tall one. With the card
+    // bounded, the inspector can simply open to its natural height and only
+    // ever scrolls when the space genuinely is not there.
+    max-height: calc(
+      100dvh - var(--titlebar-height, 44px) - env(safe-area-inset-top, 0px) - var(
+          --main-scene-inset,
+          #{$default-inset}
+        ) - var(--spacing-md) - var(--main-scene-inset, #{$default-inset})
+    );
+
     // Once the G-code inspector is present, give the slice-control row a clear
     // visual separation from the content above it. Keyed to the inspector's
     // header rather than its open body: folded, the header is still a row above
@@ -107,13 +121,19 @@ $default-inset: 40px;
     ::ng-deep nexus-slice-control .slice-block {
       padding-top: 0;
       border-top: 1px solid transparent;
+      // Slice is the reason the card exists: when the card runs out of room the
+      // inspector above gives it up, never this row.
+      flex: none;
       transition:
         padding-top var(--inspector-duration) var(--inspector-ease),
         border-color var(--inspector-duration) var(--inspector-ease);
     }
 
+    // A hairline plus a small gap is enough to separate two rows; the larger
+    // gap was sized for separating two *blocks*, and folded it doubled the
+    // header's apparent height.
     &:has(.insp-toggle) ::ng-deep nexus-slice-control .slice-block {
-      padding-top: var(--spacing-md);
+      padding-top: var(--spacing-sm);
       border-color: var(--color-border-light);
     }
   }

--- a/ui/src/app/nexus/sidebar/sidebar.component.html
+++ b/ui/src/app/nexus/sidebar/sidebar.component.html
@@ -24,7 +24,7 @@
   ></button>
 }
 
-<div class="sidebar-panel">
+<div class="sidebar-panel" #panel>
   <div class="sidebar-content" #scrollContainer (scroll)="onContentScroll($event)">
     <div class="sidebar-content-inner">
       <ng-content />
@@ -52,6 +52,13 @@
 </div>
 
 @if (collapsed() && !isExpanded()) {
+  <!-- The tab is a click target and nothing more. Hover-peek is armed from the
+       pointer's position (see `armEdgeHover` in the component), never from an
+       element: while the peek was armed by the host's own `mouseenter`, hovering
+       this tab opened the drawer, which unmounted the tab, which put the pointer
+       on the scene, which fired the matching `mouseleave` — open, close, open.
+       Arming by geometry has no element to unmount, and lays nothing invisible
+       over the plate. -->
   <button
     class="sidebar-reveal-hint"
     type="button"

--- a/ui/src/app/nexus/sidebar/sidebar.component.scss
+++ b/ui/src/app/nexus/sidebar/sidebar.component.scss
@@ -3,6 +3,13 @@
 $transition-duration: 200ms;
 $transition-easing: ease;
 
+// Both edge controls — the dock nub and the "Print settings" tab — hang at this
+// height rather than at 50%. Centred, they float over the middle of the plate,
+// which is exactly where the model is and the last place a permanent affordance
+// belongs. Anchoring both to the same offset also means toggling the panel
+// changes the control's *form* without moving it.
+$edge-control-top: calc(var(--main-scene-inset, 48px) + var(--spacing-sm));
+
 :host {
   position: relative;
   flex-shrink: 0;
@@ -102,10 +109,10 @@ $transition-easing: ease;
 // bleed, leaving only a rounded nub peeking out on the right.
 .sidebar-pin {
   position: absolute;
-  top: 50%;
+  top: $edge-control-top;
   left: var(--sidebar-w, 280px);
   // Flat left edge flush against the panel's right edge so it reads as glued.
-  transform: translate(0, -50%);
+  transform: translateX(0);
 
   display: inline-flex;
   align-items: center;
@@ -150,7 +157,7 @@ $transition-easing: ease;
   // to the sidebar as it slides out, instead of fading in place. The opacity
   // fade only cleans up the residual nub once it reaches the rail.
   :host.is-collapsed:not(.is-expanded) & {
-    transform: translate(calc(-1 * var(--sidebar-w, 280px)), -50%);
+    transform: translateX(calc(-1 * var(--sidebar-w, 280px)));
     opacity: 0;
     visibility: hidden;
     pointer-events: none;
@@ -246,18 +253,19 @@ $transition-easing: ease;
 
 .sidebar-reveal-hint {
   position: absolute;
-  left: var(--spacing-sm);
-  top: 50%;
-  transform: translateY(-50%);
+  left: 0;
+  top: $edge-control-top;
   display: inline-flex;
   align-items: center;
   gap: var(--spacing-xs);
   min-height: 34px;
-  padding: 0 var(--spacing-sm);
+  padding: 0 var(--spacing-sm) 0 10px;
   border: 1px solid transparent;
-  border-radius: 999px;
+  // Tucked against the rail it emerges from: square on the left, rounded on the
+  // right. Reads as a drawer pull rather than a button dropped on the scene.
+  border-radius: 0 999px 999px 0;
   background: var(--color-surface);
-  color: var(--color-text-secondary);
+  color: var(--color-text-tertiary);
   font-size: var(--font-size-sm);
   font-weight: var(--font-weight-medium);
   letter-spacing: 0.01em;
@@ -267,15 +275,15 @@ $transition-easing: ease;
   box-shadow: var(--shadow-xs);
   transition:
     color var(--duration-fast) var(--ease-standard),
-    border-color var(--duration-fast) var(--ease-standard),
+    background-color var(--duration-fast) var(--ease-standard),
     box-shadow var(--duration-fast) var(--ease-standard),
     transform var(--duration-fast) var(--ease-standard);
 
   &:hover {
     color: var(--color-text-primary);
-    border-color: transparent;
+    background: var(--color-surface-hover);
     box-shadow: var(--shadow-sm);
-    transform: translateY(-50%) translateX(2px);
+    transform: translateX(2px);
   }
 
   &:focus-visible {
@@ -283,6 +291,19 @@ $transition-easing: ease;
     box-shadow:
       var(--shadow-sm),
       0 0 0 2px var(--color-focus-ring);
+  }
+}
+
+// A fingertip needs the full 44px, and there is no hover state to fall back on.
+@include coarse-pointer {
+  .sidebar-reveal-hint {
+    min-height: 44px;
+    padding-right: var(--spacing-md);
+  }
+
+  .sidebar-pin {
+    width: 32px;
+    height: 56px;
   }
 }
 
@@ -358,21 +379,14 @@ $transition-easing: ease;
   }
 
   // The label does not fit beside a full-width launch card or a bottom sheet,
-  // so the handle becomes what it always was underneath: a tab on the edge it
-  // pulls from. Flush to the screen, rounded on the open side only — the same
-  // shape as the desktop dock nub, and unmistakably something to pull.
-  //
-  // It sits directly under the toolbar rather than mid-height: the sheet grows
-  // upward from the bottom as the G-code inspector opens, and anything centred
-  // vertically ends up underneath it.
+  // so the tab drops to its glyph alone. Position and shape are already the
+  // base ones — the desktop tab moved to this anchor rather than the phone
+  // having to correct for a centred one.
   .sidebar-reveal-hint {
-    top: calc(var(--main-scene-inset, 48px) + var(--spacing-sm));
-    left: 0;
-    width: 32px;
+    width: 44px;
     min-height: 60px;
     padding: 0;
     justify-content: center;
-    transform: none;
     border-radius: 0 var(--radius-md) var(--radius-md) 0;
     box-shadow: var(--shadow-md);
 

--- a/ui/src/app/nexus/sidebar/sidebar.component.scss
+++ b/ui/src/app/nexus/sidebar/sidebar.component.scss
@@ -80,9 +80,11 @@ $edge-control-top: calc(var(--main-scene-inset, 48px) + var(--spacing-sm));
   }
 }
 
-// Dismiss layer for an overlay peek. Gives touch (and mouse) a plain
-// tap-outside-to-close gesture, matching every drawer convention — the piece
-// that was missing, leaving iPad users with no way to close a peek.
+// Dismiss layer for an overlay peek. Deliberately **invisible**: it exists only
+// to give touch (and mouse) a plain tap-outside-to-close gesture, which is what
+// iPad had no way to do. Dimming the scene behind it was the wrong call — the
+// panel is a peek, not a modal, and the whole point of peeking is to keep
+// looking at the plate while you adjust it.
 .sidebar-scrim {
   position: fixed;
   inset: 0;
@@ -90,18 +92,8 @@ $edge-control-top: calc(var(--main-scene-inset, 48px) + var(--spacing-sm));
   border: none;
   padding: 0;
   margin: 0;
-  background: var(--scrim, rgba(0, 0, 0, 0.32));
+  background: transparent;
   cursor: default;
-  animation: sidebar-scrim-in $transition-duration $transition-easing;
-}
-
-@keyframes sidebar-scrim-in {
-  from {
-    opacity: 0;
-  }
-  to {
-    opacity: 1;
-  }
 }
 
 // Dock/undock affordance rendered as a tab that sits *behind* the panel: its
@@ -276,14 +268,15 @@ $edge-control-top: calc(var(--main-scene-inset, 48px) + var(--spacing-sm));
   transition:
     color var(--duration-fast) var(--ease-standard),
     background-color var(--duration-fast) var(--ease-standard),
-    box-shadow var(--duration-fast) var(--ease-standard),
-    transform var(--duration-fast) var(--ease-standard);
+    box-shadow var(--duration-fast) var(--ease-standard);
 
+  // Tone and elevation only — never a transform. The tab's left edge is flush
+  // against the nav rail, so nudging it right on hover tears a gap open between
+  // the two and makes a docked control look detached.
   &:hover {
     color: var(--color-text-primary);
     background: var(--color-surface-hover);
     box-shadow: var(--shadow-sm);
-    transform: translateX(2px);
   }
 
   &:focus-visible {
@@ -391,10 +384,6 @@ $edge-control-top: calc(var(--main-scene-inset, 48px) + var(--spacing-sm));
     box-shadow: var(--shadow-md);
 
     --icon-size: 18px;
-
-    &:hover {
-      transform: none;
-    }
 
     // Only the leading glyph survives; the words and the chevron are what did
     // not fit. The button keeps its aria-label, so nothing is lost to a reader.

--- a/ui/src/app/nexus/sidebar/sidebar.ts
+++ b/ui/src/app/nexus/sidebar/sidebar.ts
@@ -4,6 +4,7 @@ import {
   computed,
   DestroyRef,
   DOCUMENT,
+  effect,
   ElementRef,
   HostListener,
   inject,
@@ -23,6 +24,12 @@ const MAX_WIDTH = 480;
 // Hover-intent delays so a collapsed sidebar only opens/closes deliberately.
 const HOVER_OPEN_DELAY_MS = 180;
 const HOVER_CLOSE_DELAY_MS = 240;
+// How far past the panel's edge the pointer must travel before a peek closes.
+// Generous enough that the panel sliding in under a stationary pointer never
+// reads as "the pointer left".
+const HOVER_LEAVE_GRACE_PX = 32;
+// How close to the screen edge a pointer must rest to arm a peek.
+const EDGE_ARM_PX = 14;
 
 @Component({
   selector: 'nexus-sidebar',
@@ -31,8 +38,6 @@ const HOVER_CLOSE_DELAY_MS = 240;
   templateUrl: './sidebar.component.html',
   styleUrl: './sidebar.component.scss',
   host: {
-    '(mouseenter)': 'onMouseEnter()',
-    '(mouseleave)': 'onMouseLeave()',
     '[class.is-collapsed]': 'collapsed()',
     '[class.is-expanded]': 'isExpanded()',
     '[class.is-overlay]': 'isOverlay()',
@@ -68,6 +73,7 @@ export class Sidebar {
   protected readonly showScrollTop = signal(false);
 
   private readonly scrollContainer = viewChild<ElementRef<HTMLElement>>('scrollContainer');
+  private readonly panel = viewChild<ElementRef<HTMLElement>>('panel');
 
   // Only arm hover-intent on devices that truly hover. iOS/iPadOS emit synthetic
   // mouse events on tap with no matching `mouseleave`, which would otherwise leave
@@ -90,6 +96,8 @@ export class Sidebar {
   private dragCleanup: (() => void)[] = [];
   private hoverOpenTimer: ReturnType<typeof setTimeout> | null = null;
   private hoverCloseTimer: ReturnType<typeof setTimeout> | null = null;
+  /** Tears down the document pointer listeners that close a hover peek. */
+  private pointerWatch: (() => void) | null = null;
   private readonly destroyRef = inject(DestroyRef);
 
   constructor() {
@@ -97,8 +105,11 @@ export class Sidebar {
       this.applyCssWidth(this.readWidth());
     });
 
+    this.armEdgeHover();
+
     this.destroyRef.onDestroy(() => {
       this.clearHoverTimers();
+      this.stopPointerWatch();
       for (const fn of this.dragCleanup) {
         fn();
       }
@@ -108,6 +119,7 @@ export class Sidebar {
   /** Reveal the panel (used by the settings-search shortcut). Pins it open. */
   expand(): void {
     this.clearHoverTimers();
+    this.stopPointerWatch();
     if (this.collapsed()) {
       this.hoverPreview.set(false);
       this.overlayOpen.set(true);
@@ -135,40 +147,121 @@ export class Sidebar {
     const next = !this.collapsed();
     this.dockedPreference.set(next);
     this.clearHoverTimers();
+    this.stopPointerWatch();
     this.overlayOpen.set(false);
     this.hoverPreview.set(false);
     this.saveCollapsed(next);
   }
 
-  /** Hover-intent open: only after a short, deliberate hover (pointer devices). */
-  protected onMouseEnter(): void {
-    if (!this.supportsHover || !this.collapsed() || this.overlayOpen()) {
-      return;
-    }
-    this.clearCloseTimer();
-    if (this.hoverPreview() || this.hoverOpenTimer !== null) {
-      return;
-    }
-    this.hoverOpenTimer = setTimeout(() => {
-      this.hoverOpenTimer = null;
-      this.hoverPreview.set(true);
-    }, HOVER_OPEN_DELAY_MS);
+  /**
+   * Hover-intent open, armed by the pointer's position rather than by any
+   * element.
+   *
+   * An invisible strip along the edge would have to be `pointer-events: auto`
+   * to receive `mouseenter`, and the sidebar host is zero-width while collapsed
+   * — so that strip lands squarely on the leftmost slice of the 3D scene, for
+   * its whole height, swallowing camera drags, click-to-select and (because the
+   * sidebar is a *sibling* of `<main>`) file drops. Reading `clientX` instead
+   * costs one comparison per move and lays nothing over the plate.
+   *
+   * Registered only while the panel is collapsed and hidden, so a docked or
+   * open sidebar carries no listener at all.
+   */
+  private armEdgeHover(): void {
+    effect((onCleanup) => {
+      if (!this.supportsHover || !this.collapsed() || this.isExpanded()) {
+        return;
+      }
+      const onMove = (event: PointerEvent): void => {
+        const left = this.el.nativeElement.getBoundingClientRect().left;
+        const atEdge = event.clientX >= left && event.clientX <= left + EDGE_ARM_PX;
+        // The tab overlaps the arming band, and it is a button: aiming at it
+        // should arm a click, not a reveal.
+        const overTab =
+          event.target instanceof Element && event.target.closest('.sidebar-reveal-hint') !== null;
+        if (!atEdge || overTab) {
+          this.clearOpenTimer();
+          return;
+        }
+        if (this.hoverOpenTimer !== null) {
+          return;
+        }
+        this.hoverOpenTimer = setTimeout(() => {
+          this.hoverOpenTimer = null;
+          this.hoverPreview.set(true);
+          this.watchPointerForLeave();
+        }, HOVER_OPEN_DELAY_MS);
+      };
+      this.document.addEventListener('pointermove', onMove);
+      onCleanup(() => {
+        this.document.removeEventListener('pointermove', onMove);
+        this.clearOpenTimer();
+      });
+    });
   }
 
-  /** Hover-intent close: a brief grace period so the panel doesn't flicker. */
-  protected onMouseLeave(): void {
-    if (!this.supportsHover) {
+  /**
+   * Close a hover peek by where the pointer actually *is*, not by a `mouseleave`.
+   *
+   * The panel mounts, unmounts and slides under a stationary pointer, and every
+   * one of those emits enter/leave pairs that say nothing about intent — which
+   * is how the peek used to oscillate. Measuring the distance from the panel's
+   * own edge is immune to all of it: the panel is either under the pointer or
+   * it is not, however it got there.
+   *
+   * The edge is taken from the layout width rather than the animated rect, so a
+   * panel still sliding in is judged by where it is going, not where it is.
+   */
+  private watchPointerForLeave(): void {
+    if (this.pointerWatch) {
       return;
     }
-    this.clearOpenTimer();
-    if (!this.hoverPreview()) {
-      return;
-    }
-    this.clearCloseTimer();
-    this.hoverCloseTimer = setTimeout(() => {
-      this.hoverCloseTimer = null;
+    const onMove = (event: PointerEvent): void => {
+      const panel = this.panel()?.nativeElement;
+      if (!panel) {
+        return;
+      }
+      const edge = this.el.nativeElement.getBoundingClientRect().left + panel.offsetWidth;
+      if (event.clientX <= edge + HOVER_LEAVE_GRACE_PX) {
+        this.clearCloseTimer();
+        return;
+      }
+      if (this.hoverCloseTimer !== null) {
+        return;
+      }
+      this.hoverCloseTimer = setTimeout(() => {
+        this.hoverCloseTimer = null;
+        this.hoverPreview.set(false);
+        this.stopPointerWatch();
+      }, HOVER_CLOSE_DELAY_MS);
+    };
+    // Leaving the window entirely is an unambiguous "done with it" — but so is
+    // an element being unmounted under the pointer, and both arrive as a
+    // `pointerout` with no `relatedTarget`. The tab and the edge strip are both
+    // unmounted the instant the peek opens, so taking that at face value would
+    // close the panel the moment it opened: the very oscillation this watcher
+    // exists to end. A removed node is no longer connected; a window-leave
+    // target still is.
+    const onOut = (event: PointerEvent): void => {
+      const target = event.target as Node | null;
+      if (event.relatedTarget !== null || (target !== null && !target.isConnected)) {
+        return;
+      }
       this.hoverPreview.set(false);
-    }, HOVER_CLOSE_DELAY_MS);
+      this.stopPointerWatch();
+    };
+    this.document.addEventListener('pointermove', onMove);
+    this.document.addEventListener('pointerout', onOut);
+    this.pointerWatch = () => {
+      this.document.removeEventListener('pointermove', onMove);
+      this.document.removeEventListener('pointerout', onOut);
+    };
+  }
+
+  private stopPointerWatch(): void {
+    this.clearCloseTimer();
+    this.pointerWatch?.();
+    this.pointerWatch = null;
   }
 
   /** Reveal-hint tap: open a persistent overlay peek (the primary touch gesture). */
@@ -178,6 +271,7 @@ export class Sidebar {
       return;
     }
     this.clearHoverTimers();
+    this.stopPointerWatch();
     this.hoverPreview.set(false);
     this.overlayOpen.set(true);
   }
@@ -185,6 +279,7 @@ export class Sidebar {
   /** Tap/click the scrim behind an overlay peek to dismiss it (stays hidden). */
   protected dismissOverlay(): void {
     this.clearHoverTimers();
+    this.stopPointerWatch();
     this.overlayOpen.set(false);
     this.hoverPreview.set(false);
   }
@@ -195,6 +290,7 @@ export class Sidebar {
       return;
     }
     this.clearHoverTimers();
+    this.stopPointerWatch();
     this.overlayOpen.set(false);
     this.hoverPreview.set(false);
   }

--- a/ui/src/app/nexus/slice-control/slice-control.scss
+++ b/ui/src/app/nexus/slice-control/slice-control.scss
@@ -437,15 +437,19 @@
 }
 
 /* ── Phone ────────────────────────────────────────────────────────────────
-   In the bottom sheet this row is the primary action bar, so its targets grow
-   to a comfortable size — and the model name yields the space, since it is
-   already named in the title bar above. */
+   In the bottom sheet this row is the primary action bar, so the model name
+   yields space, since it is already named in the title bar above. Height comes
+   from the coarse-pointer rule below, which covers phones too. */
 @include handheld {
   .slice-btn {
-    height: 44px;
     min-width: 96px;
   }
+}
 
+/* Slice is the reason the app exists and Download is what you do next; on a
+   tablet both sat at the 40px cursor size. */
+@include coarse-pointer {
+  .slice-btn,
   .download-btn,
   .send-split {
     height: 44px;

--- a/ui/src/app/services/viewport.ts
+++ b/ui/src/app/services/viewport.ts
@@ -1,4 +1,4 @@
-import { DOCUMENT, Injectable, computed, inject, signal } from '@angular/core';
+import { DOCUMENT, Injectable, computed, inject, signal, type WritableSignal } from '@angular/core';
 
 /**
  * The one definition of "this is a phone", for TypeScript.
@@ -12,11 +12,28 @@ import { DOCUMENT, Injectable, computed, inject, signal } from '@angular/core';
 export const HANDHELD_MEDIA_QUERY =
   '(max-width: 640px), (max-width: 950px) and (max-height: 500px) and (orientation: landscape)';
 
+/**
+ * Touch (or stylus) as the primary input. Mirrors the `coarse-pointer()` mixin.
+ *
+ * Deliberately independent of width: an iPad Pro is wider than most laptops and
+ * still has no cursor to hover with, and no fingertip smaller than ~44px.
+ */
+export const COARSE_POINTER_MEDIA_QUERY = '(pointer: coarse)';
+
+/**
+ * Viewports that cannot leave the floating scene chrome permanently open.
+ * Mirrors the `compact()` mixin — keep the three in sync.
+ */
+export const COMPACT_MEDIA_QUERY = '(max-width: 1024px), (pointer: coarse)';
+
 /** Marks `<html>` while the handheld query matches, for global style overrides. */
 export const HANDHELD_CLASS = 'is-handheld';
 
+/** Marks `<html>` while the pointer is coarse, for the same reason. */
+export const COARSE_POINTER_CLASS = 'is-coarse-pointer';
+
 /**
- * Tracks whether the app is running on a phone-sized viewport.
+ * Tracks how much room and how much pointer precision the app has to work with.
  *
  * Phones are not merely "small desktops": there is no hover, no room for a
  * docked settings column beside the scene, and the bottom of the screen is the
@@ -24,34 +41,88 @@ export const HANDHELD_CLASS = 'is-handheld';
  * offering pointer-shaped affordances (a drag gizmo cube, a resize handle) or
  * niche controls that would push the essentials off-screen.
  *
- * The `<html>` class it maintains is what lets a global stylesheet reach into
+ * Tablets are the case that needs three answers rather than one. An iPad has a
+ * desktop's width and a phone's input, so a single "is it small?" flag gets it
+ * wrong either way: treat it as a phone and it loses the docked column it has
+ * ample room for; treat it as a desktop — which is what a lone `isHandheld`
+ * did — and every panel hovering over the plate stays open forever, with no
+ * cursor to dismiss it and targets sized for a mouse. Hence the split:
+ *
+ * | Signal            | Answers                                        |
+ * | ----------------- | ---------------------------------------------- |
+ * | `isHandheld`      | may the layout keep its desktop shape?         |
+ * | `isCompact`       | must chrome floating over the scene fold away? |
+ * | `isCoarsePointer` | how big must a target be?                      |
+ *
+ * The `<html>` classes it maintains are what let a global stylesheet reach into
  * the shared `@coldcrabby/ui` components, whose `:host` rules outrank a plain
- * element selector. Layout itself is driven by media queries rather than this
- * class, so a phone lays out correctly before any script runs.
+ * element selector. Layout itself is driven by media queries rather than these
+ * classes, so a phone lays out correctly before any script runs.
  */
 @Injectable({ providedIn: 'root' })
 export class Viewport {
   private readonly document = inject(DOCUMENT);
-  private readonly matches = signal(this.query()?.matches ?? false);
+
+  /**
+   * Live `MediaQueryList`s, retained deliberately.
+   *
+   * A `MediaQueryList` is only kept alive by something holding a reference to
+   * it — registering a `change` listener is not enough, and a collected list
+   * stops firing. Dropping these on the floor leaves the signals frozen at
+   * whatever they read during construction, which looks exactly like "the
+   * breakpoint does not work" the first time the window is resized.
+   */
+  private readonly lists: MediaQueryList[] = [];
+
+  private readonly handheldMatches = signal(this.query(HANDHELD_MEDIA_QUERY)?.matches ?? false);
+  private readonly coarseMatches = signal(this.query(COARSE_POINTER_MEDIA_QUERY)?.matches ?? false);
+  private readonly compactMatches = signal(this.query(COMPACT_MEDIA_QUERY)?.matches ?? false);
 
   /** True on phone-sized viewports, in either orientation. Reactive. */
-  readonly isHandheld = computed(() => this.matches());
+  readonly isHandheld = computed(() => this.handheldMatches());
+
+  /**
+   * True where a finger (or pencil) is the pointer — every iPhone and iPad, and
+   * a touchscreen laptop. Ask this to size a target, never to choose a layout.
+   */
+  readonly isCoarsePointer = computed(() => this.coarseMatches());
+
+  /**
+   * True where panels floating over the 3D scene should default to folded —
+   * because the viewport is narrow, or because there is no cursor to dismiss
+   * them with. Implied by {@link isHandheld}.
+   */
+  readonly isCompact = computed(() => this.compactMatches());
 
   constructor() {
-    const query = this.query();
-    query?.addEventListener('change', (event) => {
-      this.matches.set(event.matches);
-      this.syncClass(event.matches);
-    });
-    this.syncClass(this.matches());
+    this.watch(HANDHELD_MEDIA_QUERY, this.handheldMatches, HANDHELD_CLASS);
+    this.watch(COARSE_POINTER_MEDIA_QUERY, this.coarseMatches, COARSE_POINTER_CLASS);
+    this.watch(COMPACT_MEDIA_QUERY, this.compactMatches);
   }
 
-  private query(): MediaQueryList | null {
+  /** Keep one signal — and optionally one `<html>` class — tracking one query. */
+  private watch(query: string, target: WritableSignal<boolean>, className?: string): void {
+    const list = this.query(query);
+    if (list) {
+      this.lists.push(list);
+      list.addEventListener('change', (event) => {
+        target.set(event.matches);
+        if (className) {
+          this.syncClass(className, event.matches);
+        }
+      });
+    }
+    if (className) {
+      this.syncClass(className, target());
+    }
+  }
+
+  private query(query: string): MediaQueryList | null {
     const view = this.document.defaultView;
-    return view?.matchMedia ? view.matchMedia(HANDHELD_MEDIA_QUERY) : null;
+    return view?.matchMedia ? view.matchMedia(query) : null;
   }
 
-  private syncClass(handheld: boolean): void {
-    this.document.documentElement.classList.toggle(HANDHELD_CLASS, handheld);
+  private syncClass(className: string, active: boolean): void {
+    this.document.documentElement.classList.toggle(className, active);
   }
 }

--- a/ui/src/index.html
+++ b/ui/src/index.html
@@ -199,19 +199,24 @@
         }
       })();
 
-      // Mark phone-sized viewports before first paint, for the same reason as
-      // the theme class: the global overrides keyed to it (see
-      // styles/base/_handheld.scss) must not land a frame late. The Viewport
-      // service keeps it live afterwards; the query here is a copy of
-      // HANDHELD_MEDIA_QUERY and must match it.
+      // Mark phone-sized viewports and touch input before first paint, for the
+      // same reason as the theme class: the global overrides keyed to them (see
+      // styles/base/_handheld.scss and _touch.scss) must not land a frame late.
+      // The Viewport service keeps both live afterwards; the queries here are
+      // copies of HANDHELD_MEDIA_QUERY / COARSE_POINTER_MEDIA_QUERY and must
+      // match them.
       (function () {
         if (!window.matchMedia) return;
-        var q = window.matchMedia(
+        var mark = function (query, className) {
+          if (window.matchMedia(query).matches) {
+            document.documentElement.classList.add(className);
+          }
+        };
+        mark(
           '(max-width: 640px), (max-width: 950px) and (max-height: 500px) and (orientation: landscape)',
+          'is-handheld',
         );
-        if (q.matches) {
-          document.documentElement.classList.add('is-handheld');
-        }
+        mark('(pointer: coarse)', 'is-coarse-pointer');
       })();
 
       // iOS Safari ignores `user-scalable=no` in the viewport meta since

--- a/ui/src/styles/_breakpoints.scss
+++ b/ui/src/styles/_breakpoints.scss
@@ -24,11 +24,42 @@
 $handheld-max-width: 640px;
 $handheld-landscape-max-width: 950px;
 $handheld-landscape-max-height: 500px;
+$compact-max-width: 1024px;
 
 /// Phone-sized viewports, in either orientation.
 @mixin handheld {
   @media (max-width: #{$handheld-max-width}),
     (max-width: #{$handheld-landscape-max-width}) and (max-height: #{$handheld-landscape-max-height}) and (orientation: landscape) {
+    @content;
+  }
+}
+
+/// Touch (or stylus) as the primary input — no hover, fingertip-sized targets.
+///
+/// Orthogonal to every width query above: an iPad Pro is wider than most
+/// laptops and still has no cursor. Ask this for *sizing* a target, and
+/// `compact()` for deciding whether chrome may stay open.
+@mixin coarse-pointer {
+  @media (pointer: coarse) {
+    @content;
+  }
+}
+
+/// Viewports that cannot leave the floating scene chrome permanently open.
+///
+/// Distinct from `handheld()`, which is about a layout being impossible. This
+/// is the softer question of whether panels that *hover over the 3D scene* —
+/// the slice rail, the object list — should default to folded. Two independent
+/// reasons say yes:
+///
+/// - **Not enough room.** A 380px rail and a 280px settings column leave an
+///   iPad in portrait (820pt) with a sliver of plate between them.
+/// - **Not enough precision.** Touch has no hover, so a panel cannot be
+///   dismissed by moving away from it; it stays until it is folded.
+///
+/// Phones are wholly contained in the width arm, so `handheld()` implies this.
+@mixin compact {
+  @media (max-width: #{$compact-max-width}), (pointer: coarse) {
     @content;
   }
 }

--- a/ui/src/styles/base/_handheld.scss
+++ b/ui/src/styles/base/_handheld.scss
@@ -44,22 +44,10 @@ html.is-handheld {
   }
 
   // ── Touch targets ───────────────────────────────────────────────────────
-  // 34px controls are sized for a cursor; under a fingertip they are a
-  // coin-flip. 40px is the smallest that stops feeling like a miss.
-  nexus-select .trigger,
-  nexus-number-input .field {
-    height: 40px;
-  }
-
-  input:not([type='checkbox']):not([type='radio']):not([type='range']),
-  select {
-    min-height: 40px;
-  }
-
-  // A dropdown's own options are the same problem one level down.
-  nexus-select .option {
-    min-height: 40px;
-  }
+  // Sizing lives in `_touch.scss`, keyed to the pointer rather than the
+  // viewport — every phone is a coarse pointer, and so is the tablet this rule
+  // used to miss. Only the phone-specific *layout* of these controls is left
+  // here.
 
   // Segmented controls are the app's tab metaphor; on a phone they are also a
   // primary target, so let them use the full width.

--- a/ui/src/styles/base/_touch.scss
+++ b/ui/src/styles/base/_touch.scss
@@ -1,0 +1,52 @@
+/// Coarse-pointer adaptations of the shared `@coldcrabby/ui` components.
+/// @group base
+///
+/// The sibling `_handheld.scss` asks "is this a phone?", which is a question
+/// about *room*. This file asks "is the pointer a fingertip?", which is a
+/// question about *precision* — and on a tablet the two answers differ. An iPad
+/// has a desktop's width, so it takes the desktop layout and every one of these
+/// shared controls at its 34px cursor size: a Color-by dropdown, a layer slider
+/// with an 18px thumb, a select option row. Under a fingertip those are a
+/// coin-flip, and the layer slider is the single most-used control in the whole
+/// G-code preview.
+///
+/// Apple's HIG floor is 44pt, so that is the number here rather than the 40px
+/// the phone rules previously used — one value, applied wherever there is no
+/// cursor, instead of two that drift.
+///
+/// Keyed to `html.is-coarse-pointer` rather than a bare `@media (pointer: coarse)`
+/// for the same reason `_handheld.scss` uses its class: a component's `:host`
+/// block compiles to an attribute selector, which a plain element selector loses
+/// to. The class buys exactly that specificity without `!important`. It is set
+/// before first paint by the inline script in `index.html` and kept live by the
+/// `Viewport` service.
+
+html.is-coarse-pointer {
+  // ── Touch targets ───────────────────────────────────────────────────────
+  nexus-select .trigger,
+  nexus-number-input .field {
+    height: 44px;
+  }
+
+  input:not([type='checkbox']):not([type='radio']):not([type='range']),
+  select {
+    min-height: 44px;
+  }
+
+  // A dropdown's own options are the same problem one level down.
+  nexus-select .option {
+    min-height: 44px;
+  }
+
+  // ── Sliders ─────────────────────────────────────────────────────────────
+  // The component exposes its geometry as custom properties, so this is a
+  // re-tune rather than an override: a thumb a finger can actually catch, on a
+  // track thick enough to aim at, with a taller hit area around both. Scrubbing
+  // layers in the G-code preview is a drag gesture — the one interaction that
+  // fails outright at cursor sizes.
+  nexus-slider .range,
+  nexus-range-slider .range {
+    --thumb: 26px;
+    --track-h: 8px;
+  }
+}

--- a/ui/src/styles/main.scss
+++ b/ui/src/styles/main.scss
@@ -30,6 +30,10 @@
 // Phone-only adaptations of the shared components. MUST come after every
 // partial it overrides.
 @use './base/handheld';
+// Touch-only adaptations of the same components — a superset of phones that
+// also catches tablets. MUST come after `handheld` so the two agree on a
+// control's height wherever both apply.
+@use './base/touch';
 @use 'base/scrollbar';
 @use 'base/floating';
 


### PR DESCRIPTION
## Why

The UI had exactly one definition of "small" — `handheld()`, phones only. An iPad
has a desktop's width and a phone's input, so it fell through to the desktop
branch and got desktop chrome it has no cursor to dismiss, at sizes a fingertip
cannot hit. Every change here follows from splitting that one flag into three
questions asked separately:

| Question | SCSS | TypeScript | Matches |
| --- | --- | --- | --- |
| May the layout keep its desktop shape? | `handheld()` | `isHandheld()` | phones |
| Must chrome over the scene fold away? | `compact()` | `isCompact()` | phones, tablets, ≤1024px |
| How big must a target be? | `coarse-pointer()` | `isCoarsePointer()` | phones, tablets, touchscreens |

Width and pointer are orthogonal: a narrow desktop window needs the first, a
12.9" iPad needs the second.

## What changed

**A foldable G-code inspector.** The legend, two dropdowns and two sliders were
the tallest thing floating over the plate with no way to put them away. There is
now a header — chevron, "G-code", and `243 / 243` shown *only while folded*
(expanded, the layer section owns that readout). Folded it leaves one slim row
with Slice untouched. The preference is tri-state: `null` until the user states
one, so it defaults from `isCompact()` and then persists across sessions *and*
viewports. The object list gained the same treatment on tablets — it was already
foldable, but only on phones.

**Unfolded, it sizes by the room that is actually there.** A `vh` fraction is
wrong in both directions at once — 46vh was too little for the 500px panel on a
landscape iPad and more than it needed in portrait. The rail card is bounded
instead by `100dvh` minus the chrome above it (titlebar, safe area, toolbar
inset, its own margins), and the inspector opens to its natural height inside
that. Measured with real content:

| Viewport | Card allowed | Inspector | Scrolls? |
| --- | --- | --- | --- |
| iPad Pro 13" portrait | 1244px | 500px | no |
| iPad Pro 13" landscape | 900px | 500px | no |
| iPad Pro 11" landscape | 702px | 500px | no |
| Short desktop window (560px tall) | 428px | 309px | yes |

Where the room genuinely runs out the inspector is what shrinks: `min-height: 0`
lets flexbox squeeze it and `flex: none` on the slice row means **Slice is never
what gets clipped**. If `dvh` is unsupported the whole `calc()` is invalid and
`max-height` falls back to `none` — the old unbounded behaviour, not a broken one.

**The "Print settings" tab.** It sat at `top: 50%`, which is exactly where the
model is; it now hangs under the toolbar, and the dock nub shares the anchor so
toggling changes the control's form without moving it. Its hover no longer
nudges it 2px right — the tab is flush against the nav rail, so that tore a
visible gap open between the two. The peek's backdrop is gone: a peek is not a
modal, and the point of it is to change a setting *while watching the plate*. The
scrim element stays, because it is what gives touch tap-outside-to-close.

**A hover-flicker fix.** Hover-intent was armed by the host's own `mouseenter`:
hovering the tab opened the drawer, which `@if`-unmounted the tab, which put the
pointer on the scene, which fired the matching `mouseleave` — open, close, open.
Arming and closing are both pointer geometry now, so there is no element to
unmount.

**Touch targets**, keyed to the *pointer* rather than the viewport, so the tablet
that took the desktop layout stops taking the desktop sizes with it. New
`_touch.scss` reaches the shared `@coldcrabby/ui` primitives the way
`_handheld.scss` already reaches their layout — the layer scrubber's grip goes
18px → 26px, which matters most because scrubbing is a drag. Icon-only toolbar
buttons gained `aria-label`s: the `tooltip` directive contributes no accessible
name, and a tablet has no hover to reveal it anyway.

## For reviewers

- **A phone matches all three queries, so source order decides.** Where two
  blocks set the same property at the same specificity, they are ordered
  **compact → handheld → coarse-pointer**. A roomier `compact()` ceiling silently
  overrode the phone's deliberate one until the blocks were swapped — worth a
  look in `slice-segment-bar.scss` and `slicing-shell.scss`.
- **The first cut of the hover fix was wrong and is worth knowing about.** It
  used an invisible 14px edge strip; because the collapsed sidebar host is
  zero-width, that strip lay over the leftmost slice of the 3D scene for its full
  height, swallowing camera drags, click-to-select and — the sidebar being a
  *sibling* of `<main>` — file drops. Caught in review and replaced with the
  geometry check. There is a comment in `sidebar.ts` so nobody "simplifies" it
  back.
- No engine changes; this is chrome only. It composes cleanly with the
  pinch-to-zoom work already on main — that fixed gestures *inside* the canvas,
  this fixes the chrome *around* it.

## Testing

128/128 UI unit tests pass. Behaviour was verified in a real browser at iPad
Pro 13"/11" portrait and landscape, iPad mini, iPhone portrait/landscape and
desktop sizes — fold defaults, persistence, the hover state machine (rest on tab
→ nothing, rest on edge → opens, hold still → stays, move away → closes), and
that Slice is never clipped.

**Not yet verified on real hardware.** The test browser page runs hidden, which
freezes CSS transitions and suppresses `ResizeObserver`/resize events, so
measurements were taken with the observer stood in for manually. The CSS is
verified; the *animation* into these sizes deserves a pass on a device —
`pnpm run ios:install` (just landed on main) is the way to do it.
