### PR TITLE
Add dot-to-dot measurement feature with modal support

### DIFF
--- a/ui/src/app/components/viewer/gizmo.ts
+++ b/ui/src/app/components/viewer/gizmo.ts
@@ -4,6 +4,7 @@ import {
   Camera,
   Color,
   Group,
+  Matrix3,
   Mesh,
   Object3D,
   Quaternion,
@@ -31,6 +32,18 @@ export type GizmoDelta =
 export interface FacePickResult {
   /** `selectableId` of the hit object (string form of the WASM id). */
   objectId: string;
+  /** Triangle index inside the hit mesh's geometry. */
+  faceIndex: number;
+}
+
+/** Result of a surface-point raycast for the measuring tool. */
+export interface PointPickResult {
+  /** `selectableId` of the hit object (string form of the WASM id). */
+  objectId: string;
+  /** World-space surface point directly under the pointer. */
+  point: Vector3;
+  /** World-space outward unit normal of the hit face. */
+  normal: Vector3;
   /** Triangle index inside the hit mesh's geometry. */
   faceIndex: number;
 }
@@ -616,6 +629,41 @@ export function raycastFace(
   }
   return null;
 }
+
+/**
+ * Raycast `meshes` and return the world-space surface point under the pointer,
+ * its outward face normal, and the object it belongs to — or `null` on a miss.
+ *
+ * Used by the measuring tool, which needs the exact hit location (not just the
+ * face) so a dot-to-dot span is taken between the two points the user actually
+ * clicked. The normal is transported to world space through the object's normal
+ * matrix, so it stays correct under non-uniform scale.
+ */
+export function raycastPoint(
+  raycaster: Raycaster,
+  camera: Camera,
+  ndc: Vector2,
+  meshes: readonly Object3D[],
+): PointPickResult | null {
+  raycaster.setFromCamera(ndc, camera);
+  const hits = raycaster.intersectObjects(meshes as Object3D[], true);
+  for (const hit of hits) {
+    const objectId = findSelectableId(hit.object);
+    if (objectId === null) {
+      continue;
+    }
+    const point = hit.point.clone();
+    const normal = new Vector3(0, 0, 1);
+    if (hit.face) {
+      NORMAL_MATRIX_SCRATCH.getNormalMatrix(hit.object.matrixWorld);
+      normal.copy(hit.face.normal).applyMatrix3(NORMAL_MATRIX_SCRATCH).normalize();
+    }
+    return { objectId, point, normal, faceIndex: hit.faceIndex ?? 0 };
+  }
+  return null;
+}
+
+const NORMAL_MATRIX_SCRATCH = new Matrix3();
 
 /** Walk up parents until an `userData.selectableId` is found. */
 function findSelectableId(obj: Object3D | null): string | null {

--- a/ui/src/app/components/viewer/scene/types.ts
+++ b/ui/src/app/components/viewer/scene/types.ts
@@ -22,4 +22,19 @@ export interface SceneGizmoHandlers {
   facePicked(objectId: string, faceIndex: number): void;
 }
 
+/** A world-space surface point picked by the measuring tool. */
+export interface MeasurePickInfo {
+  /** scene-engine id (string form) of the object the point sits on. */
+  objectId: string;
+  /** World-space position in millimetres. */
+  world: [number, number, number];
+  /** World-space outward unit face normal at the hit. */
+  normal: [number, number, number];
+}
+
+export interface SceneMeasureHandlers {
+  /** A measurement endpoint was clicked in the 3D view. */
+  pick(info: MeasurePickInfo): void;
+}
+
 export type ViewerView = 'perspective' | 'ortho';

--- a/ui/src/app/services/measure/index.ts
+++ b/ui/src/app/services/measure/index.ts
@@ -1,0 +1,7 @@
+export {
+  Measure,
+  type MeasureAxis,
+  type MeasurePoint,
+  type MeasureResult,
+  type MeasureTool,
+} from './measure';

--- a/ui/src/app/services/measure/measure.spec.ts
+++ b/ui/src/app/services/measure/measure.spec.ts
@@ -1,0 +1,109 @@
+import { TestBed } from '@angular/core/testing';
+import { beforeEach, describe, expect, it } from 'vitest';
+import { Measure, type MeasurePoint } from './measure';
+
+function setup() {
+  TestBed.configureTestingModule({ providers: [Measure] });
+  return TestBed.inject(Measure);
+}
+
+const pointAt = (
+  world: [number, number, number],
+  normal?: [number, number, number],
+): MeasurePoint => ({ world, normal, objectId: '1' });
+
+describe('Measure', () => {
+  let measure: Measure;
+  beforeEach(() => {
+    measure = setup();
+  });
+
+  it('has no result until both endpoints are placed', () => {
+    expect(measure.result()).toBeNull();
+    measure.pick(pointAt([0, 0, 0]));
+    expect(measure.pointA()).not.toBeNull();
+    expect(measure.result()).toBeNull();
+    measure.pick(pointAt([3, 4, 0]));
+    expect(measure.result()).not.toBeNull();
+  });
+
+  it('computes the straight-line distance and per-axis deltas', () => {
+    measure.pick(pointAt([1, 2, 3]));
+    measure.pick(pointAt([4, 6, 15]));
+    const r = measure.result()!;
+    expect(r.delta).toEqual([3, 4, 12]);
+    expect(r.distance).toBeCloseTo(13, 6); // 3-4-12 Pythagorean quadruple
+    expect(r.vector).toEqual([3, 4, 12]);
+  });
+
+  it('reports absolute deltas regardless of pick order', () => {
+    measure.pick(pointAt([10, 10, 10]));
+    measure.pick(pointAt([4, 6, 2]));
+    const r = measure.result()!;
+    expect(r.delta).toEqual([6, 4, 8]);
+    expect(r.vector).toEqual([-6, -4, -8]);
+  });
+
+  it('computes planar distances on each world plane', () => {
+    measure.pick(pointAt([0, 0, 0]));
+    measure.pick(pointAt([3, 4, 12]));
+    const r = measure.result()!;
+    expect(r.planar.xy).toBeCloseTo(5, 6);
+    expect(r.planar.xz).toBeCloseTo(Math.hypot(3, 12), 6);
+    expect(r.planar.yz).toBeCloseTo(Math.hypot(4, 12), 6);
+  });
+
+  it('rubber-bands: a third pick starts a fresh measurement', () => {
+    measure.pick(pointAt([0, 0, 0]));
+    measure.pick(pointAt([1, 0, 0]));
+    expect(measure.complete()).toBe(true);
+    measure.pick(pointAt([5, 5, 5]));
+    expect(measure.pointA()!.world).toEqual([5, 5, 5]);
+    expect(measure.pointB()).toBeNull();
+    expect(measure.complete()).toBe(false);
+  });
+
+  it('gives parallel faces a perpendicular gap and a ~180° angle', () => {
+    // Two sides of a 10mm slab: outward normals point opposite ways.
+    measure.pick(pointAt([0, 0, 0], [0, 0, 1]));
+    measure.pick(pointAt([3, 4, 10], [0, 0, -1]));
+    const r = measure.result()!;
+    expect(r.faceAngleDeg).toBeCloseTo(180, 4);
+    expect(r.perpendicular).toBeCloseTo(10, 6); // only the Z span counts
+  });
+
+  it('leaves the perpendicular gap undefined for skew faces', () => {
+    measure.pick(pointAt([0, 0, 0], [0, 0, 1]));
+    measure.pick(pointAt([5, 0, 5], [1, 0, 0]));
+    const r = measure.result()!;
+    expect(r.faceAngleDeg).toBeCloseTo(90, 4);
+    expect(r.perpendicular).toBeUndefined();
+  });
+
+  it('omits face readouts in point mode', () => {
+    measure.pick(pointAt([0, 0, 0]));
+    measure.pick(pointAt([1, 1, 1]));
+    const r = measure.result()!;
+    expect(r.faceAngleDeg).toBeUndefined();
+    expect(r.perpendicular).toBeUndefined();
+  });
+
+  it('switching tool clears the in-progress picks', () => {
+    measure.pick(pointAt([0, 0, 0]));
+    measure.setTool('face');
+    expect(measure.pointA()).toBeNull();
+    // Same tool is a no-op and keeps picks.
+    measure.pick(pointAt([1, 1, 1]));
+    measure.setTool('face');
+    expect(measure.pointA()).not.toBeNull();
+  });
+
+  it('deactivating forgets the measurement', () => {
+    measure.activate('point');
+    measure.pick(pointAt([0, 0, 0]));
+    measure.pick(pointAt([1, 1, 1]));
+    measure.deactivate();
+    expect(measure.active()).toBe(false);
+    expect(measure.result()).toBeNull();
+  });
+});

--- a/ui/src/app/services/measure/measure.ts
+++ b/ui/src/app/services/measure/measure.ts
@@ -1,0 +1,209 @@
+import { Injectable, computed, signal } from '@angular/core';
+
+/**
+ * Which kind of thing a measurement snaps to.
+ *
+ * - `'point'` — dot-to-dot: the exact surface point under the cursor.
+ * - `'face'` — face-to-face: the same click point, but the face's outward
+ *   normal is captured too, which unlocks the perpendicular gap and the angle
+ *   between the two faces.
+ */
+export type MeasureTool = 'point' | 'face';
+
+/**
+ * Which distance reading the details modal and the 3D overlay emphasise.
+ *
+ * The straight-line `'direct'` distance is one number, but two hand-picked
+ * points rarely line up on the axis the user actually cares about — so a single
+ * component (`'x' | 'y' | 'z'`) can be singled out to read the gap along just
+ * that axis.
+ */
+export type MeasureAxis = 'direct' | 'x' | 'y' | 'z';
+
+/** A picked measurement endpoint, resolved to world space by the viewer. */
+export interface MeasurePoint {
+  /** World-space position in millimetres. */
+  readonly world: readonly [number, number, number];
+  /**
+   * Outward unit face normal, present only for a `'face'` pick. Drives the
+   * perpendicular-gap and face-angle readouts.
+   */
+  readonly normal?: readonly [number, number, number];
+  /** scene-engine id (string form) of the object the point sits on. */
+  readonly objectId: string;
+}
+
+/** The two normals were within this many degrees of (anti)parallel. */
+const PARALLEL_TOLERANCE_DEG = 3;
+
+/**
+ * A fully-resolved measurement between two picked points, plus every derived
+ * reading the card and the details modal show. Pure geometry — no rounding or
+ * formatting happens here, only in the views.
+ */
+export interface MeasureResult {
+  readonly a: MeasurePoint;
+  readonly b: MeasurePoint;
+  /** Straight-line 3D distance (mm). */
+  readonly distance: number;
+  /** Signed component vector `b - a` (mm). */
+  readonly vector: readonly [number, number, number];
+  /** Absolute per-axis distances `|b - a|` (mm). */
+  readonly delta: readonly [number, number, number];
+  /** 2D distances projected onto each world plane (mm). */
+  readonly planar: { readonly xy: number; readonly xz: number; readonly yz: number };
+  /**
+   * Angle between the two outward face normals in degrees (0–180), only when
+   * both endpoints are faces. Two sides of a flat slab read ~180°, two coplanar
+   * faces ~0°.
+   */
+  readonly faceAngleDeg?: number;
+  /**
+   * Perpendicular gap between the two faces (mm), only when they are (anti)
+   * parallel within {@link PARALLEL_TOLERANCE_DEG}. Undefined for skew faces,
+   * where a single perpendicular distance is not well defined.
+   */
+  readonly perpendicular?: number;
+}
+
+function sub(
+  b: readonly [number, number, number],
+  a: readonly [number, number, number],
+): [number, number, number] {
+  return [b[0] - a[0], b[1] - a[1], b[2] - a[2]];
+}
+
+function dot(a: readonly [number, number, number], b: readonly [number, number, number]): number {
+  return a[0] * b[0] + a[1] * b[1] + a[2] * b[2];
+}
+
+function faceReadouts(
+  a: MeasurePoint,
+  b: MeasurePoint,
+  vector: readonly [number, number, number],
+): { faceAngleDeg?: number; perpendicular?: number } {
+  if (!a.normal || !b.normal) {
+    return {};
+  }
+  const na = a.normal;
+  const nb = b.normal;
+  const cos = Math.min(1, Math.max(-1, dot(na, nb)));
+  const faceAngleDeg = (Math.acos(cos) * 180) / Math.PI;
+  // Parallel or anti-parallel faces have a single well-defined gap: project the
+  // span onto either face's normal. Skew faces do not, so it is left undefined.
+  const cosTol = Math.cos((PARALLEL_TOLERANCE_DEG * Math.PI) / 180);
+  const parallel = Math.abs(cos) >= cosTol;
+  const perpendicular = parallel ? Math.abs(dot(vector, na)) : undefined;
+  return { faceAngleDeg, perpendicular };
+}
+
+function measure(a: MeasurePoint, b: MeasurePoint): MeasureResult {
+  const vector = sub(b.world, a.world);
+  const [dx, dy, dz] = vector;
+  const delta: [number, number, number] = [Math.abs(dx), Math.abs(dy), Math.abs(dz)];
+  const distance = Math.hypot(dx, dy, dz);
+  const planar = {
+    xy: Math.hypot(dx, dy),
+    xz: Math.hypot(dx, dz),
+    yz: Math.hypot(dy, dz),
+  };
+  return { a, b, distance, vector, delta, planar, ...faceReadouts(a, b, vector) };
+}
+
+/**
+ * Single source of truth for the on-plate measuring tool.
+ *
+ * Holds only *state* — the active flag, the snap mode, the two picked
+ * endpoints and which axis is emphasised — and derives every distance from it.
+ * The viewer resolves clicks into world-space {@link MeasurePoint}s and feeds
+ * them to {@link pick}; the toolbar card and the details modal read the derived
+ * {@link result}. Deliberately root-provided so the tool, the card, the modal
+ * and the context menu all see the same measurement.
+ */
+@Injectable({ providedIn: 'root' })
+export class Measure {
+  /** Whether the measuring tool is currently taking picks. */
+  readonly active = signal(false);
+
+  /** What a click snaps to. Switching it starts a fresh measurement. */
+  readonly tool = signal<MeasureTool>('point');
+
+  /** Which reading is emphasised in the overlay and the details modal. */
+  readonly axis = signal<MeasureAxis>('direct');
+
+  /** First picked endpoint, or `null` before the first click. */
+  readonly pointA = signal<MeasurePoint | null>(null);
+  /** Second picked endpoint, or `null` while only the first is placed. */
+  readonly pointB = signal<MeasurePoint | null>(null);
+
+  /** The resolved measurement once both endpoints are placed. */
+  readonly result = computed<MeasureResult | null>(() => {
+    const a = this.pointA();
+    const b = this.pointB();
+    return a && b ? measure(a, b) : null;
+  });
+
+  /** True once both endpoints are placed and a distance can be read. */
+  readonly complete = computed(() => this.result() !== null);
+
+  /** Turn the tool on (optionally choosing the snap mode). */
+  activate(tool?: MeasureTool): void {
+    if (tool) {
+      this.tool.set(tool);
+    }
+    this.active.set(true);
+  }
+
+  /** Turn the tool off and forget the in-progress measurement. */
+  deactivate(): void {
+    this.active.set(false);
+    this.reset();
+  }
+
+  /** Flip the tool on/off, seeding a snap mode when turning on. */
+  toggle(tool?: MeasureTool): void {
+    if (this.active()) {
+      this.deactivate();
+    } else {
+      this.activate(tool);
+    }
+  }
+
+  /** Choose the snap mode; changing it clears the current picks. */
+  setTool(tool: MeasureTool): void {
+    if (this.tool() === tool) {
+      return;
+    }
+    this.tool.set(tool);
+    this.reset();
+  }
+
+  /** Emphasise a particular distance reading. */
+  setAxis(axis: MeasureAxis): void {
+    this.axis.set(axis);
+  }
+
+  /**
+   * Record a picked endpoint.
+   *
+   * The first pick (or any pick once a pair is complete) starts a new
+   * measurement; the second completes it — the usual rubber-band behaviour of a
+   * measuring tool, so a third click begins measuring afresh from that point.
+   */
+  pick(point: MeasurePoint): void {
+    const a = this.pointA();
+    const b = this.pointB();
+    if (!a || b) {
+      this.pointA.set(point);
+      this.pointB.set(null);
+    } else {
+      this.pointB.set(point);
+    }
+  }
+
+  /** Drop both endpoints but stay armed on the same snap mode. */
+  reset(): void {
+    this.pointA.set(null);
+    this.pointB.set(null);
+  }
+}


### PR DESCRIPTION
This pull request introduces a new measurement feature that allows users to measure objects on their plate using a dot-to-dot method, as well as face-to-face measurements. Key changes include:

- **New Measure Service**: Created a `Measure` service to handle measurement logic, including calculations and state management.
- **Gizmo Enhancements**: Added a `raycastPoint` helper in `gizmo.ts` to facilitate point picking for measurements.
- **Scene Type Updates**: Updated `types.ts` to include new measurement-related types and handlers.
- **Measurement Modal**: Implemented a modal for users to select XYZ distances when points do not align perfectly along the intended axis.
- **Unit Tests**: Added comprehensive tests for the measurement service to ensure accuracy and reliability.

This feature enhances the user experience by providing a flexible and intuitive way to measure distances in the 3D viewer.