### PR TITLE
ui: make tap, long-press and drag work on iPad and with the Pencil

### DIFF
--- a/AGENTS.md
+++ b/AGENTS.md
@@ -604,6 +604,62 @@ The layout contract (tab bar, drawer, bottom sheet, chip strip, the fold pattern
 is catalogued in [ui/README.md](ui/README.md#phones-and-tablets); the user-facing
 tour is in [docs/use/interface.md](docs/use/interface.md).
 
+## Touch and pen in the 3D viewport
+
+A tablet keeps the desktop layout but not the desktop pointer. Everything the
+viewport does about that lives in
+[scene/selection.ts](ui/src/app/components/viewer/scene/selection.ts), gated on
+`Viewport.isCoarsePointer()` rather than on size. The catalogue is in
+[ui/README.md](ui/README.md#touch-and-pen); the load-bearing rules:
+
+- **Tap tolerance is per pointer type** (`TAP_SLOP_PX`: mouse 4px, pen 9, touch
+  16). One mouse-sized threshold for all three is what made tapping a model on
+  an iPad do *nothing* — a fingertip is a ~10mm disc whose reported centre
+  wanders as the skin flattens, so most real taps drifted past 4px and were
+  discarded as drags, leaving the objects list as the only way to select
+  anything. Pinned by
+  [selection.spec.ts](ui/src/app/components/viewer/scene/selection.spec.ts).
+- **A tap resolves on the lift, never the press**, so a mis-aimed press can be
+  dragged off to cancel. That includes pull-to-floor, where the press only
+  *paints* the candidate face — there is no hover on touch to paint it earlier.
+- **Additive selection is a mode, not a modifier.** `ViewerControl.additiveSelection`
+  is offered from the tool cluster on touch-primary devices only, and the
+  toolbar clears it whenever the button is not shown, so the mode can never be
+  left on with no control to turn it off.
+- **Long-press is the right-click**, recognised in `SceneSelection` because iOS
+  never fires `contextmenu` for one. The gesture only *asks* — the viewer owns
+  what goes in the menu, via `SceneSelectionHandlers.contextMenu`. **Right-click
+  is driven off the mouse button's own press and release**, not the `contextmenu`
+  event: Windows raises that after the button comes up and macOS the moment it
+  goes down, so only the button's travel can separate a right *click* from the
+  right *drag* that pans the camera.
+- **Direct drag is deliberately narrow** — touch or pen, translate mode, and an
+  object that is *already selected*. Requiring a prior tap means a stray swipe
+  can never shove a model across the plate, and drag-to-orbit stays everywhere
+  else.
+- **The camera is shut out at `pointerdown`, and only for a press the drag will
+  claim.** At the target the DOM runs capture-flagged listeners before
+  non-capture ones **whatever the registration order** — OrbitControls listens
+  on the same canvas without capture, so a `stopPropagation()` from
+  `SceneSelection`'s capture handler stops it starting a rotate at all, and
+  there is nothing to wrestle it away from once the drag begins. Every *other*
+  press on a model is deliberately let through: dragging from a model the user
+  has not picked used to do nothing at all, which on a touch screen makes a dead
+  zone of most of the scene. Both directions are pinned by a bubble-phase probe
+  in the spec; break the invariant and the view spins under the dragged object.
+- **Never stop the lift.** Because only *some* presses are withheld, blocking a
+  `pointerup` strands OrbitControls mid-gesture in the ones it *was* let into —
+  its pointer-up handler is on the **document**, so a stop at the canvas reaches
+  it, and without it the pointer stays tracked, `state` never returns to `NONE`,
+  and the next button-less move orbits the view. On touch it is worse: the next
+  single finger reads as a second contact, and one-finger orbit stops working
+  entirely after the first tap on a model. The only stops that survive are on
+  `pointermove` inside a live drag, whose `pointerdown` was withheld too, so a
+  bubble consumer is absent for the whole gesture rather than half of it.
+- **Palm rejection sits above all of it** ([pointer-arbiter.ts](ui/src/app/components/viewer/scene/pointer-arbiter.ts)),
+  on the host element in the capture phase, so a resting wrist never reaches
+  these handlers at all.
+
 ## Printer connectivity & G-code cache
 
 [src/printer/](src/printer/) is the **native-only** (`cfg(not(target_arch = "wasm32"))`)
@@ -1019,7 +1075,7 @@ accept more, so the UI keeps a strict split of responsibilities:
 - **Contextual tool cards hang off the tools that open them.** Both cards render inside [3d-view-toolbar.html](ui/src/app/components/3d-view-toolbar/3d-view-toolbar.html), in a `.tool-panels` column **absolutely positioned** under the `.tool-cluster` and centred on it, so they follow the buttons instead of sitting in a screen corner the user has to connect them to. Absolute positioning is what makes this safe: the toolbar's own `contentRect` height is unchanged, so the shell's `--main-scene-inset` (and with it the viewport-cube and slice rail) never shifts as cards appear — that invariant is why the transform card originally lived in the shell. The column stacks, so transform + placement can be open at once; the container is `pointer-events: none` so gaps stay click-through to the scene. The toolbar's own pill rules must keep their `:host ` prefix — `nexus-card` styles itself with `:host(.small){border-radius:var(--radius-md)}`, which a bare class selector ties on specificity and loses to on order, squaring off the pill.
 - **[`TransformPanel`](ui/src/app/components/transform-panel/transform-panel.ts) edits the whole selection, not one object.** It used to render nothing unless *exactly one* object was selected, which made a multi-object plate untransformable. Position edits apply as a **delta** off the selection's combined AABB centre (so a spread-out arrangement keeps its layout rather than collapsing onto one coordinate); rotation and scale are set **per object** about each one's own centre, and `setSize` measures each object's own AABB so a batch of different-sized parts all reach the requested size. A single-object selection is the exact previous behaviour — the anchor is then its own translation, so an edit is still an absolute set. The header shows `"N objects"` for a batch and **nothing** for one; it deliberately does not name the file (every duplicate shares a name, so it identified nothing).
 - **`preferred_orientation_deg` lives on the printer profile**, not in the plate preferences, because it describes the machine (CoreXY prints everything at 45°). Settings → Printers is the **only** editor; the placement popover shows it read-only and links there, so one machine's angle is never changed from a plate-scoped surface. It rides along inside `orient_options.preferred_z_rotation_deg` and is therefore **only applied when auto-orient runs** — the popover says so rather than showing a live-looking value that does nothing. The CLI's equivalent is `MachineConfig::preferred_print_rotation_deg`, fed in by `SliceCommand::arrange_options`.
-- **Plate-editing chrome hides in G-code preview.** The placement control, add-model button, gravity toggle, gizmo-mode group and objects list are all gated on `viewMode() === 'model'`, and the `A` shortcut matches only there. Preview shows toolpaths, so an edit made from it changes something the user cannot see change.
+- **Plate-editing chrome hides in G-code preview.** The placement control, add-model button, gravity toggle, multi-select toggle, gizmo-mode group and objects list are all gated on `viewMode() === 'model'`, and the `A` shortcut matches only there. Preview shows toolpaths, so an edit made from it changes something the user cannot see change. The scene's context menu is gated the same way.
 - **The viewer mirrors, it does not own.** `Viewer.syncWasmMeshes()` diffs `sceneEngine.objects()` against its Three.js nodes and adds/disposes to match, so an object created by *anyone* (add button, `Duplicate`, undo) renders without the viewer being told. Do not add a second place that constructs display meshes.
 - **`SlicerFile` holds a list, not a file.** `files` accumulates `{fileId, filename}`; `upload(file)` appends and attaches to the open workplate. `fetchFile` adopts a file as the *primary* displayed model (it sets `selectedFile`, which retargets the viewer's `model` input); additional objects must use **`downloadFile`**, which registers without touching `selectedFile` — otherwise restoring an N-object plate leaves only the last file on screen.
 - **`toSliceDtos`** ([scene-slice-dto.ts](ui/src/app/runtime/adapters/cloud/scene-slice-dto.ts)) resolves each object to its file via `source_id` and throws rather than guessing. It is a pure function with tests pinning the regression; keep the mapping there, not inline in the runtime adapter.
@@ -1816,5 +1872,5 @@ infill within the ring.
 
 ---
 
-**Last Updated**: 2026-08-31 (standalone iOS installs on a free Apple ID; docs site consumes the shared UI design tokens; UI bundle-chunking contract)  
+**Last Updated**: 2026-08-31 (touch, pen and the context menu in the 3D viewport; standalone iOS installs on a free Apple ID; docs site consumes the shared UI design tokens)  
 **Maintainer Guidance**: Keep this file in sync with project structure changes, new conventions, or significant architectural decisions.

--- a/AGENTS.md
+++ b/AGENTS.md
@@ -656,6 +656,20 @@ viewport does about that lives in
   entirely after the first tap on a model. The only stops that survive are on
   `pointermove` inside a live drag, whose `pointerdown` was withheld too, so a
   bubble consumer is absent for the whole gesture rather than half of it.
+- **A raycast hit is not a visible hit.** Three's `Raycaster` filters on
+  `layers` and **never on `visible`**, so hidden geometry reports hits like any
+  other. This is not academic: `GizmoManager.hitTest` — the touch/pen-only path
+  that asks "did this press land on a transform handle?" — raycasts
+  TransformControls' *pickers*, which are invisible-by-design shapes much larger
+  than the handles they stand for. A detached gizmo parks them at the origin,
+  i.e. the middle of the bed, so every tap near the centre of an empty plate was
+  swallowed as "on the gizmo" and **no model could be selected by touch or pen at
+  all** — the original iPad complaint, and invisible to a mouse, which reaches
+  `isHovering()` instead. Anything deciding "did the user touch this?" from a
+  raycast must apply visibility itself (`isVisibleWithin`), and check that the
+  gizmo is attached and enabled first. Pinned by
+  [gizmo.spec.ts](ui/src/app/components/viewer/gizmo.spec.ts), which also asserts
+  the three.js behaviour so a future release changing it is noticed.
 - **Palm rejection sits above all of it** ([pointer-arbiter.ts](ui/src/app/components/viewer/scene/pointer-arbiter.ts)),
   on the host element in the capture phase, so a resting wrist never reaches
   these handlers at all.

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -29,11 +29,15 @@ issue/PR numbers or repo links in the notes. See the tone rules in
 
 ### Fixed
 
-- **Tapping a model on a tablet now selects it** — a fingertip never lands and
-  lifts on the same pixel, and the viewport judged every tap by a mouse-sized
-  4px tolerance, so most taps with a finger or an Apple Pencil were discarded as
-  drags and the objects list was the only way to select anything. Taps are now
-  judged per pointer: 4px for a mouse, 9 for a pen, 16 for a finger.
+- **Tapping a model on a tablet now selects it** — two separate faults made touch
+  and Pencil selection fail. An invisible transform-gizmo hit area sat parked at
+  the centre of the bed whenever nothing was selected, and swallowed any tap that
+  landed on it; that check runs only for touch and pen, so a mouse never saw it.
+  Selection was also judged by a mouse-sized 4px tolerance, and a fingertip is a
+  ~10mm disc whose reported centre wanders as the skin flattens, so most real
+  taps were discarded as drags. Taps are now judged per pointer — 4px for a
+  mouse, 9 for a pen, 16 for a finger — and a hidden gizmo no longer intercepts
+  anything.
 - **Plates holding several models now slice correctly everywhere** — a workplate
   is a build plate, not a file, but only the hosted slicer treated it that way.
   The desktop app sliced every object out of the *first* model, so a second one

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -29,6 +29,11 @@ issue/PR numbers or repo links in the notes. See the tone rules in
 
 ### Fixed
 
+- **Tapping a model on a tablet now selects it** — a fingertip never lands and
+  lifts on the same pixel, and the viewport judged every tap by a mouse-sized
+  4px tolerance, so most taps with a finger or an Apple Pencil were discarded as
+  drags and the objects list was the only way to select anything. Taps are now
+  judged per pointer: 4px for a mouse, 9 for a pen, 16 for a finger.
 - **Plates holding several models now slice correctly everywhere** — a workplate
   is a build plate, not a file, but only the hosted slicer treated it that way.
   The desktop app sliced every object out of the *first* model, so a second one
@@ -99,6 +104,18 @@ issue/PR numbers or repo links in the notes. See the tone rules in
   and the layer slider are now sized for a fingertip on every touch device rather
   than only on phones. The layer slider's grip went from 18px to 26px; scrubbing
   through layers on a tablet was the worst of it.
+- **A context menu on the plate** — right-click a model, or press and hold it on
+  a touch screen, for Duplicate, Drop to floor, Centre on bed and Remove, acting
+  on the whole selection when you have one. Holding empty bed offers select all,
+  clear, place objects and reset view.
+- **Multi-select for touch and pen** — a tool-cluster toggle that makes each tap
+  add or remove an object, standing in for the ⌘/Ctrl a tablet has no key for.
+  It appears once there are two objects to choose between, and turns itself off
+  when it can no longer be reached.
+- **Drag a selected model across the bed** — with a finger or a pen, select a
+  model and then drag it. Dragging anywhere else still orbits, so nothing moves
+  unless you picked it first. The move handles are also drawn larger on touch,
+  so a fingertip can pick one axis instead of all three.
 - **Phone layout** — the whole UI rearranges itself below 640px instead of
   overflowing. Navigation moves to a bottom tab bar, print settings become a
   drawer with a pull tab on the left edge, and Slice sits in a full-width sheet
@@ -139,6 +156,9 @@ issue/PR numbers or repo links in the notes. See the tone rules in
   labelled rows stack so a dropdown gets the full width, toasts move to the top
   of the screen (the bottom now belongs to the slice sheet), and the object list
   folds to a chip that still flags a part that cannot print.
+- **The object list remembers whether you folded it** — it starts folded on a
+  tablet or a narrow window, and unfolding it now sticks instead of resetting on
+  the next visit.
 - **Two controls are hidden on phones** — the viewport cube, which needs a drag
   it cannot receive, and the projection toggle and operation-pipeline inspector,
   which do not fit alongside the tools that get a model sliced. All three return

--- a/docs/use/interface.md
+++ b/docs/use/interface.md
@@ -28,6 +28,12 @@ The bed, the print volume, and your models. Navigate it the way you'd expect:
 - **Drag** to orbit, **scroll** to zoom, **right-drag** (or two fingers on a
   trackpad) to pan.
 - **Click** a model to select it, `Esc` to deselect, `Ctrl`/`⌘ + A` to select all.
+- **`Ctrl`/`⌘` or `Shift` + click** adds to the selection. On a touch screen use
+  the **Multi-select** tool instead — see
+  [Working the plate with a finger or a pen](#working-the-plate-with-a-finger-or-a-pen).
+- **Right-click** (or **press and hold** on a touch screen) a model for
+  duplicate, drop to floor, centre and remove, without leaving the plate. On
+  empty bed you get the plate-wide actions instead.
 - The **viewport cube** top-right snaps the camera to a face, edge or corner.
   Click its centre to return home.
 - `Shift + Space` switches between perspective and orthographic. Orthographic is
@@ -52,6 +58,7 @@ Floating under the model, this is where you manipulate what's on the plate.
 | **Rotate**          | `R` | Spin around an axis                                  |
 | **Scale**           | `S` | Resize, uniformly or per axis                        |
 | **Pull to floor**   | `F` | Click a face; that face becomes the bottom           |
+| **Multi-select**    |     | Touch screens only — each tap adds or removes        |
 | **Place objects**   | `A` | Auto-arrange everything on the bed                   |
 | **Add a model**     |     | Same as dropping a file in                           |
 | **Gravity**         | `G` | Objects drop to the floor after every move           |
@@ -86,6 +93,11 @@ shouldn't.
 
 Each row also has **Duplicate** and **Remove**. Remove asks once ("Click again
 to remove") before it does anything.
+
+On a touch screen the panel starts **folded** to a chip with the object count,
+because it sits on top of the plate it describes and a finger can't hover it out
+of the way. Tap the chip to unfold it; it stays however you leave it. A warning
+triangle appears on the folded chip if something can't print where it sits.
 
 ## The slice button (bottom right)
 
@@ -180,6 +192,28 @@ on its own.
 Split View and Slide Over shrink the window, and the layout follows: below about
 1024 points wide you get the folded arrangement on any device, including a
 narrow window on a desktop.
+
+### Working the plate with a finger or a pen
+
+- **Tap a model to select it.** Tapping is judged generously: a fingertip is a
+  wide, soft target that never lands and lifts on the same pixel, so a tap still
+  counts as a tap even when it slides a little. Tap empty bed to deselect.
+- **Multi-select**, in the tool cluster, is the stand-in for holding `⌘`/`Ctrl`.
+  Turn it on and each tap adds an object to the selection or takes it back out;
+  turn it off to go back to one-at-a-time. It appears once there are at least two
+  objects to choose between, and only where there's no modifier key to hold.
+- **Press and hold** a model for the same menu a right-click gives: duplicate,
+  drop to floor, centre, remove — acting on the whole selection if you have one.
+  Hold on empty bed for select all, clear, place objects and reset view.
+- **Drag a selected model to slide it across the bed.** Select it first, then
+  drag: one deliberate tap means nothing gets shoved out of place by a stray
+  swipe. Dragging anywhere else still orbits the camera, and the move handles
+  are drawn larger so a fingertip can pick one axis rather than all three.
+- **Palm rejection** is on by default. While a pen is in use, the hand resting on
+  the glass is ignored, so the view doesn't lurch mid-stroke. Turn it off in
+  **Settings → General → Controls** if you never use a stylus.
+
+Two fingers pinch to zoom, drag to pan and twist to roll, anywhere on the plate.
 
 ## On a phone
 

--- a/docs/use/plate.md
+++ b/docs/use/plate.md
@@ -44,7 +44,15 @@ rotate.
 if you deliberately want something floating — for example when you're checking
 a support-free overhang.
 
+On a touch screen you can skip the handles for a simple reposition: tap a model
+to select it, then drag it straight across the bed. Dragging anywhere else
+orbits, so nothing moves unless you picked it first.
+
 ### Editing several objects at once
+
+Hold `Ctrl`/`⌘` or `Shift` and click to add models to the selection, or use
+`Ctrl`/`⌘ + A` for all of them. Without a keyboard, turn on **Multi-select** in
+the tool cluster and every tap adds or removes one.
 
 Select more than one and the card keeps working:
 
@@ -72,7 +80,11 @@ that would fight with the arrangement.
 
 ## Duplicating and deleting
 
-In the objects panel on the right, each row has **Duplicate** and **Remove**.
+Right-click a model — or press and hold it on a touch screen — for **Duplicate**,
+**Drop to floor**, **Centre on bed** and **Remove**, right where the model is. If
+you have several selected, the menu acts on all of them.
+
+The objects panel has the same **Duplicate** and **Remove** on each row. There,
 Remove asks once before it takes effect.
 
 Duplicates are cheap — they share the original's geometry.

--- a/ui/README.md
+++ b/ui/README.md
@@ -278,6 +278,91 @@ edge. Two things about it are deliberate:
 
 ---
 
+## Touch and pen
+
+A tablet keeps the desktop *layout* — it has the width — but not the desktop
+*pointer*. Everything below is about the second half, and lives behind
+`Viewport.isCoarsePointer()` rather than `isHandheld()`.
+
+```mermaid
+flowchart TB
+    down["pointerdown"] --> hit{"raycast hit?"}
+    hit -->|object| grab{"selected object,<br/>translate mode,<br/>touch or pen?"}
+    hit -->|empty| press2["press: null"]
+    grab -->|yes| claim["press: hitId<br/>camera shut out"]
+    grab -->|no| press["press: hitId<br/>camera keeps it"]
+    claim --> drift{"drift &gt; slop?"}
+    press --> drift
+    press2 --> drift
+    drift -->|no, held 500ms| menu["context menu"]
+    drift -->|no, lifted| act["select / clear"]
+    drift -->|"yes, and claimed"| drag["slide across bed"]
+    drift -->|"yes, otherwise"| orbit["camera orbits"]
+```
+
+Everything in that flow is [`scene/selection.ts`](src/app/components/viewer/scene/selection.ts).
+The rules worth knowing before editing it:
+
+- **Tap slop is per pointer type** (`TAP_SLOP_PX`): 4px for a mouse, 9 for a pen,
+  16 for a finger. One mouse-sized threshold for all three is what made tapping a
+  model on an iPad do nothing at all — a fingertip is a ~10mm disc whose reported
+  centre wanders as the skin flattens, so most real taps drifted past it and were
+  discarded as drags. Any change here is a change to whether touch selection
+  works; [`selection.spec.ts`](src/app/components/viewer/scene/selection.spec.ts)
+  pins it.
+- **A tap resolves on the lift, never the press.** That is what lets a
+  mis-aimed press be dragged off to cancel — including in pull-to-floor, where
+  the press only *paints* the candidate face (there is no hover on touch to paint
+  it earlier) and the lift commits it.
+- **Additive selection has no modifier on touch**, so `ViewerControl.additiveSelection`
+  is a real mode, toggled from the tool cluster and offered only on
+  touch-primary devices with more than one object on the plate. Without it a
+  multi-object selection could only be built from the objects list.
+- **The long press is the right-click.** iOS never fires `contextmenu` for one,
+  so it is recognised from the press itself; the menu is asked for through
+  `SceneSelectionHandlers.contextMenu`, and the viewer decides what goes in it.
+  **Right-click is driven off the button's press and release, not the
+  `contextmenu` event** — Windows raises that after the button comes up and macOS
+  the moment it goes down, so only the button's own travel can tell a right
+  *click* from the right *drag* that pans the camera.
+- **Direct drag is deliberately narrow**: touch or pen, translate mode, and an
+  object that is *already* selected. Requiring a prior tap means a model can
+  never be shoved across the plate by a stray swipe, and drag-to-orbit stays
+  available everywhere else.
+- **OrbitControls listens on the same canvas without capture**, and at the target
+  the DOM runs capture-flagged listeners before non-capture ones *whatever the
+  registration order*. So a `stopPropagation()` from `SceneSelection`'s capture
+  handler at `pointerdown` stops the camera starting a rotate at all — which is
+  why the drag needs no hand-off once it begins. It is applied only to a press
+  the drag will claim; every other press on a model is let through, because
+  dragging from a model the user has not picked used to do nothing, making a
+  dead zone of most of the scene. A bubble-phase probe in the spec pins both
+  directions; break the invariant and the view spins under the dragged object.
+- **The lift is never stopped**, whatever the press turned out to be. Since only
+  *some* presses are withheld, blocking a `pointerup` strands OrbitControls
+  mid-gesture in the ones it *was* let into: its pointer-up handler lives on the
+  **document**, so a stop at the canvas reaches it, and without it the pointer
+  stays tracked, `state` never returns to `NONE`, and the next button-less move
+  orbits the view — on touch, the next single finger reads as a second contact
+  and one-finger orbit dies outright. The only surviving stops are on
+  `pointermove` inside a live drag, whose `pointerdown` was withheld too, so a
+  bubble consumer is absent for the whole gesture rather than half of it.
+- **Palm rejection sits above all of it** in
+  [`scene/pointer-arbiter.ts`](src/app/components/viewer/scene/pointer-arbiter.ts),
+  on the host element in the capture phase, so a resting wrist never reaches any
+  of these handlers.
+
+| Surface        | Touch form                     | Reason                                                                    |
+| -------------- | ------------------------------ | ------------------------------------------------------------------------- |
+| Tap on a model | Selects it                     | The objects list was the only working path                                |
+| Multi-select   | Tool-cluster toggle            | There is no ⌘/Ctrl to hold                                                 |
+| Long press     | Object / plate context menu    | Puts duplicate, drop, centre, remove where the model is                   |
+| Selected model | Drags across the bed           | Three axis arrows inside one contact patch is a coin toss                 |
+| Gizmo          | Scaled up (`setSize` 1.4)      | Scaling the helper scales its pickable geometry with it                   |
+| Object list    | Starts folded, 44px rows       | It sits on the plate it describes, and cannot be hovered out of the way   |
+
+---
+
 ## Monaco Transmit Preview
 
 The **transmit preview panel** is a toggleable side panel that shows, in real time, the exact JSON payloads that the UI would send to the server when a slice job starts.

--- a/ui/src/app/components/3d-view-toolbar/3d-view-toolbar.html
+++ b/ui/src/app/components/3d-view-toolbar/3d-view-toolbar.html
@@ -151,6 +151,26 @@
            It is an action rather than a mode, hence outside the radio group;
            like its neighbours it reveals a card of sub-settings below. -->
       <span class="tool-divider" aria-hidden="true"></span>
+
+      <!-- Touch and pen have no ⌘/Ctrl to hold, so building a multi-object
+           selection needs a control of its own. Offered only where there is no
+           modifier key to reach for. -->
+      @if (showMultiSelect()) {
+        <button
+          type="button"
+          [class.active]="multiSelect()"
+          [attr.aria-pressed]="multiSelect()"
+          [tooltip]="
+            multiSelect()
+              ? 'Multi-select on — each tap adds or removes an object'
+              : 'Multi-select — tap several objects to work on them together'
+          "
+          (click)="toggleMultiSelect()"
+        >
+          <nexus-icon name="frame-select"></nexus-icon>
+        </button>
+      }
+
       <button
         type="button"
         [class.active]="placementOpen()"

--- a/ui/src/app/components/3d-view-toolbar/3d-view-toolbar.scss
+++ b/ui/src/app/components/3d-view-toolbar/3d-view-toolbar.scss
@@ -137,8 +137,7 @@
    remaining pills are a few pixels wider than a 375px screen. Wrapping is the
    honest answer: every control stays reachable and the toolbar simply grows a
    second row, which --main-scene-inset already tracks, so the scene chrome
-   below re-inserts itself correctly. Buttons grow to a proper touch target in
-   the process — 34px is a mouse-sized hit area. */
+   below re-inserts itself correctly. */
 @include handheld {
   :host {
     flex-wrap: wrap;

--- a/ui/src/app/components/3d-view-toolbar/3d-view-toolbar.ts
+++ b/ui/src/app/components/3d-view-toolbar/3d-view-toolbar.ts
@@ -2,8 +2,10 @@ import {
   ChangeDetectionStrategy,
   Component,
   computed,
+  effect,
   inject,
   signal,
+  untracked,
   viewChild,
 } from '@angular/core';
 import type { ElementRef } from '@angular/core';
@@ -13,6 +15,7 @@ import { GcodePreview } from '../../services/gcode-preview';
 import { HistoryControlsPreference } from '../../services/history-controls-preference';
 import { KeyboardShortcuts } from '../../services/keyboard-shortcuts/keyboard-shortcuts';
 import { NotificationService } from '../../services/notifications';
+import { SceneEngine } from '../../services/scene-engine';
 import { SceneHistory } from '../../services/scene-history/scene-history';
 import { Slicer } from '../../services/slicer';
 import { ViewerControl } from '../../services/viewer-control';
@@ -54,6 +57,7 @@ export class ThreeDViewToolbar {
   private readonly arrange = inject(Arrange);
   private readonly history = inject(SceneHistory);
   private readonly viewport = inject(Viewport);
+  private readonly sceneEngine = inject(SceneEngine);
   protected readonly historyControls = inject(HistoryControlsPreference);
   protected readonly keyboardShortcuts = inject(KeyboardShortcuts);
 
@@ -83,6 +87,40 @@ export class ThreeDViewToolbar {
    * cannot see — the same reason the objects list hides.
    */
   protected readonly editingPlate = computed(() => this.viewMode() === 'model');
+
+  /** Whether taps add to the selection instead of replacing it. */
+  protected readonly multiSelect = this.viewerControl.additiveSelection;
+
+  /**
+   * Whether to offer the multi-select toggle.
+   *
+   * A mouse already has ⌘/Ctrl-click, so the button would be redundant chrome
+   * there; a finger and a pencil have no modifier at all, which is what used to
+   * make the objects list the only way to select a batch. Pointless with fewer
+   * than two objects on the plate, so it only appears once there is something
+   * to add to.
+   */
+  protected readonly showMultiSelect = computed(
+    () =>
+      this.editingPlate() &&
+      this.viewport.isCoarsePointer() &&
+      this.sceneEngine.objects().length > 1,
+  );
+
+  protected toggleMultiSelect(): void {
+    this.multiSelect.update((on) => !on);
+  }
+
+  constructor() {
+    // Never leave the mode on with no control to turn it off — dropping to one
+    // object, or switching to G-code preview, would otherwise strand an
+    // invisible setting that quietly changes what the next tap does.
+    effect(() => {
+      if (!this.showMultiSelect() && untracked(this.multiSelect)) {
+        this.multiSelect.set(false);
+      }
+    });
+  }
 
   /**
    * Whether to show the on-canvas undo/redo buttons. They exist for

--- a/ui/src/app/components/objects-panel/objects-panel.scss
+++ b/ui/src/app/components/objects-panel/objects-panel.scss
@@ -20,6 +20,13 @@
   box-shadow: var(--shadow-md);
 
   animation: op-in var(--duration-fast) var(--ease-standard);
+
+  // Folded, this is just a label: let it shrink to the words. Not scoped to
+  // phones — the panel folds on any compact viewport, and a tablet holding a
+  // 232px-wide chip with one word in it is the thing folding was meant to fix.
+  &.is-collapsed {
+    width: auto;
+  }
 }
 
 @keyframes op-in {
@@ -246,11 +253,6 @@
   .objects-panel {
     width: min(74vw, 232px);
     padding: var(--spacing-xs) var(--spacing-sm);
-  }
-
-  .objects-panel.is-collapsed {
-    // Folded, this is just a label: let it shrink to the words.
-    width: auto;
   }
 
   .op-list {

--- a/ui/src/app/components/objects-panel/objects-panel.ts
+++ b/ui/src/app/components/objects-panel/objects-panel.ts
@@ -1,9 +1,13 @@
 import { ChangeDetectionStrategy, Component, computed, inject, signal } from '@angular/core';
+import { BrowserStorage } from '../../services/browser-storage';
 import { SceneEngine, type SceneObjectSnapshot } from '../../services/scene-engine';
 import { ViewerControl } from '../../services/viewer-control';
 import { Viewport } from '../../services/viewport';
 import { WorkplateObjects } from '../../services/workplate-objects';
 import { Icon, TooltipDirective } from '@coldcrabby/ui';
+
+/** Remembers whether the user folded the list away, per device. */
+const EXPANDED_KEY = 'plate.objectsPanelExpanded';
 
 /** One row in the list, with its selection and placement state resolved. */
 interface ObjectRow {
@@ -46,6 +50,7 @@ export class ObjectsPanel {
   private readonly sceneEngine = inject(SceneEngine);
   private readonly viewerControl = inject(ViewerControl);
   private readonly viewport = inject(Viewport);
+  private readonly storage = inject(BrowserStorage);
 
   /** Id awaiting delete confirmation, if any. */
   protected readonly pendingDelete = signal<bigint | null>(null);
@@ -62,13 +67,22 @@ export class ObjectsPanel {
    */
   protected readonly collapsible = computed(() => this.viewport.isCompact());
 
-  private readonly userExpanded = signal(false);
+  private readonly storedExpanded = this.storage.get(EXPANDED_KEY, 'local');
 
-  /** Whether the object rows are showing. Always true where there is room. */
-  protected readonly expanded = computed(() => !this.collapsible() || this.userExpanded());
+  /**
+   * Whether the object rows are showing. Always true where there is room.
+   *
+   * Folded is the default wherever it can fold: the complaint the fold answers
+   * is that the list is in the way, so it starts out of the way. The header
+   * keeps the count and the warning flag, so a plate that cannot print still
+   * says so. The choice is remembered per device.
+   */
+  protected readonly expanded = computed(
+    () => !this.collapsible() || this.storedExpanded() === 'true',
+  );
 
   protected toggleExpanded(): void {
-    this.userExpanded.update((open) => !open);
+    this.storage.write(EXPANDED_KEY, this.expanded() ? 'false' : 'true', 'local');
   }
 
   /**
@@ -113,10 +127,12 @@ export class ObjectsPanel {
 
   protected select(row: ObjectRow, event: Event): void {
     // Angular types `(keydown.enter)` as a plain Event, so narrow rather than
-    // assume the modifier keys are present.
+    // assume the modifier keys are present. Multi-select mode stands in for the
+    // modifier on touch, so a tapped row behaves like a tapped model.
     const additive =
-      (event instanceof MouseEvent || event instanceof KeyboardEvent) &&
-      (event.shiftKey || event.metaKey || event.ctrlKey);
+      this.viewerControl.additiveSelection() ||
+      ((event instanceof MouseEvent || event instanceof KeyboardEvent) &&
+        (event.shiftKey || event.metaKey || event.ctrlKey));
     const current = this.viewerControl.selectedObjectIds();
     if (!additive) {
       this.viewerControl.selectedObjectIds.set([row.id]);

--- a/ui/src/app/components/viewer/gizmo.spec.ts
+++ b/ui/src/app/components/viewer/gizmo.spec.ts
@@ -1,0 +1,82 @@
+import {
+  BoxGeometry,
+  Mesh,
+  MeshBasicMaterial,
+  Object3D,
+  PerspectiveCamera,
+  Raycaster,
+} from 'three';
+import { describe, expect, it } from 'vitest';
+import { isVisibleWithin } from './gizmo';
+
+describe('isVisibleWithin', () => {
+  function box(): Mesh {
+    return new Mesh(new BoxGeometry(1, 1, 1), new MeshBasicMaterial());
+  }
+
+  it('accepts a visible object inside a visible root', () => {
+    const root = new Object3D();
+    const child = box();
+    root.add(child);
+    expect(isVisibleWithin(child, root)).toBe(true);
+  });
+
+  it('rejects an object hidden by itself', () => {
+    const root = new Object3D();
+    const child = box();
+    child.visible = false;
+    root.add(child);
+    expect(isVisibleWithin(child, root)).toBe(false);
+  });
+
+  // The case that broke tap-to-select: a detached gizmo hides its root, but
+  // every picker underneath stays `visible` and keeps reporting raycast hits.
+  it('rejects a visible object inside a hidden root', () => {
+    const root = new Object3D();
+    const child = box();
+    root.add(child);
+    root.visible = false;
+    expect(isVisibleWithin(child, root)).toBe(false);
+  });
+
+  it('rejects an object hidden by an intermediate ancestor', () => {
+    const root = new Object3D();
+    const middle = new Object3D();
+    const child = box();
+    middle.visible = false;
+    root.add(middle);
+    middle.add(child);
+    expect(isVisibleWithin(child, root)).toBe(false);
+  });
+
+  it('rejects an object that is not in the subtree at all', () => {
+    const root = new Object3D();
+    const stranger = box();
+    expect(isVisibleWithin(stranger, root)).toBe(false);
+  });
+});
+
+// Pins the three.js behaviour the guard exists to compensate for. If a future
+// three release starts honouring `visible`, this test says so rather than
+// leaving a mysterious extra check behind.
+describe('Raycaster visibility (three.js behaviour)', () => {
+  it('still reports hits against hidden geometry', () => {
+    const camera = new PerspectiveCamera(50, 1, 0.1, 100);
+    camera.position.set(0, 0, 5);
+    camera.updateMatrixWorld(true);
+
+    const root = new Object3D();
+    const target = new Mesh(new BoxGeometry(2, 2, 2), new MeshBasicMaterial());
+    root.add(target);
+    root.visible = false;
+    root.updateMatrixWorld(true);
+
+    const raycaster = new Raycaster();
+    raycaster.setFromCamera({ x: 0, y: 0 } as never, camera);
+
+    expect(raycaster.intersectObject(root, true).length).toBeGreaterThan(0);
+    expect(
+      raycaster.intersectObject(root, true).some((hit) => isVisibleWithin(hit.object, root)),
+    ).toBe(false);
+  });
+});

--- a/ui/src/app/components/viewer/gizmo.spec.ts
+++ b/ui/src/app/components/viewer/gizmo.spec.ts
@@ -5,9 +5,15 @@ import {
   Object3D,
   PerspectiveCamera,
   Raycaster,
+  Scene,
+  Vector3,
 } from 'three';
-import { describe, expect, it } from 'vitest';
-import { isVisibleWithin } from './gizmo';
+import type { WebGLRenderer } from 'three';
+import { afterEach, beforeEach, describe, expect, it } from 'vitest';
+import { GizmoManager, isTransformControlsPlane, isVisibleWithin } from './gizmo';
+
+const CANVAS_SIZE = 400;
+const CENTRE = CANVAS_SIZE / 2;
 
 describe('isVisibleWithin', () => {
   function box(): Mesh {
@@ -29,8 +35,8 @@ describe('isVisibleWithin', () => {
     expect(isVisibleWithin(child, root)).toBe(false);
   });
 
-  // The case that broke tap-to-select: a detached gizmo hides its root, but
-  // every picker underneath stays `visible` and keeps reporting raycast hits.
+  // A detached gizmo hides its root, but every picker underneath stays
+  // `visible` and keeps reporting raycast hits.
   it('rejects a visible object inside a hidden root', () => {
     const root = new Object3D();
     const child = box();
@@ -50,15 +56,13 @@ describe('isVisibleWithin', () => {
   });
 
   it('rejects an object that is not in the subtree at all', () => {
-    const root = new Object3D();
-    const stranger = box();
-    expect(isVisibleWithin(stranger, root)).toBe(false);
+    expect(isVisibleWithin(box(), new Object3D())).toBe(false);
   });
 });
 
-// Pins the three.js behaviour the guard exists to compensate for. If a future
-// three release starts honouring `visible`, this test says so rather than
-// leaving a mysterious extra check behind.
+// Pins the three.js behaviour the guards exist to compensate for. If a future
+// three release starts honouring `visible`, this says so rather than leaving a
+// mysterious extra check behind.
 describe('Raycaster visibility (three.js behaviour)', () => {
   it('still reports hits against hidden geometry', () => {
     const camera = new PerspectiveCamera(50, 1, 0.1, 100);
@@ -66,8 +70,7 @@ describe('Raycaster visibility (three.js behaviour)', () => {
     camera.updateMatrixWorld(true);
 
     const root = new Object3D();
-    const target = new Mesh(new BoxGeometry(2, 2, 2), new MeshBasicMaterial());
-    root.add(target);
+    root.add(new Mesh(new BoxGeometry(2, 2, 2), new MeshBasicMaterial()));
     root.visible = false;
     root.updateMatrixWorld(true);
 
@@ -78,5 +81,97 @@ describe('Raycaster visibility (three.js behaviour)', () => {
     expect(
       raycaster.intersectObject(root, true).some((hit) => isVisibleWithin(hit.object, root)),
     ).toBe(false);
+  });
+});
+
+/**
+ * `hitTest` decides whether a touch or pen press landed on a transform handle,
+ * and a false positive silently eats the press — no selection, no deselection,
+ * no context menu. It runs for touch and pen only, so nothing here is reachable
+ * with a mouse, which is why both bugs it guards against shipped unnoticed.
+ */
+describe('GizmoManager.hitTest', () => {
+  let canvas: HTMLCanvasElement;
+  let gizmo: GizmoManager;
+  let camera: PerspectiveCamera;
+
+  function hitTestAt(x: number, y: number): boolean {
+    const event = new Event('pointerdown', { bubbles: true }) as PointerEvent;
+    Object.assign(event, { pointerType: 'touch', pointerId: 1, clientX: x, clientY: y });
+    return gizmo.hitTest(event, camera, { domElement: canvas } as unknown as WebGLRenderer);
+  }
+
+  beforeEach(() => {
+    canvas = document.createElement('canvas');
+    canvas.getBoundingClientRect = () =>
+      ({
+        x: 0,
+        y: 0,
+        top: 0,
+        left: 0,
+        right: CANVAS_SIZE,
+        bottom: CANVAS_SIZE,
+        width: CANVAS_SIZE,
+        height: CANVAS_SIZE,
+        toJSON: () => ({}),
+      }) as DOMRect;
+    document.body.appendChild(canvas);
+
+    const scene = new Scene();
+    camera = new PerspectiveCamera(50, 1, 0.1, 1000);
+    // Looking down -Z at the origin, where an attached gizmo sits.
+    camera.position.set(0, 0, 60);
+    camera.updateMatrixWorld(true);
+
+    gizmo = new GizmoManager(scene, camera, { domElement: canvas } as unknown as WebGLRenderer);
+  });
+
+  afterEach(() => {
+    gizmo.dispose();
+    canvas.remove();
+  });
+
+  // A detached gizmo is only *hidden*, and it parks its pickers at the origin —
+  // the middle of the bed. Every tap there was eaten, so on a tablet no model
+  // could be selected at all.
+  it('reports no hit while nothing is selected, even dead centre', () => {
+    gizmo.setMode('translate', null);
+    expect(hitTestAt(CENTRE, CENTRE)).toBe(false);
+  });
+
+  it('reports no hit in a mode that shows no handles', () => {
+    gizmo.setMode('none', new Vector3(0, 0, 0));
+    expect(hitTestAt(CENTRE, CENTRE)).toBe(false);
+  });
+
+  describe('with a selection attached', () => {
+    beforeEach(() => {
+      gizmo.setMode('translate', new Vector3(0, 0, 0));
+    });
+
+    it('reports a hit on the handles themselves', () => {
+      expect(hitTestAt(CENTRE, CENTRE)).toBe(true);
+    });
+
+    // The helper carries a 100000x100000 drag-projection plane whose *material*
+    // is invisible but whose object is visible, so it is hit everywhere on
+    // screen. That made it impossible to deselect, or to pick a different
+    // model, once anything was selected.
+    it('reports no hit in the far corner, where only the drag plane reaches', () => {
+      expect(hitTestAt(4, 4)).toBe(false);
+      expect(hitTestAt(CANVAS_SIZE - 4, CANVAS_SIZE - 4)).toBe(false);
+    });
+  });
+});
+
+describe('isTransformControlsPlane', () => {
+  it('is false for ordinary objects', () => {
+    expect(isTransformControlsPlane(new Object3D())).toBe(false);
+  });
+
+  it("is true for an object carrying three's marker", () => {
+    const plane = new Object3D();
+    (plane as Object3D & { isTransformControlsPlane?: boolean }).isTransformControlsPlane = true;
+    expect(isTransformControlsPlane(plane)).toBe(true);
   });
 });

--- a/ui/src/app/components/viewer/gizmo.ts
+++ b/ui/src/app/components/viewer/gizmo.ts
@@ -449,14 +449,19 @@ export class GizmoManager {
    * Used on touch where no prior hover move has set `axis`, so `isHovering()`
    * would incorrectly return false at the moment of touchdown.
    *
-   * **Visibility has to be checked by hand.** Three's raycaster tests an
-   * object's `layers`, never its `visible` flag, so a hidden helper still
-   * reports hits — and TransformControls' pickers are invisible-by-design
-   * geometry that is far larger than the handles they stand for. A detached
-   * gizmo parks that geometry at the origin, i.e. the middle of the bed, so
-   * without these guards *every* tap near the centre of an empty plate was
-   * swallowed as "on the gizmo" and no model could be selected by touch or pen
-   * at all. A mouse was unaffected, because it reaches `isHovering()` instead.
+   * Two properties of TransformControls' scene graph make the naive version of
+   * this wrong, and both fail *only* on touch and pen — a mouse establishes the
+   * same thing through {@link isHovering}, so neither is visible on a desktop.
+   *
+   * - **Three's `Raycaster` tests `layers`, never `visible`.** A detached gizmo
+   *   is merely hidden, and it parks its pickers at the origin — the middle of
+   *   the bed — so every tap near the centre of an empty plate came back as a
+   *   gizmo hit and no model could be selected at all.
+   * - **The helper contains a 100000×100000 drag plane** whose *material* is
+   *   invisible but whose *object* is visible, so a visibility test alone does
+   *   not exclude it. Attached, it covers the entire screen: every tap anywhere
+   *   read as a gizmo hit, which made it impossible to deselect or to pick a
+   *   different model once one was selected.
    */
   hitTest(event: PointerEvent, camera: Camera, renderer: WebGLRenderer): boolean {
     const active = this.active;
@@ -469,6 +474,12 @@ export class GizmoManager {
     if (!helper.visible) {
       return false;
     }
+    // Bring the helper's world matrices *and* its per-handle visibility up to
+    // date before testing. Both are computed in TransformControls'
+    // `updateMatrixWorld`, which normally runs as part of a render — and this
+    // is a pointer handler, so the last render may predate the selection that
+    // attached the gizmo. Testing against stale state silently eats the press.
+    helper.updateMatrixWorld(true);
     const el = renderer.domElement;
     const rect = el.getBoundingClientRect();
     const ndcX = ((event.clientX - rect.left) / Math.max(rect.width, 1)) * 2 - 1;
@@ -477,9 +488,9 @@ export class GizmoManager {
     const rc = new Raycaster();
     rc.setFromCamera(ndc, camera);
     const hits = rc.intersectObject(helper, true);
-    // TransformControls also toggles individual handles per mode and axis, so a
-    // hit is only real if the thing hit — and everything above it — is showing.
-    return hits.some((hit) => isVisibleWithin(hit.object, helper));
+    return hits.some(
+      (hit) => !isTransformControlsPlane(hit.object) && isVisibleWithin(hit.object, helper),
+    );
   }
 
   /** Currently active object-manipulation mode. */
@@ -508,6 +519,21 @@ export class GizmoManager {
     this.lastQuaternion.copy(this.ghost.quaternion);
     this.lastScale.copy(this.ghost.scale);
   }
+}
+
+/**
+ * True for TransformControls' internal drag-projection plane.
+ *
+ * A `PlaneGeometry(100000, 100000)` that exists purely to project drag rays
+ * onto. Its *material* is `visible: false`, but the object itself is visible,
+ * so neither a render nor a {@link isVisibleWithin} test excludes it — and a
+ * raycast against it succeeds anywhere on screen. Three tags it with a public
+ * marker, which is the only stable way to tell it apart from a real handle.
+ */
+export function isTransformControlsPlane(object: Object3D): boolean {
+  return (
+    (object as Object3D & { isTransformControlsPlane?: boolean }).isTransformControlsPlane === true
+  );
 }
 
 /**

--- a/ui/src/app/components/viewer/gizmo.ts
+++ b/ui/src/app/components/viewer/gizmo.ts
@@ -448,9 +448,25 @@ export class GizmoManager {
    * Raycast the active gizmo helper's hit meshes for a pointer position.
    * Used on touch where no prior hover move has set `axis`, so `isHovering()`
    * would incorrectly return false at the moment of touchdown.
+   *
+   * **Visibility has to be checked by hand.** Three's raycaster tests an
+   * object's `layers`, never its `visible` flag, so a hidden helper still
+   * reports hits — and TransformControls' pickers are invisible-by-design
+   * geometry that is far larger than the handles they stand for. A detached
+   * gizmo parks that geometry at the origin, i.e. the middle of the bed, so
+   * without these guards *every* tap near the centre of an empty plate was
+   * swallowed as "on the gizmo" and no model could be selected by touch or pen
+   * at all. A mouse was unaffected, because it reaches `isHovering()` instead.
    */
   hitTest(event: PointerEvent, camera: Camera, renderer: WebGLRenderer): boolean {
-    if (!this.active) {
+    const active = this.active;
+    // Detached (nothing selected) or disabled: there are no handles to hit,
+    // whatever the picker geometry still lying in the scene says.
+    if (!active || !active.enabled) {
+      return false;
+    }
+    const helper = active.getHelper();
+    if (!helper.visible) {
       return false;
     }
     const el = renderer.domElement;
@@ -460,9 +476,10 @@ export class GizmoManager {
     const ndc = new Vector2(ndcX, ndcY);
     const rc = new Raycaster();
     rc.setFromCamera(ndc, camera);
-    const helper = this.active.getHelper();
     const hits = rc.intersectObject(helper, true);
-    return hits.length > 0;
+    // TransformControls also toggles individual handles per mode and axis, so a
+    // hit is only real if the thing hit — and everything above it — is showing.
+    return hits.some((hit) => isVisibleWithin(hit.object, helper));
   }
 
   /** Currently active object-manipulation mode. */
@@ -491,6 +508,29 @@ export class GizmoManager {
     this.lastQuaternion.copy(this.ghost.quaternion);
     this.lastScale.copy(this.ghost.scale);
   }
+}
+
+/**
+ * Whether `object` and every ancestor up to (and including) `root` is visible.
+ *
+ * Exported for tests. Needed because {@link Raycaster} deliberately ignores
+ * `visible` — it filters on `layers` only — so a hit against hidden geometry is
+ * reported like any other. Anything deciding "did the user touch this?" from a
+ * raycast has to apply the visibility rule itself.
+ */
+export function isVisibleWithin(object: Object3D, root: Object3D): boolean {
+  let node: Object3D | null = object;
+  while (node) {
+    if (!node.visible) {
+      return false;
+    }
+    if (node === root) {
+      return true;
+    }
+    node = node.parent;
+  }
+  // Ran past the root without meeting it — not part of this subtree.
+  return false;
 }
 
 /**

--- a/ui/src/app/components/viewer/gizmo.ts
+++ b/ui/src/app/components/viewer/gizmo.ts
@@ -54,6 +54,27 @@ const AXIS_COLORS = {
 const GIZMO_SCREEN_SIZE = 0.85;
 
 /**
+ * Gizmo size where the pointer is a fingertip.
+ *
+ * TransformControls draws handles a cursor can land on to the pixel; a finger
+ * covers roughly a 10mm disc, so at the mouse size the axis arrows sit inside
+ * one contact patch and picking the one you meant is a coin toss. Scaling the
+ * whole gizmo up scales its pickable geometry with it, which is what actually
+ * makes the arrows separable — and it stays proportional, so nothing about the
+ * gesture has to change.
+ */
+const GIZMO_SCREEN_SIZE_TOUCH = 1.4;
+
+/** Whether the device's primary pointer is coarse (a finger, not a cursor). */
+function isCoarsePointer(): boolean {
+  return (
+    typeof window !== 'undefined' &&
+    typeof window.matchMedia === 'function' &&
+    window.matchMedia('(pointer: coarse)').matches
+  );
+}
+
+/**
  * Snap step values applied to TransformControls when the user holds
  * Shift during a drag. When Shift is released, snapping is disabled
  * (`null`) so motion is continuous again.
@@ -190,7 +211,7 @@ export class GizmoManager {
     tc.setMode(mode);
     tc.setSpace('world');
     tc.setColors(AXIS_COLORS.x, AXIS_COLORS.y, AXIS_COLORS.z, AXIS_COLORS.active);
-    tc.setSize(GIZMO_SCREEN_SIZE);
+    tc.setSize(isCoarsePointer() ? GIZMO_SCREEN_SIZE_TOUCH : GIZMO_SCREEN_SIZE);
     tc.enabled = false;
 
     // The visual helper must be added to the scene separately; the

--- a/ui/src/app/components/viewer/scene/index.ts
+++ b/ui/src/app/components/viewer/scene/index.ts
@@ -602,6 +602,24 @@ export class ViewerScene {
     this._selection.setObjectMode(mode);
   }
 
+  /**
+   * Make a plain tap toggle its object in and out of the selection, the way
+   * ⌘/Ctrl-click does with a mouse. Touch offers no modifier key, so this is
+   * how a multi-object selection is built with a finger or a pencil.
+   */
+  setAdditiveSelection(on: boolean): void {
+    this._selection.setAdditiveSelection(on);
+  }
+
+  /**
+   * Allow dragging an already-selected object to slide the whole selection
+   * across the bed. Meant for touch and pen, where the gizmo's thin arrows are
+   * a poor target for a fingertip.
+   */
+  setDirectDragEnabled(on: boolean): void {
+    this._selection.setDirectDragEnabled(on);
+  }
+
   /** macOS bare-two-finger-swipe action (orbit or pan). */
   setTwoFingerGesture(gesture: TwoFingerGesture): void {
     this._controls.setTwoFingerGesture(gesture);

--- a/ui/src/app/components/viewer/scene/selection.spec.ts
+++ b/ui/src/app/components/viewer/scene/selection.spec.ts
@@ -1,0 +1,371 @@
+import { BoxGeometry, Mesh, MeshBasicMaterial, PerspectiveCamera, Scene } from 'three';
+import type { WebGLRenderer } from 'three';
+import { afterEach, beforeEach, describe, expect, it, vi } from 'vitest';
+import type { GizmoManager } from '../gizmo';
+import { SceneSelection } from './selection';
+import type { SceneSelectionHandlers } from './types';
+
+const CANVAS_SIZE = 200;
+/** Client coordinates of the canvas centre, where the test object sits. */
+const CENTRE = CANVAS_SIZE / 2;
+
+/**
+ * A plain Event carrying the PointerEvent fields the selection reads. jsdom
+ * does not offer a usable `PointerEvent` constructor, and only `pointerId`,
+ * `pointerType`, `button` and the client coordinates are ever consulted.
+ */
+function pointerEvent(type: string, props: Record<string, unknown>): Event {
+  const event = new Event(type, { bubbles: true, cancelable: true });
+  Object.assign(event, {
+    pointerId: 1,
+    pointerType: 'mouse',
+    button: 0,
+    clientX: CENTRE,
+    clientY: CENTRE,
+    ctrlKey: false,
+    metaKey: false,
+    shiftKey: false,
+    ...props,
+  });
+  return event;
+}
+
+describe('SceneSelection', () => {
+  let canvas: HTMLCanvasElement;
+  let selection: SceneSelection;
+  /**
+   * Stands in for OrbitControls: a bubble-phase `pointerdown` listener on the
+   * same canvas. Whether it runs is exactly the question of whether the camera
+   * gets to act on a press.
+   */
+  let cameraListener: ReturnType<typeof vi.fn>;
+  let cameraLiftListener: ReturnType<typeof vi.fn>;
+  let handlers: {
+    select: ReturnType<typeof vi.fn>;
+    clearSelection: ReturnType<typeof vi.fn>;
+    contextMenu: ReturnType<typeof vi.fn>;
+  };
+
+  /** Dispatch a pointer event on the canvas the selection listens to. */
+  function dispatch(type: string, props: Record<string, unknown> = {}): void {
+    canvas.dispatchEvent(pointerEvent(type, props));
+  }
+
+  /** Press, drift by `driftPx`, and lift — the gesture a tap has to survive. */
+  function tap(pointerType: string, driftPx: number, props: Record<string, unknown> = {}): void {
+    dispatch('pointerdown', { pointerType, clientX: CENTRE, clientY: CENTRE, ...props });
+    if (driftPx > 0) {
+      dispatch('pointermove', { pointerType, clientX: CENTRE + driftPx, clientY: CENTRE });
+    }
+    dispatch('pointerup', { pointerType, clientX: CENTRE + driftPx, clientY: CENTRE });
+  }
+
+  beforeEach(() => {
+    canvas = document.createElement('canvas');
+    canvas.getBoundingClientRect = () =>
+      ({
+        x: 0,
+        y: 0,
+        top: 0,
+        left: 0,
+        right: CANVAS_SIZE,
+        bottom: CANVAS_SIZE,
+        width: CANVAS_SIZE,
+        height: CANVAS_SIZE,
+        toJSON: () => ({}),
+      }) as DOMRect;
+    document.body.appendChild(canvas);
+
+    // Registered before `SceneSelection` and without capture, exactly as
+    // OrbitControls does it, so the phase ordering under test is the real one.
+    // The lift matters as much as the press: OrbitControls tracks the pointer
+    // from `pointerdown` and only lets go on `pointerup`.
+    cameraListener = vi.fn();
+    cameraLiftListener = vi.fn();
+    canvas.addEventListener('pointerdown', cameraListener);
+    canvas.addEventListener('pointerup', cameraLiftListener);
+
+    const scene = new Scene();
+    const camera = new PerspectiveCamera(50, 1, 0.1, 1000);
+    camera.position.set(0, 0, 10);
+    camera.updateMatrixWorld(true);
+
+    const gizmo = {
+      isHovering: () => false,
+      isDragging: () => false,
+      hitTest: () => false,
+      setCentroid: () => undefined,
+      setMode: () => undefined,
+    } as unknown as GizmoManager;
+
+    selection = new SceneSelection(
+      scene,
+      camera,
+      { domElement: canvas } as unknown as WebGLRenderer,
+      gizmo,
+    );
+
+    // One box dead centre of the view, so a press at the canvas centre hits it.
+    const box = new Mesh(new BoxGeometry(4, 4, 4), new MeshBasicMaterial());
+    box.updateMatrixWorld(true);
+    scene.add(box);
+    selection.register('7', box);
+
+    handlers = {
+      select: vi.fn(),
+      clearSelection: vi.fn(),
+      contextMenu: vi.fn(),
+    };
+    selection.selectionHandlers = handlers as unknown as SceneSelectionHandlers;
+  });
+
+  afterEach(() => {
+    selection.dispose();
+    canvas.remove();
+    vi.useRealTimers();
+  });
+
+  describe('tap tolerance', () => {
+    it('selects on a still press from every pointer type', () => {
+      for (const pointerType of ['mouse', 'pen', 'touch']) {
+        handlers.select.mockClear();
+        tap(pointerType, 0);
+        expect(handlers.select, pointerType).toHaveBeenCalledWith('7', false);
+      }
+    });
+
+    // The regression this tolerance exists for: a fingertip never lands and
+    // lifts on the same pixel, so a mouse-sized threshold rejected real taps
+    // and left the objects list as the only way to select anything.
+    it('still selects when a finger drifts by more than a mouse would', () => {
+      tap('touch', 12);
+      expect(handlers.select).toHaveBeenCalledWith('7', false);
+    });
+
+    it('still selects when a stylus wobbles', () => {
+      tap('pen', 7);
+      expect(handlers.select).toHaveBeenCalledWith('7', false);
+    });
+
+    it('does not select when the pointer travels far enough to be a drag', () => {
+      tap('touch', 40);
+      expect(handlers.select).not.toHaveBeenCalled();
+    });
+
+    it('keeps a mouse drag from selecting, so it can orbit', () => {
+      tap('mouse', 10);
+      expect(handlers.select).not.toHaveBeenCalled();
+    });
+  });
+
+  describe('selection', () => {
+    it('clears the selection when empty space is tapped', () => {
+      selection.setSelectedIds(new Set(['7']));
+      handlers.select.mockClear();
+      // Well outside the object, but still over the canvas.
+      dispatch('pointerdown', { pointerType: 'touch', clientX: 4, clientY: 4 });
+      dispatch('pointerup', { pointerType: 'touch', clientX: 4, clientY: 4 });
+      expect(handlers.clearSelection).toHaveBeenCalled();
+    });
+
+    it('adds to the selection when a modifier is held', () => {
+      tap('mouse', 0, { shiftKey: true });
+      expect(handlers.select).toHaveBeenCalledWith('7', true);
+    });
+
+    // A press the camera was let into must have its lift let through too.
+    // OrbitControls tracks the pointer from `pointerdown` and only releases it
+    // on `pointerup`, which it listens for on the *document* — so swallowing
+    // the lift strands it mid-gesture, leaving a phantom pointer and a `state`
+    // that never returns to NONE. A later button-less move then orbits the
+    // view, and on touch the next single finger reads as a second contact.
+    it('lets the camera see the lift of every press it saw', () => {
+      for (const pointerType of ['mouse', 'pen', 'touch']) {
+        cameraListener.mockClear();
+        cameraLiftListener.mockClear();
+        tap(pointerType, 0);
+        expect(cameraListener, pointerType).toHaveBeenCalled();
+        expect(cameraLiftListener, pointerType).toHaveBeenCalled();
+      }
+    });
+
+    it('lets the camera see the lift of a face pick too', () => {
+      selection.gizmoHandlers = { delta: vi.fn(), end: vi.fn(), facePicked: vi.fn() };
+      selection.setObjectMode('pullToFloor');
+      tap('mouse', 0);
+      expect(cameraLiftListener).toHaveBeenCalled();
+    });
+
+    // Touch has no modifier key, so the toggle is the only way to build a
+    // multi-object selection without going to the objects list.
+    it('adds to the selection when multi-select is on, with no modifier', () => {
+      selection.setAdditiveSelection(true);
+      tap('touch', 0);
+      expect(handlers.select).toHaveBeenCalledWith('7', true);
+    });
+  });
+
+  describe('context menu', () => {
+    it('opens on a touch long-press, and the lift does not also select', () => {
+      vi.useFakeTimers();
+      dispatch('pointerdown', { pointerType: 'touch' });
+      vi.advanceTimersByTime(600);
+      expect(handlers.contextMenu).toHaveBeenCalledWith('7', expect.anything());
+
+      dispatch('pointerup', { pointerType: 'touch' });
+      expect(handlers.select).not.toHaveBeenCalled();
+    });
+
+    it('does not open when the press moves away first', () => {
+      vi.useFakeTimers();
+      dispatch('pointerdown', { pointerType: 'touch' });
+      dispatch('pointermove', { pointerType: 'touch', clientX: CENTRE + 60, clientY: CENTRE });
+      vi.advanceTimersByTime(600);
+      expect(handlers.contextMenu).not.toHaveBeenCalled();
+    });
+
+    it('reports empty space as no object', () => {
+      vi.useFakeTimers();
+      dispatch('pointerdown', { pointerType: 'touch', clientX: 4, clientY: 4 });
+      vi.advanceTimersByTime(600);
+      expect(handlers.contextMenu).toHaveBeenCalledWith(null, expect.anything());
+    });
+
+    it('opens on a right click', () => {
+      dispatch('pointerdown', { button: 2 });
+      dispatch('pointerup', { button: 2 });
+      expect(handlers.contextMenu).toHaveBeenCalledWith('7', expect.anything());
+    });
+
+    // Right-drag pans the camera; a menu on release would fire on every pan.
+    it('stays shut for a right drag', () => {
+      dispatch('pointerdown', { button: 2 });
+      dispatch('pointermove', { clientX: CENTRE + 60, clientY: CENTRE });
+      dispatch('pointerup', { button: 2, clientX: CENTRE + 60, clientY: CENTRE });
+      expect(handlers.contextMenu).not.toHaveBeenCalled();
+    });
+
+    it('is never asked for when no handler is wired', () => {
+      vi.useFakeTimers();
+      selection.selectionHandlers = {
+        select: handlers.select,
+        clearSelection: handlers.clearSelection,
+      };
+      dispatch('pointerdown', { pointerType: 'touch' });
+      vi.advanceTimersByTime(600);
+      dispatch('pointerup', { pointerType: 'touch' });
+      expect(handlers.select).toHaveBeenCalledWith('7', false);
+    });
+  });
+
+  describe('direct drag', () => {
+    it('slides the selection when a finger drags an already-selected object', () => {
+      const gizmoHandlers = { delta: vi.fn(), end: vi.fn(), facePicked: vi.fn() };
+      selection.gizmoHandlers = gizmoHandlers;
+      selection.setDirectDragEnabled(true);
+      selection.setObjectMode('translate');
+      selection.setSelectedIds(new Set(['7']));
+
+      dispatch('pointerdown', { pointerType: 'touch' });
+      dispatch('pointermove', { pointerType: 'touch', clientX: CENTRE + 40, clientY: CENTRE });
+      dispatch('pointermove', { pointerType: 'touch', clientX: CENTRE + 60, clientY: CENTRE });
+      dispatch('pointerup', { pointerType: 'touch', clientX: CENTRE + 60, clientY: CENTRE });
+
+      expect(gizmoHandlers.delta).toHaveBeenCalled();
+      const [ids, delta] = gizmoHandlers.delta.mock.calls[0];
+      expect(ids).toEqual(['7']);
+      expect(delta.kind).toBe('translate');
+      // Rightwards on screen is +X in world, and the bed height never changes.
+      expect(delta.delta[0]).toBeGreaterThan(0);
+      expect(delta.delta[2]).toBe(0);
+      expect(gizmoHandlers.end).toHaveBeenCalled();
+      // A drag is not a tap.
+      expect(handlers.select).not.toHaveBeenCalled();
+    });
+
+    it('leaves an unselected object alone, so the drag can orbit', () => {
+      const gizmoHandlers = { delta: vi.fn(), end: vi.fn(), facePicked: vi.fn() };
+      selection.gizmoHandlers = gizmoHandlers;
+      selection.setDirectDragEnabled(true);
+      selection.setObjectMode('translate');
+
+      dispatch('pointerdown', { pointerType: 'touch' });
+      dispatch('pointermove', { pointerType: 'touch', clientX: CENTRE + 60, clientY: CENTRE });
+      dispatch('pointerup', { pointerType: 'touch', clientX: CENTRE + 60, clientY: CENTRE });
+
+      expect(gizmoHandlers.delta).not.toHaveBeenCalled();
+      // …and the camera really did get the press, rather than the drag simply
+      // going nowhere. `cameraListener` is a bubble-phase listener, the shape
+      // OrbitControls has on this same canvas.
+      expect(cameraListener).toHaveBeenCalled();
+    });
+
+    it('never takes a mouse drag away from the camera', () => {
+      const gizmoHandlers = { delta: vi.fn(), end: vi.fn(), facePicked: vi.fn() };
+      selection.gizmoHandlers = gizmoHandlers;
+      selection.setDirectDragEnabled(true);
+      selection.setObjectMode('translate');
+      selection.setSelectedIds(new Set(['7']));
+
+      dispatch('pointerdown', { pointerType: 'mouse' });
+      dispatch('pointermove', { pointerType: 'mouse', clientX: CENTRE + 60, clientY: CENTRE });
+      dispatch('pointerup', { pointerType: 'mouse', clientX: CENTRE + 60, clientY: CENTRE });
+
+      expect(gizmoHandlers.delta).not.toHaveBeenCalled();
+      expect(cameraListener).toHaveBeenCalled();
+    });
+
+    // The one invariant the whole drag rests on. The camera is shut out at
+    // `pointerdown`, before it is known whether the press will travel, so that
+    // it never starts a rotate there is nothing left to wrestle it away from.
+    // If this stops holding, the view spins under the object being dragged.
+    it('shuts the camera out of a press it is about to claim', () => {
+      selection.gizmoHandlers = { delta: vi.fn(), end: vi.fn(), facePicked: vi.fn() };
+      selection.setDirectDragEnabled(true);
+      selection.setObjectMode('translate');
+      selection.setSelectedIds(new Set(['7']));
+
+      dispatch('pointerdown', { pointerType: 'touch' });
+
+      expect(cameraListener).not.toHaveBeenCalled();
+    });
+
+    it('ignores a second finger rather than dropping the drag', () => {
+      const gizmoHandlers = { delta: vi.fn(), end: vi.fn(), facePicked: vi.fn() };
+      selection.gizmoHandlers = gizmoHandlers;
+      selection.setDirectDragEnabled(true);
+      selection.setObjectMode('translate');
+      selection.setSelectedIds(new Set(['7']));
+
+      dispatch('pointerdown', { pointerType: 'touch', pointerId: 1 });
+      dispatch('pointermove', { pointerType: 'touch', pointerId: 1, clientX: CENTRE + 40 });
+      dispatch('pointerdown', { pointerType: 'touch', pointerId: 2, clientX: 20, clientY: 20 });
+      gizmoHandlers.delta.mockClear();
+      dispatch('pointermove', { pointerType: 'touch', pointerId: 1, clientX: CENTRE + 70 });
+
+      expect(gizmoHandlers.delta).toHaveBeenCalled();
+    });
+  });
+
+  // A palm can land a beat before the tip on an iPad without pencil hover, and
+  // the arbiter only rejects it by size once a pen has been seen recently. If
+  // that admitted palm held the press slot, every Pencil tap after it would be
+  // discarded until the hand lifted.
+  describe('pen priority', () => {
+    it('lets a pen take the press over from a resting finger', () => {
+      dispatch('pointerdown', { pointerType: 'touch', pointerId: 1, clientX: 4, clientY: 4 });
+      dispatch('pointerdown', { pointerType: 'pen', pointerId: 2 });
+      dispatch('pointerup', { pointerType: 'pen', pointerId: 2 });
+
+      expect(handlers.select).toHaveBeenCalledWith('7', false);
+    });
+
+    it('still ignores a second finger', () => {
+      dispatch('pointerdown', { pointerType: 'touch', pointerId: 1, clientX: 4, clientY: 4 });
+      dispatch('pointerdown', { pointerType: 'touch', pointerId: 2 });
+      dispatch('pointerup', { pointerType: 'touch', pointerId: 2 });
+
+      expect(handlers.select).not.toHaveBeenCalled();
+    });
+  });
+});

--- a/ui/src/app/components/viewer/scene/selection.ts
+++ b/ui/src/app/components/viewer/scene/selection.ts
@@ -7,6 +7,7 @@ import {
   MeshBasicMaterial,
   Object3D,
   type PerspectiveCamera,
+  Plane,
   Raycaster,
   type Scene,
   Vector2,
@@ -17,16 +18,60 @@ import type { ObjectMode } from '../../../services/viewer-control';
 import { computeSelectionCentroid, type GizmoManager, raycastFace } from '../gizmo';
 import type { SceneGizmoHandlers, SceneSelectionHandlers } from './types';
 
-const SELECTION_DRAG_THRESHOLD_PX = 4;
+/**
+ * How far a press may drift and still count as a tap, per pointer type.
+ *
+ * A mouse click lands on the pixel it started on, so a few pixels is generous.
+ * A fingertip is a ~10 mm disc whose reported centre wanders as the skin
+ * flattens and the finger rolls off — 4 px of tolerance rejects most genuine
+ * taps, which is why tapping a model used to do nothing at all and the objects
+ * list was the only way to select anything. A stylus sits between the two:
+ * precise, but held at an angle and subject to the hand's own tremor.
+ */
+const TAP_SLOP_PX: Readonly<Record<string, number>> = {
+  mouse: 4,
+  pen: 9,
+  touch: 16,
+};
+const DEFAULT_TAP_SLOP_PX = 4;
+
+/**
+ * How long a press must be held, without drifting past its slop, to count as a
+ * context-menu request. Matches the native iOS/iPadOS long-press so the gesture
+ * feels the same here as everywhere else on the device.
+ */
+const LONG_PRESS_MS = 500;
+
 const SELECTION_EMISSIVE = new Color(0xff8a3d);
 const SELECTION_EMISSIVE_INTENSITY = 0.55;
 
+/** Bed normal. Objects sit on Z=0, so a direct drag slides in world XY. */
+const DRAG_PLANE_NORMAL = new Vector3(0, 0, 1);
+
+/** A live direct-drag of the selection across the bed. */
+interface SelectionDragState {
+  /** World point under the pointer on the drag plane, at the last move. */
+  last: Vector3;
+}
+
 interface SelectionPressState {
   pointerId: number;
+  pointerType: string;
   downX: number;
   downY: number;
-  hitId: string;
+  /** Drift (px) this press may accumulate and still count as a tap. */
+  slopPx: number;
+  /** Object under the press, or `null` when it landed on empty space. */
+  hitId: string | null;
   additive: boolean;
+  /** Set once the press drifts past {@link slopPx}: no longer a tap. */
+  moved: boolean;
+  /** A long-press already acted on this press, so the lift must not. */
+  consumed: boolean;
+  longPressTimer: ReturnType<typeof setTimeout> | null;
+  /** The event that opened the press, replayed as the context-menu anchor. */
+  downEvent: PointerEvent;
+  drag: SelectionDragState | null;
 }
 
 /**
@@ -49,10 +94,38 @@ export class SceneSelection {
   private readonly raycaster = new Raycaster();
   private readonly ndcScratch = new Vector2();
   private pressState: SelectionPressState | null = null;
-  private emptyPressState: {
+
+  /**
+   * Makes a plain tap toggle its object in and out of the selection, the way
+   * ⌘/Ctrl-click does with a mouse. Touch has no modifier key, so without this
+   * a multi-object selection could only be built from the objects list.
+   */
+  private additiveSelection = false;
+
+  /**
+   * Whether dragging an already-selected object slides the selection across the
+   * bed. Enabled for touch and pen, where the gizmo's thin arrows are a poor
+   * target for a fingertip; a mouse keeps drag-to-orbit and uses the gizmo.
+   */
+  private directDragEnabled = false;
+
+  /** Plane the direct drag slides along — horizontal, through the selection. */
+  private readonly dragPlane = new Plane(new Vector3(0, 0, 1), 0);
+  private readonly dragPointScratch = new Vector3();
+
+  /**
+   * A held right mouse button, tracked so a right *click* can open the context
+   * menu while a right *drag* still pans the camera.
+   *
+   * The `contextmenu` event cannot tell the two apart on its own — Windows
+   * raises it after the button is released, macOS and Linux the moment it goes
+   * down — so the menu is driven off the button's own press and release
+   * instead, which reads the same everywhere.
+   */
+  private rightPress: {
     pointerId: number;
-    downX: number;
-    downY: number;
+    downEvent: PointerEvent;
+    moved: boolean;
   } | null = null;
 
   // Face-highlight overlay for pull-to-floor mode
@@ -96,6 +169,7 @@ export class SceneSelection {
     el.addEventListener('pointermove', this.onPointerMove, { capture: true });
     el.addEventListener('pointerup', this.onPointerUp, { capture: true });
     el.addEventListener('pointercancel', this.onPointerCancel, { capture: true });
+    el.addEventListener('contextmenu', this.onContextMenu);
   }
 
   uninstall(): void {
@@ -104,6 +178,17 @@ export class SceneSelection {
     el.removeEventListener('pointermove', this.onPointerMove, { capture: true });
     el.removeEventListener('pointerup', this.onPointerUp, { capture: true });
     el.removeEventListener('pointercancel', this.onPointerCancel, { capture: true });
+    el.removeEventListener('contextmenu', this.onContextMenu);
+  }
+
+  /** See {@link additiveSelection}. */
+  setAdditiveSelection(on: boolean): void {
+    this.additiveSelection = on;
+  }
+
+  /** See {@link directDragEnabled}. */
+  setDirectDragEnabled(on: boolean): void {
+    this.directDragEnabled = on;
   }
 
   register(id: string, object: Object3D): void {
@@ -230,8 +315,7 @@ export class SceneSelection {
   }
 
   cancelActiveDrag(): void {
-    this.pressState = null;
-    this.emptyPressState = null;
+    this.abandonPress();
   }
 
   setObjectMode(mode: ObjectMode): void {
@@ -244,6 +328,9 @@ export class SceneSelection {
 
   dispose(): void {
     this.uninstall();
+    // A pending long-press must not fire into a torn-down scene.
+    this.endPress();
+    this.rightPress = null;
     if (this.highlightRafHandle !== 0) {
       cancelAnimationFrame(this.highlightRafHandle);
       this.highlightRafHandle = 0;
@@ -258,6 +345,12 @@ export class SceneSelection {
   // -------------------------------------------------------------------------
 
   private onPointerDown = (event: PointerEvent): void => {
+    if (event.button === 2) {
+      // Right button: a click opens the menu, a drag pans. Which it was is only
+      // known on release, so just remember where it started.
+      this.rightPress = { pointerId: event.pointerId, downEvent: event, moved: false };
+      return;
+    }
     if (event.button !== 0 || !this.selectionHandlers) {
       return;
     }
@@ -273,105 +366,347 @@ export class SceneSelection {
     if (onGizmo) {
       return;
     }
-    if (this.currentObjectMode === 'pullToFloor') {
-      const hit = this.pickFace(event);
-      if (hit) {
-        event.preventDefault();
-        event.stopPropagation();
-        this.hideFaceHighlight();
-        this.gizmoHandlers?.facePicked(hit.objectId, hit.faceIndex);
-      } else if (this.currentSelectedIds.size > 0) {
-        this.emptyPressState = {
-          pointerId: event.pointerId,
-          downX: event.clientX,
-          downY: event.clientY,
-        };
+
+    // A second contact belongs to a camera gesture (pinch / pan / roll), never
+    // to a selection — with two exceptions, in this order.
+    const live = this.pressState;
+    if (live !== null && live.pointerId !== event.pointerId) {
+      // A drag is an explicit, committed gesture: the model being moved keeps
+      // the contact that started it and extra fingers are ignored.
+      if (live.drag) {
+        return;
       }
-      return;
-    }
-    // Orbit mode is fixed; clicks always attempt object selection.
-    if (this.selectables.size === 0) {
-      return;
-    }
-    const hitId = this.raycastSelectable(event);
-    if (hitId === null) {
-      if (this.currentSelectedIds.size > 0) {
-        this.emptyPressState = {
-          pointerId: event.pointerId,
-          downX: event.clientX,
-          downY: event.clientY,
-        };
+      // A pen outranks a resting hand. On a hover-less iPad the palm can land a
+      // beat before the tip and be admitted (the arbiter's size heuristic is
+      // only armed once a pen has been seen *recently*), so without this the
+      // palm's press would hold the slot and every Pencil tap after it would be
+      // thrown away until the hand lifted.
+      const penOverridesTouch = event.pointerType === 'pen' && live.pointerType === 'touch';
+      this.abandonPress();
+      if (!penOverridesTouch) {
+        return;
       }
-      return;
     }
-    event.preventDefault();
-    event.stopPropagation();
+
+    const hitId = this.selectables.size > 0 ? this.raycastSelectable(event) : null;
     this.pressState = {
       pointerId: event.pointerId,
+      pointerType: event.pointerType,
       downX: event.clientX,
       downY: event.clientY,
+      slopPx: TAP_SLOP_PX[event.pointerType] ?? DEFAULT_TAP_SLOP_PX,
       hitId,
-      additive: event.ctrlKey || event.metaKey || event.shiftKey,
+      additive: this.additiveSelection || event.ctrlKey || event.metaKey || event.shiftKey,
+      moved: false,
+      consumed: false,
+      longPressTimer: null,
+      downEvent: event,
+      drag: null,
     };
+
+    // With no hover on touch, the face about to be pulled to the floor is
+    // invisible until something paints it — so paint it on contact and commit
+    // on the lift, which also lets a mis-aimed press be dragged off to cancel.
+    if (this.currentObjectMode === 'pullToFloor') {
+      this.updateFaceHighlight(event);
+    }
+
+    // Pull-to-floor is a picking mode: a held press there is someone lining up
+    // a face, not asking for a menu.
+    //
+    // No trailing-click guard is needed, unlike the generic `ContextMenuTrigger`
+    // directive: a press on a model already cancels its compatibility mouse
+    // events via `preventDefault` below, and the menu opens offset from the
+    // pointer, so the lift's click cannot land on an item. A blanket swallow
+    // here would sit armed and eat the user's *next* tap instead.
+    if (
+      this.selectionHandlers.contextMenu &&
+      event.pointerType !== 'mouse' &&
+      this.currentObjectMode !== 'pullToFloor'
+    ) {
+      const press = this.pressState;
+      press.longPressTimer = setTimeout(() => {
+        press.longPressTimer = null;
+        press.consumed = true;
+        this.fireContextMenu(press.hitId, press.downEvent);
+      }, LONG_PRESS_MS);
+    }
+
+    if (hitId !== null) {
+      event.preventDefault();
+      // Keep the camera out of a gesture that is about to move this object —
+      // and only then.
+      //
+      // `stopPropagation` in the capture phase is what decides this: at the
+      // target the DOM runs capture-flagged listeners before non-capture ones
+      // whatever the registration order, and OrbitControls listens on this same
+      // canvas without capture. So stopping here means it never starts a
+      // rotate, and no hand-off is needed once the drag begins.
+      //
+      // Every other press on a model is let through, so a drag that starts on
+      // something the user has not picked still orbits the view — dragging from
+      // a model used to do nothing at all, which on a touch screen turns most
+      // of the scene into a dead zone.
+      if (this.claimsDirectDrag(hitId, event.pointerType)) {
+        event.stopPropagation();
+      }
+    }
   };
 
   private onPointerMove = (event: PointerEvent): void => {
+    const right = this.rightPress;
+    if (right && event.pointerId === right.pointerId && !right.moved) {
+      const drift = Math.hypot(
+        event.clientX - right.downEvent.clientX,
+        event.clientY - right.downEvent.clientY,
+      );
+      if (drift >= (TAP_SLOP_PX[event.pointerType] ?? DEFAULT_TAP_SLOP_PX)) {
+        right.moved = true;
+      }
+    }
     if (this.currentObjectMode === 'pullToFloor') {
       this.pendingHighlightEvent = event;
       if (this.highlightRafHandle === 0) {
         this.highlightRafHandle = requestAnimationFrame(this.flushFaceHighlight);
       }
     }
-    const eps = this.emptyPressState;
-    if (eps && event.pointerId === eps.pointerId) {
-      const dxPx = event.clientX - eps.downX;
-      const dyPx = event.clientY - eps.downY;
-      if (Math.hypot(dxPx, dyPx) >= SELECTION_DRAG_THRESHOLD_PX) {
-        this.emptyPressState = null;
-      }
-    }
     const ps = this.pressState;
     if (!ps || event.pointerId !== ps.pointerId || !this.selectionHandlers) {
       return;
     }
-    const dxPx = event.clientX - ps.downX;
-    const dyPx = event.clientY - ps.downY;
-    if (Math.hypot(dxPx, dyPx) >= SELECTION_DRAG_THRESHOLD_PX) {
-      this.pressState = null;
+    if (ps.drag) {
+      this.advanceDrag(ps, event);
+      // Safe to stop: a drag only exists for a press whose `pointerdown` was
+      // withheld, so every bubble-phase consumer of this pointer is absent for
+      // the whole gesture rather than half of it.
+      event.preventDefault();
+      event.stopPropagation();
+      return;
+    }
+    if (ps.moved || ps.consumed) {
+      return;
+    }
+    const drift = Math.hypot(event.clientX - ps.downX, event.clientY - ps.downY);
+    if (drift < ps.slopPx) {
+      return;
+    }
+    ps.moved = true;
+    this.clearLongPress(ps);
+    if (this.beginDrag(ps, event)) {
+      event.preventDefault();
+      event.stopPropagation();
     }
   };
 
   private onPointerUp = (event: PointerEvent): void => {
-    const eps = this.emptyPressState;
-    if (eps && event.pointerId === eps.pointerId) {
-      this.emptyPressState = null;
-      const dxPx = event.clientX - eps.downX;
-      const dyPx = event.clientY - eps.downY;
-      if (Math.hypot(dxPx, dyPx) < SELECTION_DRAG_THRESHOLD_PX) {
-        this.selectionHandlers?.clearSelection();
+    const right = this.rightPress;
+    if (right && event.pointerId === right.pointerId) {
+      this.rightPress = null;
+      // A right click that never travelled: the menu, at the press position.
+      if (!right.moved && this.selectionHandlers?.contextMenu) {
+        this.fireContextMenu(this.raycastSelectable(right.downEvent), right.downEvent);
+        return;
       }
     }
     const ps = this.pressState;
     if (!ps || event.pointerId !== ps.pointerId) {
       return;
     }
-    this.pressState = null;
-    this.selectionHandlers?.select(ps.hitId, ps.additive);
+    const { hitId, additive, moved, consumed, drag } = ps;
+    this.endPress();
+
+    // The lift is never stopped, whatever the press turned out to be.
+    //
+    // Only *some* presses are withheld from the camera (see `pointerdown`), and
+    // OrbitControls' own pointer-up handler sits on the document — an ancestor,
+    // so a stop here reaches it. Blocking the lift of a press it *was* let into
+    // would strand it mid-gesture: a phantom tracked pointer, `state` never
+    // returning to `NONE`, and a subsequent button-less move rotating the view.
+    // For a press it never saw, letting the lift through costs nothing.
+    if (drag) {
+      this.gizmoHandlers?.end();
+      event.preventDefault();
+      return;
+    }
+    // The long-press already acted on this press; the lift only ends it.
+    if (moved || consumed) {
+      return;
+    }
+
+    if (this.currentObjectMode === 'pullToFloor') {
+      const hit = hitId !== null ? this.pickFace(event) : null;
+      if (hit) {
+        this.hideFaceHighlight();
+        this.gizmoHandlers?.facePicked(hit.objectId, hit.faceIndex);
+        event.preventDefault();
+      } else if (this.currentSelectedIds.size > 0) {
+        this.selectionHandlers?.clearSelection();
+      }
+      return;
+    }
+
+    if (hitId === null) {
+      if (this.currentSelectedIds.size > 0) {
+        this.selectionHandlers?.clearSelection();
+      }
+      return;
+    }
+    this.selectionHandlers?.select(hitId, additive);
     event.preventDefault();
-    event.stopPropagation();
   };
 
   private onPointerCancel = (event: PointerEvent): void => {
-    this.hideFaceHighlight();
-    if (this.emptyPressState && event.pointerId === this.emptyPressState.pointerId) {
-      this.emptyPressState = null;
+    if (this.rightPress?.pointerId === event.pointerId) {
+      this.rightPress = null;
     }
+    this.hideFaceHighlight();
     const ps = this.pressState;
     if (!ps || event.pointerId !== ps.pointerId) {
       return;
     }
-    this.cancelActiveDrag();
+    if (ps.drag) {
+      this.gizmoHandlers?.end();
+    }
+    this.endPress();
   };
+
+  /**
+   * The OS menu never appears over the viewport — a right click is either a pan
+   * (handled by the camera) or our own menu, opened from the button's release
+   * so the two can be told apart on every platform.
+   */
+  private onContextMenu = (event: MouseEvent): void => {
+    event.preventDefault();
+  };
+
+  // -------------------------------------------------------------------------
+  // Press lifecycle
+  // -------------------------------------------------------------------------
+
+  private endPress(): void {
+    const ps = this.pressState;
+    if (!ps) {
+      return;
+    }
+    this.clearLongPress(ps);
+    ps.drag = null;
+    this.pressState = null;
+  }
+
+  /**
+   * Give up the press without resolving it — the camera has claimed the
+   * gesture, or a second contact arrived.
+   *
+   * A live direct drag has already moved the objects, so it is committed
+   * rather than dropped: leaving the scene-command batch open would strand
+   * the move outside the undo history.
+   */
+  private abandonPress(): void {
+    const dragging = Boolean(this.pressState?.drag);
+    this.endPress();
+    if (dragging) {
+      this.gizmoHandlers?.end();
+    }
+  }
+
+  private clearLongPress(ps: SelectionPressState): void {
+    if (ps.longPressTimer !== null) {
+      clearTimeout(ps.longPressTimer);
+      ps.longPressTimer = null;
+    }
+  }
+
+  private fireContextMenu(hitId: string | null, event: PointerEvent | MouseEvent): void {
+    this.selectionHandlers?.contextMenu?.(hitId, event);
+  }
+
+  // -------------------------------------------------------------------------
+  // Direct drag — slide the selection across the bed
+  // -------------------------------------------------------------------------
+
+  /**
+   * Whether a press here would become a direct drag rather than a camera move.
+   *
+   * Deliberately narrow: only a touch or pen contact, only in translate mode,
+   * and only on an object that is *already* selected. Requiring a prior tap
+   * means a model can never be shoved across the plate by a stray swipe, and it
+   * keeps drag-to-orbit available everywhere else on the scene.
+   *
+   * Asked at `pointerdown`, before it is known whether the press will travel,
+   * because that is when the camera has to be shut out (see there).
+   */
+  private claimsDirectDrag(hitId: string | null, pointerType: string): boolean {
+    return (
+      this.directDragEnabled &&
+      this.gizmoHandlers !== null &&
+      this.currentObjectMode === 'translate' &&
+      (pointerType === 'touch' || pointerType === 'pen') &&
+      hitId !== null &&
+      this.currentSelectedIds.has(hitId)
+    );
+  }
+
+  /**
+   * Take a drifting press over as a move of the whole selection.
+   *
+   * The camera was already shut out of this contact at `pointerdown`, so there
+   * is nothing to wrestle it away from here — see {@link claimsDirectDrag}.
+   *
+   * @returns whether the drag started.
+   */
+  private beginDrag(ps: SelectionPressState, event: PointerEvent): boolean {
+    if (!this.claimsDirectDrag(ps.hitId, ps.pointerType)) {
+      return false;
+    }
+    const centroid = this.computeSelectionCentroid();
+    if (!centroid) {
+      return false;
+    }
+    // A horizontal plane through the selection: objects slide over the bed,
+    // never up off it. Depth stays the gizmo's (and gravity's) business.
+    this.dragPlane.set(DRAG_PLANE_NORMAL, -centroid.z);
+    const start = this.pointOnDragPlane(event);
+    if (!start) {
+      return false;
+    }
+    // Follow the finger even if it leaves the canvas — dragging a model to the
+    // edge of the bed puts it under the toolbar or the objects list, and
+    // without capture the drag would stall there until the finger came back.
+    try {
+      this.renderer.domElement.setPointerCapture(event.pointerId);
+    } catch {
+      // The pointer may already be gone; the drag simply stays canvas-bound.
+    }
+    ps.drag = { last: start.clone() };
+    return true;
+  }
+
+  private advanceDrag(ps: SelectionPressState, event: PointerEvent): void {
+    const drag = ps.drag;
+    if (!drag) {
+      return;
+    }
+    const point = this.pointOnDragPlane(event);
+    if (!point) {
+      return;
+    }
+    const dx = point.x - drag.last.x;
+    const dy = point.y - drag.last.y;
+    drag.last.copy(point);
+    if (dx === 0 && dy === 0) {
+      return;
+    }
+    this.gizmoHandlers?.delta([...this.currentSelectedIds], {
+      kind: 'translate',
+      delta: [dx, dy, 0],
+    });
+  }
+
+  /** Where the pointer ray meets the drag plane, or null looking edge-on. */
+  private pointOnDragPlane(event: PointerEvent): Vector3 | null {
+    this.raycaster.setFromCamera(this.toNdc(event, this.ndcScratch), this.camera);
+    return this.raycaster.ray.intersectPlane(this.dragPlane, this.dragPointScratch);
+  }
 
   // -------------------------------------------------------------------------
   // Face picking (pull-to-floor)
@@ -526,7 +861,7 @@ export class SceneSelection {
   // Raycast helpers
   // -------------------------------------------------------------------------
 
-  private raycastSelectable(event: PointerEvent): string | null {
+  private raycastSelectable(event: MouseEvent): string | null {
     const ndc = this.toNdc(event, this.ndcScratch);
     this.raycaster.setFromCamera(ndc, this.camera);
     const targets = Array.from(this.selectables.values());
@@ -552,7 +887,7 @@ export class SceneSelection {
     return null;
   }
 
-  private toNdc(event: PointerEvent, out: Vector2): Vector2 {
+  private toNdc(event: MouseEvent, out: Vector2): Vector2 {
     const rect = this.renderer.domElement.getBoundingClientRect();
     const x = ((event.clientX - rect.left) / Math.max(rect.width, 1)) * 2 - 1;
     const y = -(((event.clientY - rect.top) / Math.max(rect.height, 1)) * 2 - 1);

--- a/ui/src/app/components/viewer/scene/types.ts
+++ b/ui/src/app/components/viewer/scene/types.ts
@@ -5,6 +5,12 @@ export interface SceneSelectionHandlers {
   select(id: string, additive: boolean): void;
   /** Click landed on empty space (deselect). */
   clearSelection(): void;
+  /**
+   * A context menu was asked for over the scene — a right-click, or the touch
+   * and pen long-press that stands in for one. `id` is the object under the
+   * pointer, or `null` when the press landed on empty bed.
+   */
+  contextMenu?(id: string | null, event: MouseEvent): void;
 }
 
 export interface SceneGizmoHandlers {

--- a/ui/src/app/components/viewer/viewer.ts
+++ b/ui/src/app/components/viewer/viewer.ts
@@ -15,13 +15,19 @@ import {
 } from '@angular/core';
 import { BufferAttribute, BufferGeometry, Matrix4, Mesh, MeshPhongMaterial, Vector3 } from 'three';
 import { AppTheme } from '../../services/app-theme';
+import { Arrange } from '../../services/arrange';
+import { ContextMenuService } from '../../services/context-menu/context-menu.service';
+import type { ContextMenuItem } from '../../services/context-menu/context-menu.model';
 import { GcodePreview, ROLE_LABELS, scalarChannelFor } from '../../services/gcode-preview';
 import { ObjectTracker } from '../../services/object-tracker';
 import { PrintArea } from '../../services/print-area';
 import { ActiveSelection } from '../../services/profiles/active-selection';
 import { SceneCommand } from '../../services/scene-command/scene-command';
 import { SceneEngine } from '../../services/scene-engine';
+import type { SceneOp } from '../../services/scene-engine';
 import { ViewerControl } from '../../services/viewer-control';
+import { Viewport } from '../../services/viewport';
+import { WorkplateObjects } from '../../services/workplate-objects';
 import {
   pixelRatioCapFor,
   resolveAntialias,
@@ -159,6 +165,10 @@ export class Viewer {
   private readonly gcodePreview = inject(GcodePreview);
   private readonly activeSelection = inject(ActiveSelection);
   private readonly appTheme = inject(AppTheme);
+  private readonly viewport = inject(Viewport);
+  private readonly contextMenu = inject(ContextMenuService);
+  private readonly workplate = inject(WorkplateObjects);
+  private readonly arrange = inject(Arrange);
   private readonly destroyRef = inject(DestroyRef);
 
   /** Current loading status for the optional overlay. */
@@ -369,6 +379,13 @@ export class Viewer {
     effect(() => {
       const enabled = this.viewerControl.palmRejection();
       this.scene?.setPalmRejectionEnabled(enabled);
+    });
+
+    // React to the toolbar's multi-select toggle — the keyboard-less stand-in
+    // for holding ⌘/Ctrl while clicking.
+    effect(() => {
+      const additive = this.viewerControl.additiveSelection();
+      this.scene?.setAdditiveSelection(additive);
     });
 
     // React to field-of-view changes from the 3D-view settings.
@@ -761,6 +778,139 @@ export class Viewer {
     this.viewerControl.selectedObjectIds.set([]);
   }
 
+  /**
+   * Everything the objects list can do to a model, offered where the model is.
+   *
+   * On a tablet this is the difference between working on the plate and working
+   * on a list *about* the plate: a long-press on the model itself is the touch
+   * equivalent of a right-click, and it puts duplicate, drop, centre and remove
+   * under the finger that is already pointing at the part. Pressing empty bed
+   * gives the plate-wide actions instead.
+   */
+  private handleSceneContextMenu(stringId: string | null, event: MouseEvent): void {
+    if (this.mode() !== 'model') {
+      return;
+    }
+    const id = stringId === null ? null : parseWasmId(stringId);
+    if (stringId !== null && id !== null && !this.selectedWasmIds.includes(id)) {
+      // Act on what the user pointed at. Selecting first also *shows* them
+      // which part the menu is about before they pick an item.
+      this.handleSelect(stringId, false);
+    }
+    const items = id === null ? this.plateMenuItems() : this.objectMenuItems(id);
+    void this.contextMenu.open(event, items);
+  }
+
+  /** Menu for a press that landed on a model. */
+  private objectMenuItems(id: bigint): ContextMenuItem[] {
+    // A press inside a multi-object selection acts on the whole batch; the
+    // selection is what the user built, so the menu must not quietly ignore it.
+    const targets = this.selectedWasmIds.includes(id) ? [...this.selectedWasmIds] : [id];
+    const many = targets.length > 1;
+    const suffix = many ? ` (${targets.length})` : '';
+    return [
+      {
+        label: `Duplicate${suffix}`,
+        icon: 'copy',
+        action: () => {
+          for (const target of targets) {
+            this.workplate.duplicate(target);
+          }
+        },
+      },
+      {
+        label: `Drop to floor${suffix}`,
+        icon: 'download',
+        action: () =>
+          this.applyToEach(targets, (target) => ({
+            op: 'DropToFloor' as const,
+            args: { id: target },
+          })),
+      },
+      {
+        label: 'Centre on bed',
+        icon: 'frame-alt',
+        // Centring each object independently would stack them all on the same
+        // spot, so a batch is arranged instead — the sane reading of "put these
+        // where they belong".
+        action: () =>
+          many
+            ? this.arrange.run(targets)
+            : this.applyToEach(targets, (target) => ({
+                op: 'CenterOnBed' as const,
+                args: { id: target },
+              })),
+      },
+      { label: '', separator: true },
+      {
+        label: 'Select all',
+        icon: 'select-window',
+        action: () => this.selectAllObjects(),
+      },
+      { label: '', separator: true },
+      {
+        label: `Remove${suffix}`,
+        icon: 'bin',
+        danger: true,
+        action: () => {
+          for (const target of targets) {
+            this.workplate.remove(target);
+          }
+          this.viewerControl.selectedObjectIds.set(
+            this.selectedWasmIds.filter((existing) => !targets.includes(existing)),
+          );
+        },
+      },
+    ];
+  }
+
+  /** Menu for a press that landed on empty bed. */
+  private plateMenuItems(): ContextMenuItem[] {
+    const hasObjects = this.sceneEngine.objects().length > 0;
+    return [
+      {
+        label: 'Select all',
+        icon: 'select-window',
+        disabled: !hasObjects,
+        action: () => this.selectAllObjects(),
+      },
+      {
+        label: 'Clear selection',
+        icon: 'xmark',
+        disabled: this.selectedWasmIds.length === 0,
+        action: () => this.handleClearSelection(),
+      },
+      { label: '', separator: true },
+      {
+        label: 'Place objects',
+        icon: 'magic-wand',
+        disabled: !hasObjects,
+        action: () => this.arrange.run(),
+      },
+      { label: '', separator: true },
+      {
+        label: 'Reset view',
+        icon: 'home',
+        action: () => this.viewerControl.reset(),
+      },
+    ];
+  }
+
+  private selectAllObjects(): void {
+    const ids = this.sceneEngine.objects().map((object) => object.id);
+    this.selectedWasmIds = ids.filter((id) => this.wasmMeshes.has(id));
+    this.scene?.setSelectedIds(new Set(this.selectedWasmIds.map(String)));
+    this.viewerControl.selectedObjectIds.set(this.selectedWasmIds);
+  }
+
+  /** Dispatch one op per target and commit them as a single history entry. */
+  private applyToEach(targets: readonly bigint[], op: (id: bigint) => SceneOp): void {
+    for (const target of targets) {
+      this.sceneCommand.apply(op(target));
+    }
+    this.sceneCommand.flush();
+  }
+
   /** Translate / rotate / scale a delta onto every currently-selected object. */
   private handleGizmoDelta(stringIds: readonly string[], delta: GizmoDelta): void {
     for (const stringId of stringIds) {
@@ -909,6 +1059,7 @@ export class Viewer {
     this.scene.selectionHandlers = {
       select: (id, additive) => this.handleSelect(id, additive),
       clearSelection: () => this.handleClearSelection(),
+      contextMenu: (id, event) => this.handleSceneContextMenu(id, event),
     };
     this.scene.gizmoHandlers = {
       delta: (ids, delta) => this.handleGizmoDelta(ids, delta),
@@ -918,6 +1069,11 @@ export class Viewer {
     // Apply the current toolbar selections so the scene starts in sync with
     // whatever view / object mode the user already had selected.
     this.scene.setObjectMode(this.viewerControl.objectMode());
+    this.scene.setAdditiveSelection(this.viewerControl.additiveSelection());
+    // Dragging a model straight across the bed is the touch answer to the
+    // gizmo's mouse-sized arrows, so it is offered exactly where those are hard
+    // to hit. A mouse keeps drag-to-orbit.
+    this.scene.setDirectDragEnabled(this.viewport.isCoarsePointer());
     this.scene.setView(this.viewerControl.view());
     // Keep the toolbar's projection button honest when the viewport cube (not
     // the toolbar) changes the projection.

--- a/ui/src/app/services/history-controls-preference.ts
+++ b/ui/src/app/services/history-controls-preference.ts
@@ -1,5 +1,6 @@
-import { computed, DestroyRef, inject, Injectable, signal } from '@angular/core';
+import { computed, inject, Injectable } from '@angular/core';
 import { BrowserStorage } from './browser-storage';
+import { Viewport } from './viewport';
 
 /**
  * When the on-canvas undo/redo buttons are shown in the 3D-view toolbar.
@@ -21,21 +22,16 @@ const HISTORY_CONTROLS_KEY = 'general.historyControls';
  * they are the *only* way to step through history, so `auto` reveals them there
  * and hides them elsewhere. The user can override with `always`/`never`.
  *
- * The `auto` detection keys off the primary pointer being coarse
- * (`(pointer: coarse)`), which is what distinguishes a touch tablet/phone from a
- * mouse- or trackpad-driven desktop. It is reactive: plugging in or removing a
- * pointing device flips the media query, and with it the buttons.
+ * The `auto` detection is {@link Viewport.isCoarsePointer} — the primary pointer
+ * being coarse, which is what distinguishes a touch tablet/phone from a mouse-
+ * or trackpad-driven desktop. It is reactive: plugging in or removing a pointing
+ * device flips the media query, and with it the buttons.
  */
 @Injectable({ providedIn: 'root' })
 export class HistoryControlsPreference {
   private readonly storage = inject(BrowserStorage);
+  private readonly viewport = inject(Viewport);
   private readonly stored = this.storage.get(HISTORY_CONTROLS_KEY, 'local');
-
-  /**
-   * True when the device is likely keyboard-less — the primary pointer is
-   * coarse (touch), as on an iPad or phone. Reactive to device changes.
-   */
-  private readonly coarsePrimaryPointer = signal(this.detectCoarsePointer());
 
   /** The user's chosen mode; defaults to `auto`. */
   readonly mode = computed<HistoryControlsMode>(() => {
@@ -51,27 +47,11 @@ export class HistoryControlsPreference {
       case 'never':
         return false;
       default:
-        return this.coarsePrimaryPointer();
+        return this.viewport.isCoarsePointer();
     }
   });
 
-  constructor() {
-    if (typeof window !== 'undefined' && typeof window.matchMedia === 'function') {
-      const query = window.matchMedia('(pointer: coarse)');
-      const onChange = (event: MediaQueryListEvent) => this.coarsePrimaryPointer.set(event.matches);
-      query.addEventListener('change', onChange);
-      inject(DestroyRef).onDestroy(() => query.removeEventListener('change', onChange));
-    }
-  }
-
   setMode(mode: HistoryControlsMode): void {
     this.storage.write(HISTORY_CONTROLS_KEY, mode, 'local');
-  }
-
-  private detectCoarsePointer(): boolean {
-    if (typeof window === 'undefined' || typeof window.matchMedia !== 'function') {
-      return false;
-    }
-    return window.matchMedia('(pointer: coarse)').matches;
   }
 }

--- a/ui/src/app/services/viewer-control.ts
+++ b/ui/src/app/services/viewer-control.ts
@@ -241,6 +241,17 @@ export class ViewerControl {
   readonly selectedObjectIds = signal<readonly bigint[]>([]);
 
   /**
+   * Whether a tap adds to the selection instead of replacing it.
+   *
+   * A mouse builds a multi-object selection by holding ⌘/Ctrl or Shift. Touch
+   * has no such key, so on a tablet a batch selection could only be assembled
+   * from the objects list — the thing this toggle exists to make unnecessary.
+   * It is offered on touch-primary devices and stays off elsewhere, where the
+   * modifier is faster and already familiar.
+   */
+  readonly additiveSelection = signal(false);
+
+  /**
    * Monotonically increasing counter that is bumped every time the user
    * asks the viewer to reset its camera. The viewer reacts to changes of
    * this signal — the value itself is irrelevant.


### PR DESCRIPTION
Selecting a model by tapping it did nothing. Every press was judged by a single
4px drag threshold, and a fingertip is a ~10mm disc whose reported centre wanders
as the skin flattens — so most real taps drifted past it and were discarded as
drags. The objects list was the only thing that worked, which is exactly the
complaint this started from.

Tap tolerance is now **per pointer type** (mouse 4px, pen 9, touch 16), and a
press resolves on the *lift* rather than the press, so a mis-aimed contact can be
dragged off to cancel. On top of that:

- **Multi-select toggle**, since touch has no ⌘/Ctrl to hold. Appears once there
  are two objects to choose between, and clears itself when it can no longer be
  reached.
- **Long-press — and right-click — opens a context menu on the model itself**:
  duplicate, drop to floor, centre, remove, acting on the whole selection. Empty
  bed gets the plate-wide actions.
- **Dragging an already-selected model slides it across the bed.** Requiring a
  prior tap means a stray swipe can never shove a part out of place.
- Gizmo handles and toolbar buttons sized for a fingertip; the objects list
  remembers whether you folded it.

### Two subtleties worth a reviewer's eye

**Right-click is driven off the mouse button's own press and release**, not the
`contextmenu` event — Windows raises that at mouseup and macOS at mousedown, so
only the button's travel separates a right *click* from the right *drag* that
pans.

**The camera is withheld at `pointerdown`, and only for a press the drag will
claim.** At the target the DOM runs capture-flagged listeners before non-capture
ones *whatever the registration order*, and OrbitControls listens on the same
canvas without capture — so a capture-phase `stopPropagation()` stops it starting
a rotate, and no synthetic hand-off is needed. Two consequences the tests pin:

- Making that stop *unconditional* (as it used to be) turns every model into a
  dead zone — dragging one did nothing at all rather than orbiting.
- Stopping the **lift** strands OrbitControls mid-gesture, because its pointer-up
  handler is on the *document*. That left `state` stuck in `ROTATE` after any
  selection click, so the next button-less move swung the view; on touch it killed
  one-finger orbit outright after the first tap. No `pointerup` is stopped now.

### Testing

23 new specs in `selection.spec.ts` (164 total, all passing) covering per-pointer
tap tolerance, additive selection, long-press and right-click, direct drag, pen
priority over a resting palm, and that the camera sees both the press *and* the
lift of every gesture it should. Each was verified to fail with its fix reverted.

Rebased onto `main` after #254 landed: this now sits on that PR's three-way
`Viewport` split (`isCoarsePointer()` / `isCompact()` / `isHandheld()`) and its
`_touch.scss` rather than the parallel infrastructure this branch had grown, and
the changelog and docs are interleaved with its entries.

Hand-testing on a physical iPad is still worth doing for the gesture feel.