### PR TITLE
Improve bridge flow settings for better first-time user experience

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -27,6 +27,14 @@ issue/PR numbers or repo links in the notes. See the tone rules in
 
 ## [Unreleased]
 
+### Changed
+
+- **Smooth-bridge defaults.** Bridges now print at **10 mm/s** with a **1.5×**
+  flow ratio by default, so their strands fuse into a continuous floor and full
+  part-cooling freezes them before they sag — the community "smooth unsupported
+  bridge" recipe, out of the box. The most-airborne overhang band drops to
+  8 mm/s to stay below the new bridge speed.
+
 ## [0.4.0] - 2026-08-31
 
 The biggest release so far — 181 files and about 15,000 new lines — and it pulls

--- a/src/core/README.md
+++ b/src/core/README.md
@@ -229,10 +229,10 @@ was tried at one point — any one of them suppresses _all_ overhang
 detection. See `test_classify_overhang_e2e_*` in `walls.rs` for the
 production-geometry lockdown tests.
 
-Reclassified paths inherit the bridge speed (`bridge_speed`) and reduced-flow
-width (`nozzle_diameter_mm × bridge_flow_ratio`) in the G-code generator and
-trigger the bridge fan boost via `has_bridges`. This eliminates sagging
-walls printed across windows, slots, and similar mid-air features.
+Reclassified paths inherit the bridge speed (`bridge_speed`) and the fused-flow
+width (`nozzle_diameter_mm × bridge_flow_ratio`, > 1× by default) in the G-code
+generator and trigger the bridge fan boost via `has_bridges`. This eliminates
+sagging walls printed across windows, slots, and similar mid-air features.
 
 ### Dynamic overhang speed & cooling
 

--- a/src/core/surfaces.rs
+++ b/src/core/surfaces.rs
@@ -1081,9 +1081,10 @@ pub(crate) fn clip_walls_against_bridge_region(layer: &mut SliceLayer, bridge_re
 /// - Selects the **optimal bridge direction** by finding the axis that
 ///   minimises the unsupported span length (perpendicular to the longest
 ///   bounding dimension of the region) — unless `bridge_angle_deg` overrides it.
-/// - Stores a **reduced extrusion width** in `path_widths` based on
-///   `nozzle_diameter_mm × bridge_flow_ratio` so the G-code generator emits
-///   proportionally less plastic — this stiffens the strand and reduces sag.
+/// - Stores a **flow-scaled extrusion width** in `path_widths` based on
+///   `nozzle_diameter_mm × bridge_flow_ratio` so the G-code generator meters the
+///   plastic to match. The default ratio is > 1, so neighbouring strands (laid
+///   one nozzle-diameter apart) overlap and fuse into a smooth, continuous floor.
 ///
 /// `bridge_angle_deg` follows the PrusaSlicer/Orca convention: `0` means
 /// "detect automatically", so a horizontal (0°) override is spelled `180`.
@@ -1172,10 +1173,11 @@ fn emit_bridge_lines(
     bridge_flow_ratio: f64,
     bridge_angle: f64,
 ) {
-    // Bridge line spacing = nozzle diameter (no overlapping beads on air).
+    // Bridge line pitch = nozzle diameter (centre-to-centre). With the default
+    // `bridge_flow_ratio` > 1 the wider beads overlap at this pitch and fuse.
     let line_spacing = nozzle_diameter_mm.max(0.1);
 
-    // Effective bead width with flow reduction.
+    // Effective bead width from the flow ratio (> nozzle when the ratio > 1).
     let bead_width = (nozzle_diameter_mm * bridge_flow_ratio).max(0.01);
 
     let infill_paths = generate_rectilinear_infill(region, line_spacing, bridge_angle, 0.0);

--- a/src/settings/README.md
+++ b/src/settings/README.md
@@ -100,8 +100,8 @@ is present, since the raft then owns bed contact.
 
 | Parameter                | Type | Default | Effect                                                                      |
 | ------------------------ | ---- | ------- | --------------------------------------------------------------------------- |
-| `bridge_speed`           | mm/s | 25      | Print speed for bridge / overhang-perimeter extrusions                      |
-| `bridge_flow_ratio`      | 0–1  | 0.8     | Flow multiplier for bridge lines (less material = less sag)                 |
+| `bridge_speed`           | mm/s | 10      | Print speed for bridge / overhang-perimeter extrusions (slow = smooth)      |
+| `bridge_flow_ratio`      | 0–1.5| 1.5     | Flow multiplier for bridge lines (>1 fuses strands into a smooth floor)     |
 | `bridge_anchor_mm`       | mm   | 0.4     | Inflate the bridge region outward to anchor strands into solid material     |
 | `bridge_min_area_mm2`    | mm²  | 0.5     | Drop bridge candidates smaller than this; reclassified as `BottomSurface`   |
 | `bridge_noise_filter_mm` | mm   | 0.05    | Morphological-open radius to wipe sub-pixel slivers before bridge detection |

--- a/src/settings/params.rs
+++ b/src/settings/params.rs
@@ -928,9 +928,11 @@ Set to `0` to fall back to `print_speed`.
     #[schemars(
         description = "Speed for bridge extrusions spanning unsupported gaps in mm/s.
 
-Slower speeds with high fan cooling reduce sagging on bridges.
+Bridges print in mid-air, so the strand is not squished onto a layer below like
+every other extrusion.  Crawling across the gap gives full part-cooling
+(`bridge_fan_speed`) time to freeze the strand in place before it can sag.
 Set to `0` to fall back to `print_speed`.
-**Typical:** 20–30 mm/s.",
+**Typical:** 10–25 mm/s. **Default:** 10 mm/s.",
         extend("x-group" = "Speed")
     )]
     #[serde(default = "SlicingParams::default_bridge_speed")]
@@ -991,7 +993,7 @@ pinning a second number that can drift out of sync with it.
 The steepest, most sag-prone band — effectively extruding into air, but without
 a bridge's anchored far end to tension against, so it wants to run slower than
 `bridge_speed`.  `0` = inherit `bridge_speed`.
-**Default:** 15 mm/s.",
+**Default:** 8 mm/s.",
         extend("x-group" = "Speed")
     )]
     #[serde(default = "SlicingParams::default_overhang_4_4_speed")]
@@ -1013,11 +1015,12 @@ one, discarding the grading — enable it deliberately when a model curls.
     #[schemars(
         description = "Flow ratio for bridge extrusions (0.0–1.5).
 
-Reducing the flow rate for bridges improves stiffness by letting the strand
-cool and tension in mid-air before the next line lands on it.  Values below
-1.0 under-extrude intentionally; the reduced bead width stretches across the
-gap with less sag.
-**Default:** 0.8 (80% of normal flow).",
+Bridge lines are laid one nozzle-diameter apart, so a value **above 1.0** widens
+each bead until neighbouring strands overlap and fuse into a continuous, smooth
+floor — the opposite of the old under-extrude approach that left thin, gappy,
+sag-prone strands.  Pair it with a slow `bridge_speed` and full `bridge_fan_speed`
+so the fatter bead freezes in place before it sags.
+**Default:** 1.5 (150% of normal flow).",
         extend("x-group" = "Speed")
     )]
     #[serde(default = "SlicingParams::default_bridge_flow_ratio")]
@@ -2920,7 +2923,12 @@ impl SlicingParams {
     }
 
     fn default_bridge_speed() -> f64 {
-        25.0
+        // Community-standard "smooth unsupported bridge" recipe: crawl the strand
+        // across the gap so full part-cooling (`bridge_fan_speed`) freezes it in
+        // place before it can sag, paired with the >1 `bridge_flow_ratio` that
+        // fuses adjacent strands into a solid floor. 10 mm/s at 0.6 mm × 0.2 mm is
+        // ≈ 1.2 mm³/s — well inside every filament's melt rate.
+        10.0
     }
 
     fn default_enable_overhang_speed() -> bool {
@@ -2948,12 +2956,13 @@ impl SlicingParams {
     /// Deg4 (75–100 % unsupported) in mm/s.
     ///
     /// This band is effectively extruding into air, but unlike a bridge it has
-    /// no anchored far end to tension against — so it wants to be slower than
-    /// `bridge_speed` (25), not equal to it. 15 mm/s gives the strand time to
-    /// set while staying well inside the melt rate (≈ 1.2 mm³/s at 0.4 mm ×
-    /// 0.2 mm).
+    /// no anchored far end to tension against — so it must stay the *slowest* of
+    /// all, below `bridge_speed`. With the smooth-bridge default putting
+    /// `bridge_speed` (which Deg3 inherits) at 10 mm/s, 8 mm/s keeps the grade
+    /// strictly monotonic (perimeter → Deg3 → Deg4) instead of letting the most
+    /// airborne band outrun the merely-steep one.
     fn default_overhang_4_4_speed() -> f64 {
-        15.0
+        8.0
     }
 
     fn default_slowdown_for_curled_perimeters() -> bool {
@@ -2978,7 +2987,12 @@ impl SlicingParams {
     }
 
     fn default_bridge_flow_ratio() -> f64 {
-        0.8
+        // Deliberately over 1.0. Bridge lines are laid one nozzle-diameter apart,
+        // so a 1.5× bead (0.6 mm at a 0.4 mm nozzle) overlaps its neighbours ~0.2 mm
+        // and fuses them into a continuous, smooth floor instead of thin, gappy,
+        // sag-prone strands. Paired with the slow `bridge_speed` and full
+        // `bridge_fan_speed`, this is the "smooth unsupported bridge" recipe.
+        1.5
     }
 
     fn default_bridge_min_area_mm2() -> f64 {


### PR DESCRIPTION
This pull request updates the default settings for bridge flow to enhance the user experience based on community standards for 3D printing bridges. The changes include:

- **Updated Defaults**:
  - Changed `bridge_flow_ratio` from **0.8** to **1.5** to increase extrusion and reduce sagging.
  - Reduced `bridge_speed` from **25 mm/s** to **10 mm/s** to allow for better cooling and smoother finishes.
  
- **Documentation Updates**:
  - Revised the README files in both the core and settings directories to reflect the new default values and their rationale.
  - Updated comments in the code to clarify the new approach to bridge flow, moving away from the previous under-extrusion strategy.

- **Changelog Entry**:
  - Added a new entry in the CHANGELOG to document these changes under `## [Unreleased]`.

These adjustments aim to align the bridge printing process with best practices, ensuring a smoother and more reliable experience for users.